### PR TITLE
docs: add /llms.txt route for AI doc discovery

### DIFF
--- a/apps/web/app/llms.txt/route.ts
+++ b/apps/web/app/llms.txt/route.ts
@@ -1,0 +1,75 @@
+import { siteConfig } from '@/config/site'
+
+/**
+ * Generates /llms.txt — a curated, LLM-friendly index of the site's docs, per
+ * the llmstxt.org convention. Retrieval agents (ChatGPT, Perplexity, Claude,
+ * IDE doc fetchers) read this to find the canonical pages without scraping HTML.
+ *
+ * Kept as a route (not a static file) so it derives from `siteConfig` and the
+ * one page list below — the same reason `robots.ts`/`sitemap.ts` are routes.
+ * When you add a docs page, add it to `DOCS` here and to `sitemap.ts`.
+ */
+
+interface DocLink {
+  title: string
+  path: string
+  description: string
+}
+
+const DOCS: DocLink[] = [
+  { title: 'Docs home', path: '/docs', description: 'Overview of the Elah SDK and how the packages fit together.' },
+  { title: 'Installation', path: '/docs/installation', description: 'Install @elah/editor and its peer dependencies.' },
+  { title: 'Getting started', path: '/docs/getting-started', description: 'Mount EditorProvider, Preview, and Timeline into a working editor.' },
+  { title: 'Timeline', path: '/docs/timeline', description: 'The @elah/timeline UI: tracks, clips, ruler, playhead, drag/trim.' },
+  { title: 'Editor', path: '/docs/editor', description: 'The @elah/editor SDK: EditorProvider, Preview, AssetPanel, ElementsPanel.' },
+  { title: 'Export', path: '/docs/export', description: 'Render a project to MP4 with exportVideo (worker + OffscreenCanvas + mediabunny).' },
+  { title: 'Architecture', path: '/docs/architecture', description: 'Engine design: integer frames, the one mutation funnel, pure resolver, dumb renderers.' },
+  { title: 'API reference', path: '/docs/api', description: 'Public API surface across @elah/core, @elah/timeline, and @elah/editor.' },
+  { title: 'Plugins', path: '/docs/plugins', description: 'Extension points and integration patterns.' },
+]
+
+const RESOURCES: DocLink[] = [
+  { title: 'Playgrounds', path: '/playgrounds', description: 'Live, editable examples running the SDK in the browser.' },
+  { title: 'Examples', path: '/examples', description: 'Focused code samples for common tasks.' },
+  { title: 'Blog', path: '/blog', description: 'Engineering notes and release posts.' },
+]
+
+const EXTERNAL: DocLink[] = [
+  { title: 'GitHub repository', path: siteConfig.links.github, description: 'Source, ARCHITECTURE.md, and AGENTS.md (the brief for coding agents in the checkout).' },
+  { title: '@elah/editor on npm', path: 'https://www.npmjs.com/package/@elah/editor', description: 'The full React editor SDK package.' },
+]
+
+function section(title: string, links: DocLink[], base: string): string {
+  const line = ({ title, path, description }: DocLink) => {
+    const url = path.startsWith('http') ? path : `${base}${path}`
+    return `- [${title}](${url}): ${description}`
+  }
+  return `## ${title}\n\n${links.map(line).join('\n')}`
+}
+
+export function GET(): Response {
+  const base = siteConfig.url
+
+  const body = `# ${siteConfig.name}
+
+> ${siteConfig.description}
+
+Elah is a browser-native, frame-accurate video editing engine: a framework-agnostic
+core (timeline engine, pure resolver, WebGL2 renderer, WebCodecs decode, MP4 export)
+with React bindings on top. Time is integer frames; every edit funnels through one
+engine; \`resolveTimeline(frame, project) → Scene\` is the pure bridge to any renderer.
+
+${section('Documentation', DOCS, base)}
+
+${section('Resources', RESOURCES, base)}
+
+${section('Source & packages', EXTERNAL, base)}
+`
+
+  return new Response(body, {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600, s-maxage=3600',
+    },
+  })
+}


### PR DESCRIPTION
## What does this PR do?

Adds a `/llms.txt` route so retrieval LLMs (ChatGPT, Perplexity, Claude, IDE doc fetchers) can discover the canonical docs without scraping HTML, per the [llmstxt.org](https://llmstxt.org) convention.

Closes #

---

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behavior change)
- [x] Documentation
- [ ] Performance improvement

---

## How to test

1. `npm run dev` and open `http://localhost:3001/llms.txt`.
2. Confirm it returns `200` with `Content-Type: text/plain; charset=utf-8` and a `Cache-Control` header.
3. Confirm the body is a valid llms.txt: an H1 (`# elah`), a summary blockquote, a short engine primer, then `## Documentation` / `## Resources` / `## Source & packages` sections linking every docs page as absolute URLs derived from `siteConfig`.

---

## Screenshots / Recording

Plain-text output of `curl -s http://localhost:3001/llms.txt`:

```
# elah

> Framework-agnostic, browser-native video infrastructure. ...

## Documentation
- [Docs home](https://www.elah.dev/docs): Overview of the Elah SDK and how the packages fit together.
- [Installation](https://www.elah.dev/docs/installation): Install @elah/editor and its peer dependencies.
... (getting-started, timeline, editor, export, architecture, api, plugins)

## Resources
- [Playgrounds](https://www.elah.dev/playgrounds): ...

## Source & packages
- [GitHub repository](https://github.com/elahlabs/elah): ...
```

---

## Checklist

- [x] `npm test` passes
- [x] `npm run typecheck` passes <!-- route typechecks clean; the only tsc error is the pre-existing MediaPanel.tsx one on dev, unrelated to this change -->
- [x] I've tested this in the playground <!-- verified the rendered /llms.txt over HTTP -->
- [x] No `any` types introduced without justification

---

### Notes

- Implemented as a Next.js route handler (`apps/web/app/llms.txt/route.ts`), not a static file, so it derives from `siteConfig` — same rationale as the existing `robots.ts` / `sitemap.ts` routes.
- Follow-ups (deliberately out of scope here): a companion `/llms-full.txt`, and consolidating the `sitemap.ts` and `llms.txt` page lists into one shared source (they can otherwise drift — this route already lists `architecture` and `plugins`, which `sitemap.ts` currently omits).
