### PR TITLE
docs: add JSDoc to TimelineEngine public API

### DIFF
--- a/packages/core/src/editor/TimelineEngine.ts
+++ b/packages/core/src/editor/TimelineEngine.ts
@@ -129,6 +129,7 @@ export class TimelineEngine {
   // Queries
   // ---------------------------------------------------------------------------
 
+  /** Returns an immutable snapshot that is replaced on every commit — re-read after edits, never mutate it. */
   getProject(): Project {
     return this.project
   }

--- a/packages/core/src/editor/TimelineEngine.ts
+++ b/packages/core/src/editor/TimelineEngine.ts
@@ -134,14 +134,17 @@ export class TimelineEngine {
     return this.project
   }
 
+  /** Returns undefined for unknown ids — callers decide whether a missing track is an error. */
   getTrack(trackId: string): Track | undefined {
     return this.project.tracks.find((t) => t.id === trackId)
   }
 
+  /** Always sorted by startFrame; returns [] for unknown tracks so callers can iterate without guarding. */
   getClipsOnTrack(trackId: string): Clip[] {
     return this.project.clips[trackId] ?? []
   }
 
+  /** Scans every track for a clip by id alone — use when the caller doesn't know which track holds it. */
   findClip(clipId: string): { clip: Clip; trackId: string } | null {
     for (const [trackId, clips] of Object.entries(this.project.clips)) {
       const clip = clips.find((c) => c.id === clipId)
@@ -150,14 +153,17 @@ export class TimelineEngine {
     return null
   }
 
+  /** Effective timeline length: the frame where the last clip on any track ends, not a configured value. */
   getTotalFrames(): number {
     return getTotalFrames(this.project.clips)
   }
 
+  /** History is capped, so the oldest edits eventually stop being undoable; track via 'history:change' rather than polling. */
   canUndo(): boolean {
     return this.undoStack.length > 0
   }
 
+  /** Any new edit after an undo clears the redo stack, flipping this back to false. */
   canRedo(): boolean {
     return this.redoStack.length > 0
   }
@@ -181,6 +187,7 @@ export class TimelineEngine {
   // Track operations
   // ---------------------------------------------------------------------------
 
+  /** New tracks append below existing ones (order = current count) and start with an empty clip list. */
   addTrack(kind: TrackKind, options?: Partial<CreateTrackOptions>): Track {
     const order = this.project.tracks.length
     const track = createTrack({
@@ -202,6 +209,7 @@ export class TimelineEngine {
     return track
   }
 
+  /** Removes the track's clips with it, all in a single undo entry. */
   removeTrack(trackId: string): void {
     this.commit(
       (draft) => removeTrack(draft, trackId),
@@ -210,6 +218,7 @@ export class TimelineEngine {
     this.emit('track:removed', trackId)
   }
 
+  /** Shallow-merges partial updates; for order changes prefer reorderTracks, which keeps all indices consistent. */
   updateTrack(trackId: string, updates: Partial<Track>): void {
     this.commit(
       (draft) => updateTrack(draft, trackId, updates),
@@ -217,6 +226,7 @@ export class TimelineEngine {
     )
   }
 
+  /** Expects the complete id list — tracks omitted from it keep stale order values. */
   reorderTracks(orderedIds: string[]): void {
     this.commit((draft) => {
       orderedIds.forEach((id, index) => {
@@ -231,6 +241,7 @@ export class TimelineEngine {
   // Clip operations
   // ---------------------------------------------------------------------------
 
+  /** Throws if the target track is missing or the clip would overlap an existing one — validate placement first. */
   addClip(options: CreateClipOptions): Clip {
     const clip = createClip(options)
 
@@ -243,6 +254,7 @@ export class TimelineEngine {
     return clip
   }
 
+  /** Transitions referencing the removed clip are pruned in the same undo entry. */
   removeClip(clipId: string, trackId: string): void {
     this.commit(
       (draft) => removeClip(draft, clipId, trackId),
@@ -251,6 +263,7 @@ export class TimelineEngine {
     this.emit('clip:removed', { clipId, trackId })
   }
 
+  /** Positional changes are validated against neighbouring clips and re-sort the track; undoable — use previewClip during gestures. */
   updateClip(clipId: string, trackId: string, updates: Partial<Clip>): void {
     this.commit(
       (draft) => updateClip(draft, clipId, trackId, updates),
@@ -425,6 +438,7 @@ export class TimelineEngine {
     }, 'Trim clip')
   }
 
+  /** The left half keeps the original clip id; returns null when atFrame isn't strictly inside the clip. */
   splitClip(
     clipId: string,
     trackId: string,
@@ -448,6 +462,7 @@ export class TimelineEngine {
     return result
   }
 
+  /** Copies onto the same track at startFrame; returns null instead of throwing when the spot is occupied. */
   cloneClip(
     clipId: string,
     trackId: string,


### PR DESCRIPTION
## What does this PR do?

Adds one-line JSDoc to the 16 undocumented public methods of `TimelineEngine`, so SDK users get hover documentation in their editor.

Part of #3 (covers `packages/core/src/editor/TimelineEngine.ts`; the other files listed in the issue are left for separate PRs).

---

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [x] Documentation
- [ ] Performance improvement

---

## How to test

1. Open `packages/core/src/editor/TimelineEngine.ts` in VS Code and hover any of the 16 methods (e.g. `addClip`, `splitClip`, `getProject`) — each now shows a one-line tooltip.
2. Run `npm run build:packages` and confirm the comments are carried into `packages/core/dist/editor/TimelineEngine.d.ts`, so consumers of the published package get the same hover docs.
3. Run `npm test` — comment-only change, all 345 core tests still pass.

---

## Screenshots / Recording

Not applicable — comment-only change, no UI.

---

## Checklist

- [x] `npm test` passes (345/345 in `packages/core`, 2/2 in `packages/timeline`)
- [x] `npm run typecheck` passes for `packages/core` (root `tsc --build` has pre-existing failures on `main` in `apps/web`/`playground`, unrelated to this change)
- [x] I've tested this in the playground (dev playground builds and runs; change introduces no runtime behavior)
- [x] No `any` types introduced without justification (no code changes at all)

---

## Notes for the reviewer

Per the CONTRIBUTING JSDoc rules, each comment is a single line documenting the why/contract rather than restating the method name — e.g. `addClip` documents that it throws on overlap or missing track, `splitClip` that the left half keeps the original id and `null` means the frame wasn't strictly inside the clip, `getProject` that the snapshot is replaced on every commit.

While auditing the file I noticed 7 more public methods missing JSDoc that aren't in the issue's list (`removeTransition`, `updateTransition`, `loadProject`, `undo`, `redo`, `on`, `off`). Kept this PR to the issue's exact scope — happy to cover those here or in a follow-up if you'd like.