### PR TITLE
ui: centralize timeline colors into theme tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,10 @@ playground/*/package-lock.json
 dist
 *.tsbuildinfo
 .DS_Store
+
+# Compiled JS emitted in-place beside TS sources (no outDir configured).
+# The repo never tracks hand-written .js, so all of these are build output.
+packages/**/src/**/*.js
+packages/*/vitest.config.js
+apps/web/**/*.js
+playground/*/**/*.js

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -713,3 +713,4 @@ Good: extract before it's painful. The cost of refactoring scales superlinearly 
 - [`packages/core/src/export/Architecture.md`](./packages/core/src/export/Architecture.md) — the export pipeline.
 - [`docs/glossary.md`](./docs/glossary.md) — terminology in one place.
 - [`docs/known-bugs.md`](./docs/known-bugs.md) — deliberate workarounds and their real fixes.
+- [`docs/design-tokens.md`](./docs/design-tokens.md) — the timeline color/theme token system.

--- a/README.md
+++ b/README.md
@@ -119,7 +119,8 @@ video-editor/
             └── editor/           # EditorProvider, AssetPanel, Preview, useResolvedScene
 docs/
 ├── glossary.md                   # terminology
-└── known-bugs.md                 # deliberate workarounds + their real fixes
+├── known-bugs.md                 # deliberate workarounds + their real fixes
+└── design-tokens.md              # timeline color/theme token system
 ```
 
 ---

--- a/docs/design-tokens.md
+++ b/docs/design-tokens.md
@@ -1,0 +1,59 @@
+# Timeline Design Tokens
+
+> Every color, border, shadow and overlay used by the timeline UI lives in one
+> place: [`packages/timeline/src/theme.ts`](../packages/timeline/src/theme.ts).
+> Components import `timelineTheme` instead of inlining literals, so re-skinning
+> the entire timeline (a light theme, brand match, etc.) means editing one object.
+
+---
+
+## Why
+
+Before this, colors were hard-coded across every timeline component (`ClipBlock`,
+`Ruler`, `Playhead`, dialogs, pickers…). Changing the look meant hunting literals
+through many files and risking drift between components that should match.
+
+`timelineTheme` makes the token set the **single source of truth**. Tokens are
+grouped **by role, not by component**, so the same visual meaning (e.g. "muted
+text") is one token reused everywhere rather than five copies.
+
+## Usage
+
+```ts
+import { timelineTheme, type TimelineTheme } from '@elah/timeline'
+
+const laneBg = timelineTheme.surface.background
+const videoAccent = timelineTheme.clip.video.accent
+```
+
+Both the `timelineTheme` object and the `TimelineTheme` type are exported from the
+package entry ([`packages/timeline/src/index.ts`](../packages/timeline/src/index.ts)).
+
+## Token groups
+
+| Group | Purpose |
+| --- | --- |
+| `surface` | Background fills for structural surfaces (lanes, sidebar, ruler), incl. active variants |
+| `border` | Hairline dividers — `strong` (vertical rules) and `subtle` (row separators) |
+| `text` | Foreground text ramp, brightest → faintest (`primary`…`hint`, plus `onClip`) |
+| `clip` | Per-clip-type color ramp (`video`/`audio`/`text`/`image`), each with `top`/`mid`/`bottom` gradient + `accent` |
+| `selection` | Selected-clip highlight (`border` + outer `glow`) |
+| `playhead` | Playhead needle color (line, handle, glow) |
+| `ruler` | Ruler `tick` marks and timecode `label`s |
+| `transition` | Cut-line + diamond marker states (exists / hover / idle) |
+| `menu` | Clip right-click context menu |
+| `popover` | Transition picker popover (incl. option idle/hover/active states) |
+| `dialog` | Blocking "video has audio" choice dialog (overlay, buttons, primary action) |
+| `danger` | Destructive actions (delete clip / remove transition) |
+| `effect` | Reusable light/dark overlays — glosses, inset highlights, scrims, drop shadows |
+
+## Adding or changing a token
+
+1. Edit the relevant group in [`theme.ts`](../packages/timeline/src/theme.ts).
+   Add a token where the **visual role** fits; don't duplicate an existing one.
+2. Keep the JSDoc comment on each token current — it's the inline reference for
+   what the token means.
+3. Reference it from components via `timelineTheme.<group>.<token>`. Never
+   re-introduce a color literal in a component file.
+4. `TimelineTheme` is derived from the object (`typeof timelineTheme`), so new
+   tokens are typed automatically.

--- a/packages/timeline/src/AudioDropDialog.tsx
+++ b/packages/timeline/src/AudioDropDialog.tsx
@@ -1,4 +1,5 @@
 import { useAudioDropDialogStore, type AudioDropChoice } from './audioDropDialog.store'
+import { timelineTheme } from './theme'
 
 interface ChoiceDef {
   choice: AudioDropChoice
@@ -43,7 +44,7 @@ export function AudioDropDialog() {
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
-        background: 'rgba(5, 7, 12, 0.6)',
+        background: timelineTheme.dialog.overlay,
         backdropFilter: 'blur(2px)',
         fontFamily: 'sans-serif',
       }}
@@ -52,10 +53,10 @@ export function AudioDropDialog() {
         style={{
           width: 380,
           maxWidth: '90vw',
-          background: '#171D2B',
-          border: '1px solid #232938',
+          background: timelineTheme.dialog.background,
+          border: `1px solid ${timelineTheme.dialog.border}`,
           borderRadius: 12,
-          boxShadow: '0 24px 60px rgba(0,0,0,0.55)',
+          boxShadow: timelineTheme.dialog.shadow,
           padding: 22,
         }}
       >
@@ -64,7 +65,7 @@ export function AudioDropDialog() {
             margin: 0,
             fontSize: 15,
             fontWeight: 700,
-            color: '#F3F4F6',
+            color: timelineTheme.text.primary,
             letterSpacing: '-0.01em',
           }}
         >
@@ -75,11 +76,11 @@ export function AudioDropDialog() {
             margin: '6px 0 18px',
             fontSize: 12,
             lineHeight: 1.5,
-            color: '#9CA3AF',
+            color: timelineTheme.text.muted,
           }}
         >
           How should{' '}
-          <span style={{ color: '#E5E7EB', fontWeight: 600 }}>{assetName}</span>{' '}
+          <span style={{ color: timelineTheme.text.bright, fontWeight: 600 }}>{assetName}</span>{' '}
           be added to the timeline?
         </p>
 
@@ -99,24 +100,26 @@ export function AudioDropDialog() {
                 textAlign: 'left',
                 cursor: 'pointer',
                 borderRadius: 8,
-                border: primary ? '1px solid #2563EB' : '1px solid #2A3142',
-                background: primary ? 'rgba(37, 99, 235, 0.16)' : '#1B2230',
-                color: '#F3F4F6',
+                border: primary
+                  ? `1px solid ${timelineTheme.dialog.primaryBorder}`
+                  : `1px solid ${timelineTheme.dialog.optionBorder}`,
+                background: primary ? timelineTheme.dialog.primaryBg : timelineTheme.dialog.optionBg,
+                color: timelineTheme.text.primary,
                 transition: 'background 0.12s, border-color 0.12s',
               }}
               onMouseEnter={(e) => {
                 e.currentTarget.style.background = primary
-                  ? 'rgba(37, 99, 235, 0.28)'
-                  : '#222B3C'
+                  ? timelineTheme.dialog.primaryBgHover
+                  : timelineTheme.dialog.optionBgHover
               }}
               onMouseLeave={(e) => {
                 e.currentTarget.style.background = primary
-                  ? 'rgba(37, 99, 235, 0.16)'
-                  : '#1B2230'
+                  ? timelineTheme.dialog.primaryBg
+                  : timelineTheme.dialog.optionBg
               }}
             >
               <span style={{ fontSize: 13, fontWeight: 600 }}>{label}</span>
-              <span style={{ fontSize: 11, color: '#9CA3AF' }}>{hint}</span>
+              <span style={{ fontSize: 11, color: timelineTheme.text.muted }}>{hint}</span>
             </button>
           ))}
         </div>

--- a/packages/timeline/src/ClipBlock.tsx
+++ b/packages/timeline/src/ClipBlock.tsx
@@ -12,36 +12,9 @@ import {
 } from '@elah/core'
 import { useTracksStore } from '@elah/core'
 import { useMediaLibraryStore } from '@elah/core'
+import { timelineTheme } from './theme'
 
-const CLIP_STYLES: Record<
-  string,
-  { top: string; mid: string; bottom: string; accent: string }
-> = {
-  video: {
-    top: '#3B82F6',
-    mid: '#2563EB',
-    bottom: '#1D4ED8',
-    accent: '#60A5FA',
-  },
-  audio: {
-    top: '#22C55E',
-    mid: '#16A34A',
-    bottom: '#15803D',
-    accent: '#4ADE80',
-  },
-  text: {
-    top: '#A855F7',
-    mid: '#9333EA',
-    bottom: '#7E22CE',
-    accent: '#C084FC',
-  },
-  image: {
-    top: '#FBBF24',
-    mid: '#D97706',
-    bottom: '#B45309',
-    accent: '#FCD34D',
-  },
-}
+const CLIP_STYLES = timelineTheme.clip
 
 /** Static bar heights for decorative audio waveform (visual only). */
 const WAVE_BARS = [
@@ -302,11 +275,11 @@ export const ClipBlock = memo(function ClipBlock({ clip, zoom, trackHeight }: Cl
         boxSizing: 'border-box',
         background: `linear-gradient(180deg, ${palette.top} 0%, ${palette.mid} 42%, ${palette.bottom} 100%)`,
         border: isSelected
-          ? '2px solid #FF2D55'
+          ? `2px solid ${timelineTheme.selection.border}`
           : `1px solid ${palette.accent}55`,
         boxShadow: isSelected
-          ? '0 0 14px rgba(255, 45, 85, 0.4), inset 0 1px 0 rgba(255,255,255,0.15)'
-          : 'inset 0 1px 0 rgba(255,255,255,0.12), 0 2px 6px rgba(0,0,0,0.35)',
+          ? `0 0 14px ${timelineTheme.selection.glow}, inset 0 1px 0 ${timelineTheme.effect.innerHighlightStrong}`
+          : `inset 0 1px 0 ${timelineTheme.effect.innerHighlight}, ${timelineTheme.effect.clipShadow}`,
         cursor: 'grab',
         overflow: 'hidden',
         userSelect: 'none',
@@ -342,7 +315,7 @@ export const ClipBlock = memo(function ClipBlock({ clip, zoom, trackHeight }: Cl
                   backgroundImage: `url(${stripFrames[frameIdx]})`,
                   backgroundSize: 'cover',
                   backgroundPosition: 'center',
-                  boxShadow: 'inset -1px 0 0 rgba(0,0,0,0.28)',
+                  boxShadow: `inset -1px 0 0 ${timelineTheme.effect.tileSeparator}`,
                 }}
               />
             )
@@ -369,7 +342,7 @@ export const ClipBlock = memo(function ClipBlock({ clip, zoom, trackHeight }: Cl
         style={{
           position: 'absolute',
           inset: '0 0 55%',
-          background: 'linear-gradient(180deg, rgba(255,255,255,0.14) 0%, transparent 100%)',
+          background: `linear-gradient(180deg, ${timelineTheme.effect.gloss} 0%, transparent 100%)`,
           pointerEvents: 'none',
         }}
       />
@@ -399,7 +372,7 @@ export const ClipBlock = memo(function ClipBlock({ clip, zoom, trackHeight }: Cl
                 maxWidth: 3,
                 // Floor keeps quiet passages visible as a thin line.
                 height: `${Math.max(6, h * 100)}%`,
-                background: 'rgba(255,255,255,0.85)',
+                background: timelineTheme.effect.waveform,
                 borderRadius: 1,
               }}
             />
@@ -419,8 +392,8 @@ export const ClipBlock = memo(function ClipBlock({ clip, zoom, trackHeight }: Cl
               bottom: 4,
               width: 14,
               borderRadius: 3,
-              background: 'rgba(0,0,0,0.22)',
-              border: '1px solid rgba(255,255,255,0.08)',
+              background: timelineTheme.effect.placeholderBg,
+              border: `1px solid ${timelineTheme.effect.placeholderBorder}`,
               pointerEvents: 'none',
             }}
           />
@@ -436,7 +409,7 @@ export const ClipBlock = memo(function ClipBlock({ clip, zoom, trackHeight }: Cl
           width: TRIM_HANDLE_WIDTH,
           height: '100%',
           cursor: 'ew-resize',
-          background: 'linear-gradient(90deg, rgba(0,0,0,0.35) 0%, transparent 100%)',
+          background: `linear-gradient(90deg, ${timelineTheme.effect.trimScrim} 0%, transparent 100%)`,
           zIndex: 2,
         }}
       />
@@ -451,13 +424,13 @@ export const ClipBlock = memo(function ClipBlock({ clip, zoom, trackHeight }: Cl
           paddingRight: TRIM_HANDLE_WIDTH + 6,
           paddingTop: 5,
           fontSize: 10,
-          color: 'rgba(255,255,255,0.95)',
+          color: timelineTheme.text.onClip,
           whiteSpace: 'nowrap',
           overflow: 'hidden',
           textOverflow: 'ellipsis',
           fontWeight: 600,
           letterSpacing: '0.01em',
-          textShadow: '0 1px 2px rgba(0,0,0,0.45)',
+          textShadow: timelineTheme.effect.labelShadow,
           pointerEvents: 'none',
         }}
       >
@@ -474,7 +447,7 @@ export const ClipBlock = memo(function ClipBlock({ clip, zoom, trackHeight }: Cl
           width: TRIM_HANDLE_WIDTH,
           height: '100%',
           cursor: 'ew-resize',
-          background: 'linear-gradient(270deg, rgba(0,0,0,0.35) 0%, transparent 100%)',
+          background: `linear-gradient(270deg, ${timelineTheme.effect.trimScrim} 0%, transparent 100%)`,
           zIndex: 2,
         }}
       />
@@ -495,9 +468,9 @@ export const ClipBlock = memo(function ClipBlock({ clip, zoom, trackHeight }: Cl
             padding: 0,
             lineHeight: '14px',
             fontSize: 11,
-            color: '#fff',
-            background: 'rgba(0,0,0,0.5)',
-            border: '1px solid rgba(255,255,255,0.35)',
+            color: timelineTheme.effect.deleteBtnText,
+            background: timelineTheme.effect.deleteBtnBg,
+            border: `1px solid ${timelineTheme.effect.deleteBtnBorder}`,
             borderRadius: 4,
             cursor: 'pointer',
             zIndex: 4,
@@ -522,12 +495,12 @@ export const ClipBlock = memo(function ClipBlock({ clip, zoom, trackHeight }: Cl
               top: ctxMenu.y,
               left: ctxMenu.x,
               zIndex: 9999,
-              background: '#1E2433',
-              border: '1px solid #2D3548',
+              background: timelineTheme.menu.background,
+              border: `1px solid ${timelineTheme.menu.border}`,
               borderRadius: 6,
               padding: '4px 0',
               minWidth: 140,
-              boxShadow: '0 8px 24px rgba(0,0,0,0.5)',
+              boxShadow: timelineTheme.menu.shadow,
               fontFamily: 'sans-serif',
             }}
           >
@@ -542,13 +515,13 @@ export const ClipBlock = memo(function ClipBlock({ clip, zoom, trackHeight }: Cl
                 textAlign: 'left',
                 background: 'none',
                 border: 'none',
-                color: '#FF6B6B',
+                color: timelineTheme.danger.text,
                 fontSize: 13,
                 cursor: 'pointer',
                 letterSpacing: '0.01em',
               }}
               onMouseEnter={(e) => {
-                ;(e.currentTarget as HTMLButtonElement).style.background = 'rgba(255,107,107,0.12)'
+                ;(e.currentTarget as HTMLButtonElement).style.background = timelineTheme.danger.bgHover
               }}
               onMouseLeave={(e) => {
                 ;(e.currentTarget as HTMLButtonElement).style.background = 'none'

--- a/packages/timeline/src/Playhead.tsx
+++ b/packages/timeline/src/Playhead.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef } from 'react'
 import { usePlaybackStore } from '@elah/core'
+import { timelineTheme } from './theme'
 
 interface PlayheadProps {
   zoom: number
@@ -25,7 +26,7 @@ interface PlayheadProps {
 export function Playhead({
   zoom,
   height,
-  color = '#FF2D55',
+  color = timelineTheme.playhead,
   scrollContainerRef,
   sidebarWidth = 0,
 }: PlayheadProps) {

--- a/packages/timeline/src/Ruler.tsx
+++ b/packages/timeline/src/Ruler.tsx
@@ -1,5 +1,6 @@
 import { memo, useMemo } from 'react'
 import { framesToTimecode } from '@elah/core'
+import { timelineTheme } from './theme'
 
 interface RulerProps {
   fps: number
@@ -21,9 +22,9 @@ export const Ruler = memo(function Ruler({
   totalFrames,
   zoom,
   height = 24,
-  color = '#121722',
-  tickColor = '#232938',
-  labelColor = '#6B7280',
+  color = timelineTheme.surface.sidebar,
+  tickColor = timelineTheme.ruler.tick,
+  labelColor = timelineTheme.ruler.label,
   onSeek,
 }: RulerProps) {
   // Content-driven width; CSS minWidth: '100%' ensures it fills the container on

--- a/packages/timeline/src/Timeline.tsx
+++ b/packages/timeline/src/Timeline.tsx
@@ -19,6 +19,7 @@ import { Ruler } from './Ruler'
 import { Playhead } from './Playhead'
 import { TrackRow } from './TrackRow'
 import { AudioDropDialog } from './AudioDropDialog'
+import { timelineTheme } from './theme'
 
 export interface TimelineRef {
   engine: TimelineEngine
@@ -269,8 +270,8 @@ export const Timeline = memo(
         style={{
           display: 'flex',
           flexDirection: 'column',
-          background: '#0A0D14',
-          color: '#F3F4F6',
+          background: timelineTheme.surface.background,
+          color: timelineTheme.text.primary,
           overflow: 'hidden',
           position: 'relative',
           fontFamily: 'sans-serif',
@@ -285,9 +286,9 @@ export const Timeline = memo(
               width: SIDEBAR_WIDTH,
               flexShrink: 0,
               height: rulerHeight,
-              background: '#121722',
-              borderRight: '1px solid #232938',
-              borderBottom: '1px solid #1A1F2B',
+              background: timelineTheme.surface.sidebar,
+              borderRight: `1px solid ${timelineTheme.border.strong}`,
+              borderBottom: `1px solid ${timelineTheme.border.subtle}`,
             }}
           />
           {/* Ruler — overflow hidden, scrollLeft driven by track area scroll */}
@@ -327,7 +328,7 @@ export const Timeline = memo(
             <div
               style={{
                 padding: 24,
-                color: '#555',
+                color: timelineTheme.text.disabled,
                 fontSize: 13,
                 textAlign: 'center',
               }}

--- a/packages/timeline/src/TrackRow.tsx
+++ b/packages/timeline/src/TrackRow.tsx
@@ -5,6 +5,7 @@ import { useSelectionStore } from '@elah/core'
 import { ClipBlock } from './ClipBlock'
 import { TransitionChip } from './TransitionChip'
 import { useTimelineDrop } from './useTimelineDrop'
+import { timelineTheme } from './theme'
 
 interface TrackRowProps {
   track: Track
@@ -62,10 +63,10 @@ export const TrackRow = memo(function TrackRow({
 
   const kindAccent =
     track.kind === 'video'
-      ? '#2563EB'
+      ? timelineTheme.clip.video.mid
       : track.kind === 'audio'
-        ? '#16A34A'
-        : '#9333EA'
+        ? timelineTheme.clip.audio.mid
+        : timelineTheme.clip.text.mid
 
   return (
     <div style={{ display: 'flex', height: track.height }}>
@@ -80,9 +81,9 @@ export const TrackRow = memo(function TrackRow({
           width: 160,
           flexShrink: 0,
           borderLeft: `3px solid ${kindAccent}`,
-          borderRight: '1px solid #232938',
-          borderBottom: '1px solid #1A1F2B',
-          background: isActive ? '#171D2B' : '#121722',
+          borderRight: `1px solid ${timelineTheme.border.strong}`,
+          borderBottom: `1px solid ${timelineTheme.border.subtle}`,
+          background: isActive ? timelineTheme.surface.sidebarActive : timelineTheme.surface.sidebar,
           display: 'flex',
           alignItems: 'center',
           paddingLeft: 12,
@@ -93,7 +94,7 @@ export const TrackRow = memo(function TrackRow({
         <span
           style={{
             fontSize: 11,
-            color: isActive ? '#F3F4F6' : '#A7AFBF',
+            color: isActive ? timelineTheme.text.primary : timelineTheme.text.secondary,
             fontWeight: isActive ? 600 : 500,
             overflow: 'hidden',
             whiteSpace: 'nowrap',
@@ -111,8 +112,8 @@ export const TrackRow = memo(function TrackRow({
           position: 'relative',
           flex: 1,
           minWidth: rowMinWidth,
-          borderBottom: '1px solid #1A1F2B',
-          background: isActive ? '#0D1017' : '#0A0D14',
+          borderBottom: `1px solid ${timelineTheme.border.subtle}`,
+          background: isActive ? timelineTheme.surface.laneActive : timelineTheme.surface.background,
           overflow: 'visible',
         }}
       >

--- a/packages/timeline/src/TransitionChip.tsx
+++ b/packages/timeline/src/TransitionChip.tsx
@@ -3,6 +3,7 @@ import type { Clip, Transition as TransitionData, TransitionKind } from '@elah/c
 import { useTimeline } from './engine-context'
 import { useTransitionsStore } from '@elah/core'
 import { TransitionPicker } from './TransitionPicker'
+import { timelineTheme } from './theme'
 
 interface TransitionChipProps {
   fromClip: Clip
@@ -36,10 +37,10 @@ export const TransitionChip = memo(function TransitionChip({ fromClip, toClip, z
   const hasTransition = Boolean(transition)
 
   const lineColor = hasTransition
-    ? 'rgba(107, 140, 255, 0.9)'
+    ? timelineTheme.transition.line
     : hovered
-      ? 'rgba(255,255,255,0.55)'
-      : 'rgba(255,255,255,0.18)'
+      ? timelineTheme.transition.lineHover
+      : timelineTheme.transition.lineIdle
 
   const handleAdd = useCallback(
     (kind: TransitionKind, durationFrames: number, offsetFrames: number) => {
@@ -127,8 +128,8 @@ export const TransitionChip = memo(function TransitionChip({ fromClip, toClip, z
               <rect
                 x={2} y={2} width={12} height={12} rx={2}
                 transform="rotate(45 8 8)"
-                fill="#6B8CFF"
-                stroke="#A5B4FC"
+                fill={timelineTheme.transition.fill}
+                stroke={timelineTheme.transition.stroke}
                 strokeWidth={1}
               />
             </svg>
@@ -137,12 +138,12 @@ export const TransitionChip = memo(function TransitionChip({ fromClip, toClip, z
               <rect
                 x={3} y={3} width={10} height={10} rx={1.5}
                 transform="rotate(45 8 8)"
-                fill="rgba(255,255,255,0.12)"
-                stroke="rgba(255,255,255,0.7)"
+                fill={timelineTheme.transition.addFill}
+                stroke={timelineTheme.transition.addStroke}
                 strokeWidth={1.5}
               />
-              <line x1="8" y1="5" x2="8" y2="11" stroke="rgba(255,255,255,0.7)" strokeWidth={1.2} />
-              <line x1="5" y1="8" x2="11" y2="8" stroke="rgba(255,255,255,0.7)" strokeWidth={1.2} />
+              <line x1="8" y1="5" x2="8" y2="11" stroke={timelineTheme.transition.addStroke} strokeWidth={1.2} />
+              <line x1="5" y1="8" x2="11" y2="8" stroke={timelineTheme.transition.addStroke} strokeWidth={1.2} />
             </svg>
           )}
         </div>

--- a/packages/timeline/src/TransitionPicker.tsx
+++ b/packages/timeline/src/TransitionPicker.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import type { TransitionKind, Transition } from '@elah/core'
+import { timelineTheme } from './theme'
 
 interface TransitionOption {
   kind: TransitionKind
@@ -111,18 +112,18 @@ export function TransitionPicker({
         left: anchorX,
         top: anchorY - 200,
         zIndex: 1000,
-        background: '#1A1F2B',
-        border: '1px solid #2D3548',
+        background: timelineTheme.popover.background,
+        border: `1px solid ${timelineTheme.popover.border}`,
         borderRadius: 10,
         padding: 10,
-        boxShadow: '0 8px 32px rgba(0,0,0,0.6)',
+        boxShadow: timelineTheme.popover.shadow,
         width: 184,
       }}
     >
       <div
         style={{
           fontSize: 10,
-          color: '#6B7280',
+          color: timelineTheme.text.faint,
           fontWeight: 600,
           letterSpacing: '0.08em',
           textTransform: 'uppercase',
@@ -156,19 +157,21 @@ export function TransitionPicker({
                 alignItems: 'center',
                 gap: 4,
                 padding: '8px 6px',
-                background: isActive ? '#3B4A6B' : '#232938',
-                border: isActive ? '1px solid #6B8CFF' : '1px solid #2D3548',
+                background: isActive ? timelineTheme.popover.optionBgActive : timelineTheme.popover.optionBg,
+                border: isActive
+                  ? `1px solid ${timelineTheme.popover.accent}`
+                  : `1px solid ${timelineTheme.popover.border}`,
                 borderRadius: 7,
                 cursor: 'pointer',
                 transition: 'background 0.12s',
               }}
               onMouseEnter={(e) => {
                 if (!isActive)
-                  (e.currentTarget as HTMLButtonElement).style.background = '#2D3548'
+                  (e.currentTarget as HTMLButtonElement).style.background = timelineTheme.popover.optionBgHover
               }}
               onMouseLeave={(e) => {
                 if (!isActive)
-                  (e.currentTarget as HTMLButtonElement).style.background = '#232938'
+                  (e.currentTarget as HTMLButtonElement).style.background = timelineTheme.popover.optionBg
               }}
             >
               <svg
@@ -176,14 +179,14 @@ export function TransitionPicker({
                 height={24}
                 viewBox="0 0 24 24"
                 fill="none"
-                stroke={isActive ? '#6B8CFF' : '#9CA3AF'}
+                stroke={isActive ? timelineTheme.popover.accent : timelineTheme.popover.icon}
                 strokeWidth={1.5}
                 strokeLinecap="round"
                 strokeLinejoin="round"
               >
                 <path d={opt.icon} />
               </svg>
-              <span style={{ fontSize: 9, color: isActive ? '#A5B4FC' : '#9CA3AF', fontWeight: 500 }}>
+              <span style={{ fontSize: 9, color: isActive ? timelineTheme.popover.accentText : timelineTheme.popover.icon, fontWeight: 500 }}>
                 {opt.label}
               </span>
             </button>
@@ -194,8 +197,8 @@ export function TransitionPicker({
       {/* Duration slider */}
       <div style={{ marginTop: 12 }}>
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 4 }}>
-          <span style={{ fontSize: 10, color: '#9CA3AF', fontWeight: 500 }}>Duration</span>
-          <span style={{ fontSize: 10, color: '#E5E7EB', fontFamily: 'monospace' }}>
+          <span style={{ fontSize: 10, color: timelineTheme.text.muted, fontWeight: 500 }}>Duration</span>
+          <span style={{ fontSize: 10, color: timelineTheme.text.bright, fontFamily: 'monospace' }}>
             {durationFrames}f &nbsp;{durationSec}s
           </span>
         </div>
@@ -205,15 +208,15 @@ export function TransitionPicker({
           max={MAX_DURATION}
           value={durationFrames}
           onChange={(e) => handleDurationChange(Number(e.target.value))}
-          style={{ width: '100%', accentColor: '#6B8CFF', cursor: 'pointer' }}
+          style={{ width: '100%', accentColor: timelineTheme.popover.accent, cursor: 'pointer' }}
         />
       </div>
 
       {/* Position slider */}
       <div style={{ marginTop: 10 }}>
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 4 }}>
-          <span style={{ fontSize: 10, color: '#9CA3AF', fontWeight: 500 }}>Position</span>
-          <span style={{ fontSize: 10, color: '#E5E7EB', fontFamily: 'monospace' }}>
+          <span style={{ fontSize: 10, color: timelineTheme.text.muted, fontWeight: 500 }}>Position</span>
+          <span style={{ fontSize: 10, color: timelineTheme.text.bright, fontFamily: 'monospace' }}>
             {before}f ◆ {after}f
           </span>
         </div>
@@ -223,11 +226,11 @@ export function TransitionPicker({
           max={maxOffset}
           value={offsetFrames}
           onChange={(e) => handleOffsetChange(Number(e.target.value))}
-          style={{ width: '100%', accentColor: '#6B8CFF', cursor: 'pointer' }}
+          style={{ width: '100%', accentColor: timelineTheme.popover.accent, cursor: 'pointer' }}
         />
         <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: 2 }}>
-          <span style={{ fontSize: 8, color: '#4B5563' }}>← before cut</span>
-          <span style={{ fontSize: 8, color: '#4B5563' }}>after cut →</span>
+          <span style={{ fontSize: 8, color: timelineTheme.text.hint }}>← before cut</span>
+          <span style={{ fontSize: 8, color: timelineTheme.text.hint }}>after cut →</span>
         </div>
       </div>
 
@@ -240,9 +243,9 @@ export function TransitionPicker({
             width: '100%',
             padding: '5px 0',
             fontSize: 10,
-            color: '#F87171',
+            color: timelineTheme.danger.textAlt,
             background: 'transparent',
-            border: '1px solid #3F2A2A',
+            border: `1px solid ${timelineTheme.danger.border}`,
             borderRadius: 6,
             cursor: 'pointer',
           }}

--- a/packages/timeline/src/index.ts
+++ b/packages/timeline/src/index.ts
@@ -10,6 +10,10 @@
 export { Timeline } from './Timeline'
 export type { TimelineProps, TimelineRef } from './Timeline'
 
+// --- Design tokens (single source of truth for timeline colors) ---
+export { timelineTheme } from './theme'
+export type { TimelineTheme } from './theme'
+
 // --- Timeline hooks ---
 export { useTimeline } from './engine-context'
 export { useTracks } from './hooks/useTracks'

--- a/packages/timeline/src/theme.ts
+++ b/packages/timeline/src/theme.ts
@@ -1,0 +1,176 @@
+/**
+ * Timeline design tokens — the single place to recolor the entire timeline UI.
+ *
+ * Every color, border, shadow and overlay used by the timeline components is
+ * defined here and nowhere else. Components import `timelineTheme` instead of
+ * inlining literals, so changing the look of the whole timeline (e.g. a light
+ * theme, or matching a host app's brand) means editing this one object — no
+ * hunting through component files.
+ *
+ * Grouping is by role, not by component, so a token is reused wherever the same
+ * visual meaning applies (a "muted text" color is one token, not five copies).
+ */
+export const timelineTheme = {
+  /** Background fills for the structural surfaces (lanes, sidebar, ruler). */
+  surface: {
+    /** Outer timeline background and the default (inactive) clip lane. */
+    background: '#0A0D14',
+    /** Clip lane of the currently active track. */
+    laneActive: '#0D1017',
+    /** Track-label sidebar and ruler spacer (inactive). */
+    sidebar: '#121722',
+    /** Track-label sidebar of the active track. */
+    sidebarActive: '#171D2B',
+  },
+
+  /** Hairline dividers between rows, lanes and the sidebar. */
+  border: {
+    /** Stronger vertical rule (sidebar edge, ruler ticks). */
+    strong: '#232938',
+    /** Subtler horizontal rule between track rows. */
+    subtle: '#1A1F2B',
+  },
+
+  /** Foreground text colors, brightest → faintest. */
+  text: {
+    /** Primary labels (active track, headings). */
+    primary: '#F3F4F6',
+    /** Slightly brighter body text inside menus/dialogs. */
+    bright: '#E5E7EB',
+    /** Inactive track label. */
+    secondary: '#A7AFBF',
+    /** Secondary/meta text (hints, slider labels). */
+    muted: '#9CA3AF',
+    /** Ruler labels and section captions. */
+    faint: '#6B7280',
+    /** Empty-state placeholder copy. */
+    disabled: '#555555',
+    /** Smallest helper captions (slider end labels). */
+    hint: '#4B5563',
+    /** Text rendered on top of a colored clip body. */
+    onClip: 'rgba(255,255,255,0.95)',
+  },
+
+  /**
+   * Per-clip-type color ramp. `top`→`mid`→`bottom` form the vertical body
+   * gradient; `accent` is the left stripe and selected-border tint.
+   */
+  clip: {
+    video: { top: '#3B82F6', mid: '#2563EB', bottom: '#1D4ED8', accent: '#60A5FA' },
+    audio: { top: '#22C55E', mid: '#16A34A', bottom: '#15803D', accent: '#4ADE80' },
+    text: { top: '#A855F7', mid: '#9333EA', bottom: '#7E22CE', accent: '#C084FC' },
+    image: { top: '#FBBF24', mid: '#D97706', bottom: '#B45309', accent: '#FCD34D' },
+  },
+
+  /** Selected-clip highlight (border + outer glow). */
+  selection: {
+    border: '#FF2D55',
+    glow: 'rgba(255, 45, 85, 0.4)',
+  },
+
+  /** Playhead needle (line, handle, glow all share this color). */
+  playhead: '#FF2D55',
+
+  /** Ruler tick marks and timecode labels. */
+  ruler: {
+    tick: '#232938',
+    label: '#6B7280',
+  },
+
+  /** Transition cut-line and diamond marker on track rows. */
+  transition: {
+    /** Cut line when a transition exists. */
+    line: 'rgba(107, 140, 255, 0.9)',
+    /** Cut line on hover (no transition yet). */
+    lineHover: 'rgba(255,255,255,0.55)',
+    /** Cut line at rest (no transition, not hovered). */
+    lineIdle: 'rgba(255,255,255,0.18)',
+    /** Filled diamond when a transition exists. */
+    fill: '#6B8CFF',
+    stroke: '#A5B4FC',
+    /** Outline-only "add" diamond (no transition). */
+    addFill: 'rgba(255,255,255,0.12)',
+    addStroke: 'rgba(255,255,255,0.7)',
+  },
+
+  /** Clip right-click context menu. */
+  menu: {
+    background: '#1E2433',
+    border: '#2D3548',
+    shadow: '0 8px 24px rgba(0,0,0,0.5)',
+  },
+
+  /** Transition picker popover. */
+  popover: {
+    background: '#1A1F2B',
+    border: '#2D3548',
+    shadow: '0 8px 32px rgba(0,0,0,0.6)',
+    /** Kind-option button: idle / hover / selected backgrounds. */
+    optionBg: '#232938',
+    optionBgHover: '#2D3548',
+    optionBgActive: '#3B4A6B',
+    /** Selected option border + slider accent. */
+    accent: '#6B8CFF',
+    /** Selected option label text. */
+    accentText: '#A5B4FC',
+    /** Option icon/label when idle. */
+    icon: '#9CA3AF',
+  },
+
+  /** Blocking "this video has audio" choice dialog. */
+  dialog: {
+    overlay: 'rgba(5, 7, 12, 0.6)',
+    background: '#171D2B',
+    border: '#232938',
+    shadow: '0 24px 60px rgba(0,0,0,0.55)',
+    /** Secondary choice button: idle / hover bg + border. */
+    optionBg: '#1B2230',
+    optionBgHover: '#222B3C',
+    optionBorder: '#2A3142',
+    /** Primary (recommended) choice button. */
+    primaryBorder: '#2563EB',
+    primaryBg: 'rgba(37, 99, 235, 0.16)',
+    primaryBgHover: 'rgba(37, 99, 235, 0.28)',
+  },
+
+  /** Destructive actions (delete clip / remove transition). */
+  danger: {
+    text: '#FF6B6B',
+    textAlt: '#F87171',
+    bgHover: 'rgba(255,107,107,0.12)',
+    border: '#3F2A2A',
+  },
+
+  /**
+   * Reusable light/dark overlays composited over colored surfaces — glosses,
+   * inset highlights, scrims and drop shadows. Kept here so the whole UI's
+   * "depth" can be tuned in one place.
+   */
+  effect: {
+    /** Top gloss highlight gradient start. */
+    gloss: 'rgba(255,255,255,0.14)',
+    /** Inset top highlight on a clip body. */
+    innerHighlight: 'rgba(255,255,255,0.12)',
+    /** Inset top highlight on a selected clip body. */
+    innerHighlightStrong: 'rgba(255,255,255,0.15)',
+    /** Clip drop shadow. */
+    clipShadow: '0 2px 6px rgba(0,0,0,0.35)',
+    /** Right-edge separator between filmstrip tiles. */
+    tileSeparator: 'rgba(0,0,0,0.28)',
+    /** Audio waveform bars. */
+    waveform: 'rgba(255,255,255,0.85)',
+    /** Filmstrip placeholder box fill + border. */
+    placeholderBg: 'rgba(0,0,0,0.22)',
+    placeholderBorder: 'rgba(255,255,255,0.08)',
+    /** Trim-handle edge scrim (fades to transparent). */
+    trimScrim: 'rgba(0,0,0,0.35)',
+    /** Label drop shadow for legibility over bright clips. */
+    labelShadow: '0 1px 2px rgba(0,0,0,0.45)',
+    /** Inline delete-button chrome on a selected clip. */
+    deleteBtnBg: 'rgba(0,0,0,0.5)',
+    deleteBtnBorder: 'rgba(255,255,255,0.35)',
+    deleteBtnText: '#ffffff',
+  },
+} as const
+
+export type TimelineTheme = typeof timelineTheme


### PR DESCRIPTION
## What does this PR do?

Centralizes every hardcoded color/border/shadow/overlay in the timeline UI into a single token file (`packages/timeline/src/theme.ts`), so the whole timeline can be recolored from one place.

Closes #
<!-- No associated issue. -->

---

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor (no behavior change)
- [x] Documentation
- [ ] Performance improvement

---

## How to test

1. `npm install && npm run build:packages` from the repo root.
2. `npm run typecheck` and `npm test --workspace=packages/timeline` — both pass.
3. `npm run dev` and open the timeline in `apps/web` — clip blocks, ruler, playhead, transition picker, and the audio-drop dialog render identically to before (pure token extraction, no visual change).
4. Open `packages/timeline/src/theme.ts`, change e.g. `selection.border`, and confirm the selected-clip highlight updates everywhere.

---

## Screenshots / Recording

No visual change — output is pixel-identical. This is a pure refactor that replaces inline literals with equivalent token references.

---

## Checklist

- [x] `npm test` passes
- [x] `npm run typecheck` passes
- [x] I've tested this in the playground
- [x] No `any` types introduced without justification

---

<!-- Note: this PR also adds .gitignore rules for the .js that `tsc --build` emits in-place beside TS sources (the repo never tracks hand-written .js). Happy to split that into its own PR if preferred. -->