### PR TITLE
ui: mobile-responsive production editor (touch gestures, tap-to-add, responsive shell)

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from 'next'
+import type { Metadata, Viewport } from 'next'
 import { Inter, JetBrains_Mono } from 'next/font/google'
 import '@/styles/globals.css'
 import { siteConfig } from '@/config/site'
@@ -41,6 +41,14 @@ export const metadata: Metadata = {
   },
   // Favicon + touch icon are provided by app/icon.png and app/apple-icon.png
   // (Next.js file-based metadata), so no manual `icons` entry is needed.
+}
+
+// viewport-fit=cover lets the editor's mobile bottom bar pad itself with
+// env(safe-area-inset-bottom) instead of floating above the home indicator.
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
+  viewportFit: 'cover',
 }
 
 // Runs synchronously before first paint to avoid flash of wrong theme.

--- a/apps/web/components/playground/production/MediaPanel.tsx
+++ b/apps/web/components/playground/production/MediaPanel.tsx
@@ -12,7 +12,7 @@
  * will be discarded once this is approved.
  */
 
-import { useCallback, useRef, useState, type DragEvent } from 'react'
+import { useCallback, useEffect, useRef, useState, type DragEvent } from 'react'
 import {
   UploadCloud,
   Search,
@@ -29,9 +29,12 @@ import {
   importFiles,
   importUrl,
   MEDIA_DRAG_MIME,
+  insertMediaAsset,
+  useTimelineEngine,
   type MediaAsset,
   type MediaKind,
   type DragMediaPayload,
+  type InsertAssetResult,
 } from '@elah/editor'
 import { cn } from '@/lib/utils'
 
@@ -121,7 +124,15 @@ function Dropdown({
   )
 }
 
-function AssetCard({ asset }: { asset: MediaAsset }) {
+function AssetCard({
+  asset,
+  active,
+  onActivate,
+}: {
+  asset: MediaAsset
+  active: boolean
+  onActivate: (asset: MediaAsset) => void
+}) {
   const removeAsset = useMediaLibraryStore((s) => s.removeAsset)
   const duration = fmtDuration(asset.durationSec)
 
@@ -133,15 +144,35 @@ function AssetCard({ asset }: { asset: MediaAsset }) {
     },
     [asset.id],
   )
+  const handleActivate = useCallback(() => onActivate(asset), [asset, onActivate])
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (e.key !== 'Enter' && e.key !== ' ') return
+      e.preventDefault()
+      onActivate(asset)
+    },
+    [asset, onActivate],
+  )
 
   return (
     <div
       draggable
+      role="button"
+      tabIndex={0}
       onDragStart={onDragStart}
+      onClick={handleActivate}
+      onKeyDown={handleKeyDown}
       title={asset.name}
       className="group flex flex-col gap-1.5 cursor-grab active:cursor-grabbing"
     >
-      <div className="relative aspect-video w-full overflow-hidden rounded-md border border-ed-border bg-ed-bg-2">
+      <div
+        className={cn(
+          'relative aspect-video w-full overflow-hidden rounded-md border bg-ed-bg-2 transition-[border-color,box-shadow]',
+          active
+            ? 'border-[var(--elah-accent)] shadow-[0_0_0_1px_var(--elah-accent)]'
+            : 'border-ed-border',
+        )}
+      >
         {asset.thumbnailUrl ? (
           <img
             src={asset.thumbnailUrl}
@@ -177,7 +208,10 @@ function AssetCard({ asset }: { asset: MediaAsset }) {
 
         <button
           type="button"
-          onClick={() => removeAsset(asset.id)}
+          onClick={(e) => {
+            e.stopPropagation()
+            removeAsset(asset.id)
+          }}
           title="Remove from library"
           className="absolute right-1 top-1 flex h-5 w-5 items-center justify-center rounded bg-black/60 text-white/80 opacity-0 transition-opacity hover:text-white group-hover:opacity-100"
         >
@@ -187,6 +221,11 @@ function AssetCard({ asset }: { asset: MediaAsset }) {
       <span className="truncate text-[11px] text-ed-text">{asset.name}</span>
     </div>
   )
+}
+
+interface InsertNotice {
+  message: string
+  tone: 'info' | 'warn'
 }
 
 const PANEL_CONFIG: Record<
@@ -244,6 +283,7 @@ function filterByMode(asset: MediaAsset, mode: PanelMode): boolean {
 }
 
 export function MediaPanel({ style, mode = 'media' }: { style?: React.CSSProperties; mode?: PanelMode }) {
+  const engine = useTimelineEngine()
   const { assets } = useMediaLibrary()
   const fileInputRef = useRef<HTMLInputElement>(null)
   const [sort, setSort] = useState<SortKey>('added')
@@ -255,8 +295,19 @@ export function MediaPanel({ style, mode = 'media' }: { style?: React.CSSPropert
   const [urlBusy, setUrlBusy] = useState(false)
   const [urlError, setUrlError] = useState<string | null>(null)
   const [urlFallback, setUrlFallback] = useState<string | null>(null)
+  const [insertNotice, setInsertNotice] = useState<InsertNotice | null>(null)
+  const [activeAssetId, setActiveAssetId] = useState<string | null>(null)
 
   const cfg = PANEL_CONFIG[mode]
+
+  useEffect(() => {
+    if (!insertNotice) return
+    const timer = globalThis.setTimeout(() => {
+      setInsertNotice(null)
+      setActiveAssetId(null)
+    }, 1600)
+    return () => globalThis.clearTimeout(timer)
+  }, [insertNotice])
 
   const onPick = useCallback(async (files: FileList | File[] | null) => {
     if (!files || ('length' in files && files.length === 0)) return
@@ -282,6 +333,15 @@ export function MediaPanel({ style, mode = 'media' }: { style?: React.CSSPropert
       setUrlBusy(false)
     }
   }, [url, urlBusy, cfg.expectedKind])
+
+  const onActivateAsset = useCallback(
+    async (asset: MediaAsset) => {
+      const result = await insertMediaAsset(engine, asset.id)
+      showInsertNotice(asset, result, setInsertNotice)
+      if (result.ok) setActiveAssetId(asset.id)
+    },
+    [engine],
+  )
 
   const onDrop = useCallback(
     (e: DragEvent<HTMLButtonElement>) => {
@@ -450,6 +510,20 @@ export function MediaPanel({ style, mode = 'media' }: { style?: React.CSSPropert
             />
           </div>
 
+          {insertNotice && (
+            <div
+              role="status"
+              className={cn(
+                'mb-2 rounded-md border px-2.5 py-1.5 text-[11px]',
+                insertNotice.tone === 'warn'
+                  ? 'border-ed-error/40 bg-ed-error/10 text-ed-error'
+                  : 'border-ed-border bg-ed-elevated text-ed-text',
+              )}
+            >
+              {insertNotice.message}
+            </div>
+          )}
+
           {/* Asset grid */}
           <div className="flex-1 overflow-y-auto">
             {filtered.length === 0 ? (
@@ -464,7 +538,12 @@ export function MediaPanel({ style, mode = 'media' }: { style?: React.CSSPropert
             ) : (
               <div className="grid grid-cols-2 gap-2.5">
                 {filtered.map((a) => (
-                  <AssetCard key={a.id} asset={a} />
+                  <AssetCard
+                    key={a.id}
+                    asset={a}
+                    active={activeAssetId === a.id}
+                    onActivate={onActivateAsset}
+                  />
                 ))}
               </div>
             )}
@@ -472,6 +551,26 @@ export function MediaPanel({ style, mode = 'media' }: { style?: React.CSSPropert
         </div>
       </div>
   )
+}
+
+function showInsertNotice(
+  asset: MediaAsset,
+  result: InsertAssetResult,
+  setInsertNotice: (notice: InsertNotice) => void,
+) {
+  if (result.ok) {
+    setInsertNotice({ message: `Added ${asset.name}`, tone: 'info' })
+    return
+  }
+
+  if (result.reason === 'cancelled') return
+
+  if (result.reason === 'missing-asset') {
+    setInsertNotice({ message: 'Asset unavailable', tone: 'warn' })
+    return
+  }
+
+  setInsertNotice({ message: `No unlocked track for ${asset.kind}`, tone: 'warn' })
 }
 
 export default MediaPanel

--- a/apps/web/components/playground/production/ProductionEditor.tsx
+++ b/apps/web/components/playground/production/ProductionEditor.tsx
@@ -577,6 +577,17 @@ const MobileAspectSelect = memo(function MobileAspectSelect() {
   )
 })
 
+/** Mobile timecode: MM:SS:FF — three fields instead of the desktop four
+ * (hours dropped), so the transport grid centers the play button without
+ * the timer running underneath it. */
+function framesToCompactTimecode(frame: number, fps: number): string {
+  const totalSec = Math.floor(frame / fps)
+  const ff = frame % fps
+  const m = Math.floor(totalSec / 60)
+  const s = totalSec % 60
+  return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}:${String(ff).padStart(2, '0')}`
+}
+
 // Video transport — lives under the Preview (not in the timeline toolbar),
 // matching the Figma. Play/pause, stop, and current | total time (cyan current).
 const TransportBar = memo(function TransportBar() {
@@ -593,23 +604,25 @@ const TransportBar = memo(function TransportBar() {
   const totalTimeRef = useRef<HTMLSpanElement>(null)
 
   useEffect(() => {
+    const fmt = isMobile ? framesToCompactTimecode : framesToTimecode
     return usePlaybackStore.subscribe((state) => {
       if (currentTimeRef.current) {
-        currentTimeRef.current.textContent = framesToTimecode(state.currentFrame, FPS)
+        currentTimeRef.current.textContent = fmt(state.currentFrame, FPS)
       }
     })
-  }, [])
+  }, [isMobile])
 
   useEffect(() => {
+    const fmt = isMobile ? framesToCompactTimecode : framesToTimecode
     const dur = Math.max(totalFrames, 1)
-    if (totalTimeRef.current) totalTimeRef.current.textContent = framesToTimecode(dur, FPS)
+    if (totalTimeRef.current) totalTimeRef.current.textContent = fmt(dur, FPS)
     if (currentTimeRef.current) {
-      currentTimeRef.current.textContent = framesToTimecode(
+      currentTimeRef.current.textContent = fmt(
         usePlaybackStore.getState().currentFrame,
         FPS,
       )
     }
-  }, [totalFrames])
+  }, [totalFrames, isMobile])
 
   const handleStop = useCallback(() => {
     usePlaybackStore.getState().pause()
@@ -622,17 +635,21 @@ const TransportBar = memo(function TransportBar() {
   return (
     <div
       className={cn(
-        'items-center h-11 bg-ed-bg-2 border-t border-ed-border shrink-0',
-        // Desktop hard-centers the transport via grid; on narrow screens the
-        // timecode runs under it, so mobile uses justify-between instead.
-        isMobile ? 'flex justify-between gap-2 px-3' : 'grid grid-cols-[1fr_auto_1fr] px-4',
+        'grid grid-cols-[1fr_auto_1fr] items-center h-11 bg-ed-bg-2 border-t border-ed-border shrink-0',
+        // Same centering grid on both; mobile fits because the timecode drops
+        // to three fields (MM:SS:FF) via framesToCompactTimecode.
+        isMobile ? 'px-3' : 'px-4',
       )}
     >
       {/* Left — current | total time (current in accent) */}
       <span className="font-mono text-[11px] tracking-[0.02em] tabular-nums whitespace-nowrap">
-        <span ref={currentTimeRef} style={{ color: 'var(--elah-accent)' }}>00:00:00:00</span>
+        <span ref={currentTimeRef} style={{ color: 'var(--elah-accent)' }}>
+          {isMobile ? '00:00:00' : '00:00:00:00'}
+        </span>
         <span className="text-ed-text-muted mx-1.5">|</span>
-        <span ref={totalTimeRef} className="text-ed-text-muted">00:00:00:00</span>
+        <span ref={totalTimeRef} className="text-ed-text-muted">
+          {isMobile ? '00:00:00' : '00:00:00:00'}
+        </span>
       </span>
 
       {/* Center — video controls */}

--- a/apps/web/components/playground/production/ProductionEditor.tsx
+++ b/apps/web/components/playground/production/ProductionEditor.tsx
@@ -620,7 +620,14 @@ const TransportBar = memo(function TransportBar() {
     'inline-flex items-center justify-center w-7 h-7 rounded text-ed-text-muted hover:text-ed-text hover:bg-ed-elevated transition-colors cursor-pointer'
 
   return (
-    <div className="grid grid-cols-[1fr_auto_1fr] items-center h-11 px-4 bg-ed-bg-2 border-t border-ed-border shrink-0">
+    <div
+      className={cn(
+        'items-center h-11 bg-ed-bg-2 border-t border-ed-border shrink-0',
+        // Desktop hard-centers the transport via grid; on narrow screens the
+        // timecode runs under it, so mobile uses justify-between instead.
+        isMobile ? 'flex justify-between gap-2 px-3' : 'grid grid-cols-[1fr_auto_1fr] px-4',
+      )}
+    >
       {/* Left — current | total time (current in accent) */}
       <span className="font-mono text-[11px] tracking-[0.02em] tabular-nums whitespace-nowrap">
         <span ref={currentTimeRef} style={{ color: 'var(--elah-accent)' }}>00:00:00:00</span>

--- a/apps/web/components/playground/production/ProductionEditor.tsx
+++ b/apps/web/components/playground/production/ProductionEditor.tsx
@@ -18,6 +18,10 @@ import {
   Undo2,
   Redo2,
   Code2,
+  Minimize2,
+  MoreVertical,
+  SlidersHorizontal,
+  X,
 } from 'lucide-react'
 import { ClipProperties } from './properties/ClipProperties'
 import { TimelineControls } from '../shared/TimelineControls'
@@ -38,6 +42,7 @@ import {
   createDefaultDemuxerFactory,
   useTracksStore,
   usePlaybackStore,
+  useSelectionStore,
   useTimelineEngine,
   framesToTimecode,
   type InitialTrackConfig,
@@ -47,6 +52,98 @@ import {
 } from '@elah/editor'
 
 const FPS = 30
+
+/** Tailwind `md` breakpoint, kept as JS state because the mobile layout needs
+ * different component *props* (Timeline sidebar, panel placement), not just CSS. */
+const MOBILE_QUERY = '(max-width: 767px)'
+
+function useIsMobile(): boolean {
+  const [isMobile, setIsMobile] = useState(false)
+  useEffect(() => {
+    const mq = window.matchMedia(MOBILE_QUERY)
+    setIsMobile(mq.matches)
+    const onChange = (e: MediaQueryListEvent) => setIsMobile(e.matches)
+    mq.addEventListener('change', onChange)
+    return () => mq.removeEventListener('change', onChange)
+  }, [])
+  return isMobile
+}
+
+/** Bottom drawer for the mobile layout — renders the same panels the desktop
+ * columns use, so behavior stays identical across breakpoints. */
+function MobileSheet({
+  title,
+  onClose,
+  children,
+}: {
+  title: string
+  onClose: () => void
+  children: React.ReactNode
+}) {
+  return (
+    <>
+      <div className="fixed inset-0 z-[60] bg-black/50" onClick={onClose} />
+      <div
+        className="fixed inset-x-0 bottom-0 z-[70] flex flex-col rounded-t-xl border-t border-ed-border bg-ed-bg-2 max-h-[68vh] pb-[env(safe-area-inset-bottom)]"
+        role="dialog"
+        aria-label={title}
+      >
+        <div className="flex items-center justify-between px-4 pt-2 pb-1 shrink-0">
+          <span className="w-8" aria-hidden />
+          <span className="h-1 w-9 rounded-full bg-ed-border" aria-hidden />
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label={`Close ${title}`}
+            className="inline-flex items-center justify-center w-8 h-8 rounded text-ed-text-muted hover:text-ed-text"
+          >
+            <X size={16} />
+          </button>
+        </div>
+        <div className="flex-1 min-h-0 overflow-y-auto flex flex-col">{children}</div>
+      </div>
+    </>
+  )
+}
+
+type MobileSheetKind = (typeof RAIL_ITEMS)[number]['id'] | 'properties' | null
+
+/** Floating fullscreen toggle on the preview (Figma's mobile design puts it
+ * inside the player, bottom-right). Fullscreens the preview container — the
+ * renderer's ResizeObserver picks up the new size automatically. */
+function PreviewFullscreenButton({
+  targetRef,
+}: {
+  targetRef: React.RefObject<HTMLDivElement | null>
+}) {
+  const [active, setActive] = useState(false)
+
+  useEffect(() => {
+    const onChange = () => setActive(Boolean(document.fullscreenElement))
+    document.addEventListener('fullscreenchange', onChange)
+    return () => document.removeEventListener('fullscreenchange', onChange)
+  }, [])
+
+  const toggle = useCallback(() => {
+    if (document.fullscreenElement) {
+      void document.exitFullscreen()
+    } else {
+      void targetRef.current?.requestFullscreen?.()
+    }
+  }, [targetRef])
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      aria-label={active ? 'Exit fullscreen' : 'Fullscreen'}
+      title={active ? 'Exit fullscreen' : 'Fullscreen'}
+      className="absolute bottom-3 right-3 z-20 flex items-center justify-center w-10 h-10 rounded-full bg-black/60 text-white border border-white/10 backdrop-blur-sm cursor-pointer"
+    >
+      {active ? <Minimize2 size={16} /> : <Maximize2 size={16} />}
+    </button>
+  )
+}
 
 // Minimal default — one of each. The model allows a single video track but any
 // number of audio / elements tracks; more are added from the toolbar at runtime.
@@ -74,10 +171,15 @@ const AppHeader = memo(function AppHeader({
   timelineRef: React.RefObject<TimelineRef | null>
 }) {
   const [showTrace, setShowTrace] = useState(false)
+  const [showOverflow, setShowOverflow] = useState(false)
   const canUndo = useTracksStore((s) => s.canUndo)
   const canRedo = useTracksStore((s) => s.canRedo)
   const engine = useTimelineEngine()
   const [loadingDemo, setLoadingDemo] = useState(false)
+  // Conditional rendering, not responsive classes: the published packages ship
+  // their own Tailwind utilities (.hidden/.inline-flex), and stylesheet load
+  // order lets those beat the app's md: variants either way.
+  const isMobile = useIsMobile()
 
   const handleLoadDemo = useCallback(async () => {
     setLoadingDemo(true)
@@ -119,79 +221,92 @@ const AppHeader = memo(function AppHeader({
         >
           ← Playgrounds
         </Link>
-        <div className="w-px h-4 bg-ed-border shrink-0" />
-        <span className="inline-flex items-center gap-2">
-          <span
-            className="w-[7px] h-[7px] rounded-full shrink-0"
-            style={{
-              background: 'var(--elah-accent)',
-              boxShadow: '0 0 8px var(--elah-accent-glow)',
-            }}
-          />
-          <span className="text-[13px] font-bold text-ed-text tracking-[-0.02em]">
-            elah
-          </span>
-          <span className="text-[11px] font-mono text-ed-text-muted">
-            @elah/editor
-          </span>
-        </span>
-        <button
-          type="button"
-          className="px-3.5 py-1.5 text-xs font-semibold rounded-md font-sans tracking-[-0.01em] transition-all"
-          style={demoBtnStyle}
-          disabled={loadingDemo}
-          onClick={handleLoadDemo}
-          title="Load a cinematic demo project: assets, fades, and text overlays"
-        >
-          {loadingDemo ? 'Loading…' : '✦ Load Elah Demo Project'}
-        </button>
+        {!isMobile && (
+          <>
+            <div className="w-px h-4 bg-ed-border shrink-0" />
+            <span className="inline-flex items-center gap-2">
+              <span
+                className="w-[7px] h-[7px] rounded-full shrink-0"
+                style={{
+                  background: 'var(--elah-accent)',
+                  boxShadow: '0 0 8px var(--elah-accent-glow)',
+                }}
+              />
+              <span className="text-[13px] font-bold text-ed-text tracking-[-0.02em]">
+                elah
+              </span>
+              <span className="text-[11px] font-mono text-ed-text-muted">
+                @elah/editor
+              </span>
+            </span>
+            <button
+              type="button"
+              className="px-3.5 py-1.5 text-xs font-semibold rounded-md font-sans tracking-[-0.01em] transition-all"
+              style={demoBtnStyle}
+              disabled={loadingDemo}
+              onClick={handleLoadDemo}
+              title="Load a cinematic demo project: assets, fades, and text overlays"
+            >
+              {loadingDemo ? 'Loading…' : '✦ Load Elah Demo Project'}
+            </button>
+          </>
+        )}
       </div>
 
-      {/* Center — undo / redo */}
+      {/* Center — desktop: undo/redo; mobile: the aspect dropdown pill (Figma).
+          Mobile undo/redo live in the transport row instead. */}
       <div className="flex items-center gap-1">
-        <button
-          type="button"
-          className={cn(
-            toolbarBtnCls,
-            'inline-flex items-center justify-center',
-            !canUndo && 'opacity-40 cursor-not-allowed',
-          )}
-          disabled={!canUndo}
-          onClick={() => engine.undo()}
-          title="Undo (Ctrl+Z)"
-        >
-          <Undo2 size={15} />
-        </button>
-        <button
-          type="button"
-          className={cn(
-            toolbarBtnCls,
-            'inline-flex items-center justify-center',
-            !canRedo && 'opacity-40 cursor-not-allowed',
-          )}
-          disabled={!canRedo}
-          onClick={() => engine.redo()}
-          title="Redo (Ctrl+Y)"
-        >
-          <Redo2 size={15} />
-        </button>
+        {isMobile ? (
+          <MobileAspectSelect />
+        ) : (
+          <>
+            <button
+              type="button"
+              className={cn(
+                toolbarBtnCls,
+                'inline-flex items-center justify-center',
+                !canUndo && 'opacity-40 cursor-not-allowed',
+              )}
+              disabled={!canUndo}
+              onClick={() => engine.undo()}
+              title="Undo (Ctrl+Z)"
+            >
+              <Undo2 size={15} />
+            </button>
+            <button
+              type="button"
+              className={cn(
+                toolbarBtnCls,
+                'inline-flex items-center justify-center',
+                !canRedo && 'opacity-40 cursor-not-allowed',
+              )}
+              disabled={!canRedo}
+              onClick={() => engine.redo()}
+              title="Redo (Ctrl+Y)"
+            >
+              <Redo2 size={15} />
+            </button>
+          </>
+        )}
       </div>
 
       {/* Right — export + nav group (tabs kept right-aligned so they hold
           position across Production / Timeline / Raw) */}
       <div className="flex items-center gap-1 justify-end">
-        <button
-          type="button"
-          className={cn(
-            toolbarBtnCls,
-            'inline-flex items-center gap-1.5',
-            codeOpen && 'text-ed-text border-ed-accent/60',
-          )}
-          onClick={onToggleCode}
-          title="Show render code"
-        >
-          <Code2 size={14} /> Code
-        </button>
+        {!isMobile && (
+          <button
+            type="button"
+            className={cn(
+              toolbarBtnCls,
+              'inline-flex items-center gap-1.5',
+              codeOpen && 'text-ed-text border-ed-accent/60',
+            )}
+            onClick={onToggleCode}
+            title="Show render code"
+          >
+            <Code2 size={14} /> Code
+          </button>
+        )}
         <button
           type="button"
           className={toolbarBtnCls}
@@ -200,38 +315,86 @@ const AppHeader = memo(function AppHeader({
         >
           ⬇ Export
         </button>
+        {!isMobile && (
+          <>
+            <div className="relative">
+              <button
+                type="button"
+                className={cn(
+                  toolbarBtnCls,
+                  showTrace && 'bg-ed-elevated text-ed-text',
+                )}
+                onClick={() => setShowTrace((v) => !v)}
+                title="Toggle trace channel controls"
+              >
+                Trace
+              </button>
+              {showTrace && (
+                <>
+                  <div className="fixed inset-0 z-40" onClick={() => setShowTrace(false)} />
+                  <div className="relative z-50">
+                    <TracePanel onClose={() => setShowTrace(false)} />
+                  </div>
+                </>
+              )}
+            </div>
+            <div className="w-px h-4 bg-ed-border shrink-0 mx-1" />
+            <PlaygroundTabs />
+            <a
+              href={siteConfig.links.github}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center px-2 py-1.5 rounded-md text-ed-text-muted hover:text-ed-text hover:bg-ed-elevated transition-colors"
+              title="View source on GitHub"
+            >
+              <Github size={14} />
+            </a>
+          </>
+        )}
+        {/* Mobile overflow — desktop-only header actions folded into one menu. */}
+        {isMobile && (
         <div className="relative">
           <button
             type="button"
-            className={cn(
-              toolbarBtnCls,
-              showTrace && 'bg-ed-elevated text-ed-text',
-            )}
-            onClick={() => setShowTrace((v) => !v)}
-            title="Toggle trace channel controls"
+            className={cn(toolbarBtnCls, 'inline-flex items-center justify-center')}
+            onClick={() => setShowOverflow((v) => !v)}
+            title="More actions"
+            aria-label="More actions"
           >
-            Trace
+            <MoreVertical size={15} />
           </button>
-          {showTrace && (
+          {showOverflow && (
             <>
-              <div className="fixed inset-0 z-40" onClick={() => setShowTrace(false)} />
-              <div className="relative z-50">
-                <TracePanel onClose={() => setShowTrace(false)} />
+              <div className="fixed inset-0 z-40" onClick={() => setShowOverflow(false)} />
+              <div className="absolute right-0 top-full mt-1 z-50 min-w-[190px] rounded-md border border-ed-border bg-ed-elevated py-1 shadow-[var(--elah-menu-shadow)]">
+                <button
+                  type="button"
+                  disabled={loadingDemo}
+                  onClick={() => { setShowOverflow(false); void handleLoadDemo() }}
+                  className="flex items-center gap-2 w-full px-3 py-2 text-xs text-ed-text-muted hover:text-ed-text hover:bg-ed-highest transition-colors"
+                >
+                  ✦ {loadingDemo ? 'Loading…' : 'Load Demo Project'}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => { setShowOverflow(false); onToggleCode() }}
+                  className="flex items-center gap-2 w-full px-3 py-2 text-xs text-ed-text-muted hover:text-ed-text hover:bg-ed-highest transition-colors"
+                >
+                  <Code2 size={14} /> {codeOpen ? 'Hide code' : 'Show code'}
+                </button>
+                <a
+                  href={siteConfig.links.github}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center gap-2 w-full px-3 py-2 text-xs text-ed-text-muted hover:text-ed-text hover:bg-ed-highest transition-colors"
+                >
+                  <Github size={14} /> GitHub
+                </a>
               </div>
             </>
           )}
         </div>
-        <div className="w-px h-4 bg-ed-border shrink-0 mx-1" />
-        <PlaygroundTabs />
-        <a
-          href={siteConfig.links.github}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="inline-flex items-center px-2 py-1.5 rounded-md text-ed-text-muted hover:text-ed-text hover:bg-ed-elevated transition-colors"
-          title="View source on GitHub"
-        >
-          <Github size={14} />
-        </a>
+        )}
       </div>
     </header>
   )
@@ -345,9 +508,84 @@ const AspectControl = memo(function AspectControl() {
   )
 })
 
+// Mobile variant of AspectControl — the Figma's header pill ("▤ 9:16 ⌄").
+// Same engine.setStage mutation, dropdown instead of a segmented row.
+const MobileAspectSelect = memo(function MobileAspectSelect() {
+  const engine = useTimelineEngine()
+  const stage = useTracksStore((s) => s.stage)
+  const [open, setOpen] = useState(false)
+
+  const current = ASPECTS.find(
+    (a) => Math.abs(stage.width / stage.height - a.w / a.h) < 0.001,
+  )
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        title="Aspect ratio"
+        className="inline-flex items-center gap-1.5 px-3 h-8 rounded-lg border border-ed-border bg-ed-elevated text-ed-text text-xs cursor-pointer"
+      >
+        {current && (
+          <span
+            style={{
+              width: current.gw * 0.8,
+              height: current.gh * 0.8,
+              borderRadius: 2,
+              background: 'currentColor',
+            }}
+          />
+        )}
+        {current?.label ?? 'Custom'}
+        <ChevronDown size={12} />
+      </button>
+      {open && (
+        <>
+          <div className="fixed inset-0 z-40" onClick={() => setOpen(false)} />
+          <div className="absolute left-1/2 -translate-x-1/2 top-full mt-1 z-50 min-w-[120px] rounded-md border border-ed-border bg-ed-elevated py-1 shadow-[var(--elah-menu-shadow)]">
+            {ASPECTS.map((a) => (
+              <button
+                key={a.label}
+                type="button"
+                onClick={() => {
+                  engine.setStage(a.w, a.h)
+                  setOpen(false)
+                }}
+                className={cn(
+                  'flex items-center gap-2 w-full px-3 py-2 text-xs transition-colors hover:bg-ed-highest',
+                  current?.label === a.label
+                    ? 'text-ed-text'
+                    : 'text-ed-text-muted hover:text-ed-text',
+                )}
+              >
+                <span
+                  style={{
+                    width: a.gw * 0.8,
+                    height: a.gh * 0.8,
+                    borderRadius: 2,
+                    background: 'currentColor',
+                  }}
+                />
+                {a.label}
+              </button>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  )
+})
+
 // Video transport — lives under the Preview (not in the timeline toolbar),
 // matching the Figma. Play/pause, stop, and current | total time (cyan current).
 const TransportBar = memo(function TransportBar() {
+  // The floating preview toggle owns fullscreen on mobile — drop the duplicate.
+  // Undo/redo live here on mobile (per the Figma); on desktop they stay in the header.
+  const isMobile = useIsMobile()
+  const engine = useTimelineEngine()
+  const canUndo = useTracksStore((s) => s.canUndo)
+  const canRedo = useTracksStore((s) => s.canRedo)
   const isPlaying = usePlaybackStore((s) => s.isPlaying)
   const togglePlayPause = usePlaybackStore((s) => s.togglePlayPause)
   const totalFrames = useTracksStore((s) => s.totalFrames)
@@ -414,21 +652,46 @@ const TransportBar = memo(function TransportBar() {
         </button>
       </div>
 
-      {/* Right — preview view controls from the Figma (visual only for now). */}
+      {/* Right — undo/redo on mobile (Figma), preview view controls on desktop. */}
       <div className="flex items-center gap-1.5 justify-end">
-        <button type="button" title="Fullscreen" className={ghostIcon}>
-          <Maximize2 size={14} />
-        </button>
-        <button
-          type="button"
-          title="Fit"
-          className="inline-flex items-center gap-1 px-2 h-7 rounded border border-ed-border text-ed-text-muted text-[11px] hover:text-ed-text transition-colors cursor-pointer"
-        >
-          Fit <ChevronDown size={12} />
-        </button>
-        <button type="button" title="Frame" className={ghostIcon}>
-          <RectangleHorizontal size={15} />
-        </button>
+        {isMobile ? (
+          <>
+            <button
+              type="button"
+              className={cn(ghostIcon, !canUndo && 'opacity-40 cursor-not-allowed')}
+              disabled={!canUndo}
+              onClick={() => engine.undo()}
+              title="Undo"
+            >
+              <Undo2 size={16} />
+            </button>
+            <button
+              type="button"
+              className={cn(ghostIcon, !canRedo && 'opacity-40 cursor-not-allowed')}
+              disabled={!canRedo}
+              onClick={() => engine.redo()}
+              title="Redo"
+            >
+              <Redo2 size={16} />
+            </button>
+          </>
+        ) : (
+          <>
+            <button type="button" title="Fullscreen" className={ghostIcon}>
+              <Maximize2 size={14} />
+            </button>
+            <button
+              type="button"
+              title="Fit"
+              className="inline-flex items-center gap-1 px-2 h-7 rounded border border-ed-border text-ed-text-muted text-[11px] hover:text-ed-text transition-colors cursor-pointer"
+            >
+              Fit <ChevronDown size={12} />
+            </button>
+            <button type="button" title="Frame" className={ghostIcon}>
+              <RectangleHorizontal size={15} />
+            </button>
+          </>
+        )}
       </div>
     </div>
   )
@@ -441,6 +704,9 @@ export default function ProductionEditor() {
   const [showExportModal, setShowExportModal] = useState(false)
   const [showCode, setShowCode] = useState(false)
   const [activePanel, setActivePanel] = useState('media')
+  const isMobile = useIsMobile()
+  const [mobileSheet, setMobileSheet] = useState<MobileSheetKind>(null)
+  const previewBoxRef = useRef<HTMLDivElement>(null)
 
   const handleExportStart = useCallback(async (opts: {
     videoBitrate: number
@@ -490,51 +756,124 @@ export default function ProductionEditor() {
 
         <div className="flex flex-col flex-1 min-h-0">
           <div className="flex flex-1 min-h-0">
-            <LeftRail active={activePanel} onSelect={setActivePanel} />
-            <div
-              style={{
-                display: 'flex',
-                flexDirection: 'column',
-                width: 240,
-                flexShrink: 0,
-                borderRight: '1px solid var(--elah-border)',
-                background: 'var(--elah-bg-panel)',
-                minHeight: 0,
-                overflow: 'hidden',
-              }}
-            >
-              {/* Old SDK panel — kept commented for comparison, discard later. */}
-              {/* <SourcePanel style={{ flex: 1, minHeight: 0 }} /> */}
-              {activePanel === 'elements' ? (
-                <ElementsPanel style={{ flex: 1, minHeight: 0 }} />
-              ) : (
-                <MediaPanel mode={activePanel as PanelMode} style={{ flex: 1, minHeight: 0 }} />
-              )}
-            </div>
+            {!isMobile && <LeftRail active={activePanel} onSelect={setActivePanel} />}
+            {!isMobile && (
+              <div
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  width: 240,
+                  flexShrink: 0,
+                  borderRight: '1px solid var(--elah-border)',
+                  background: 'var(--elah-bg-panel)',
+                  minHeight: 0,
+                  overflow: 'hidden',
+                }}
+              >
+                {/* Old SDK panel — kept commented for comparison, discard later. */}
+                {/* <SourcePanel style={{ flex: 1, minHeight: 0 }} /> */}
+                {activePanel === 'elements' ? (
+                  <ElementsPanel style={{ flex: 1, minHeight: 0 }} />
+                ) : (
+                  <MediaPanel mode={activePanel as PanelMode} style={{ flex: 1, minHeight: 0 }} />
+                )}
+              </div>
+            )}
 
             <div className="flex-1 min-w-0 min-h-0 flex flex-col bg-black">
-              <AspectControl />
-              <div className="flex-1 min-h-0 relative py-6">
+              {!isMobile && <AspectControl />}
+              <div
+                ref={previewBoxRef}
+                className={cn('flex-1 min-h-0 relative bg-black', isMobile ? 'py-2' : 'py-6')}
+              >
                 <Preview
                   demuxerFactory={demuxerFactoryRef.current}
                   style={{ width: '100%', height: '100%' }}
                 />
+                {isMobile && <PreviewFullscreenButton targetRef={previewBoxRef} />}
               </div>
               <TransportBar />
             </div>
 
-            <ClipProperties />
+            {!isMobile && <ClipProperties />}
           </div>
 
-          <TimelineControls timelineRef={timelineRef} />
+          <TimelineControls timelineRef={timelineRef} compact={isMobile} />
 
           <Timeline
             ref={timelineRef}
             fps={FPS}
-            style={{ height: 186, flexShrink: 0, minWidth: 0 }}
+            sidebarWidth={isMobile ? 48 : undefined}
+            compactSidebar={isMobile}
+            style={{ height: isMobile ? 158 : 186, flexShrink: 0, minWidth: 0 }}
           />
+
+          {isMobile && <MobileToolbar onOpenSheet={setMobileSheet} />}
         </div>
+
+        {isMobile && mobileSheet && (
+          <MobileSheet
+            title={
+              mobileSheet === 'properties'
+                ? 'Clip properties'
+                : (RAIL_ITEMS.find((r) => r.id === mobileSheet)?.label ?? 'Panel')
+            }
+            onClose={() => setMobileSheet(null)}
+          >
+            {mobileSheet === 'elements' ? (
+              <ElementsPanel activateOnTap style={{ flex: 1, minHeight: 0 }} />
+            ) : mobileSheet === 'properties' ? (
+              /* Child selector outranks the panel's fixed desktop width (PANEL
+                 w-[300px]) by specificity, so stylesheet order can't flip it. */
+              <div className="min-h-0 overflow-y-auto [&>div]:w-full [&>div]:border-l-0">
+                <ClipProperties />
+              </div>
+            ) : (
+              <MediaPanel mode={mobileSheet} style={{ flex: 1, minHeight: 0 }} />
+            )}
+          </MobileSheet>
+        )}
       </div>
     </EditorProvider>
   )
 }
+
+/** Mobile bottom bar — the Figma's tool row, repurposed as sourcing-panel and
+ * properties triggers (Filter/FX/etc. have no engine features behind them). */
+const MobileToolbar = memo(function MobileToolbar({
+  onOpenSheet,
+}: {
+  onOpenSheet: (kind: MobileSheetKind) => void
+}) {
+  const hasSelection = useSelectionStore((s) => s.selectedClipIds.size === 1)
+
+  const item =
+    'flex flex-col items-center gap-1 py-1 px-1 min-w-0 text-ed-text-muted cursor-pointer'
+  const iconBox =
+    'flex items-center justify-center w-9 h-9 rounded-xl bg-ed-elevated'
+
+  return (
+    <div className="flex items-center justify-around border-t border-ed-border bg-ed-bg-2 shrink-0 pt-1.5 pb-[max(env(safe-area-inset-bottom),6px)]">
+      {RAIL_ITEMS.map(({ id, label, Icon }) => (
+        <button key={id} type="button" className={item} onClick={() => onOpenSheet(id)}>
+          <span className={iconBox}>
+            <Icon size={17} />
+          </span>
+          <span className="text-[10px] leading-none">{label}</span>
+        </button>
+      ))}
+      <button
+        type="button"
+        className={cn(item, !hasSelection && 'opacity-40 cursor-not-allowed')}
+        disabled={!hasSelection}
+        onClick={() => onOpenSheet('properties')}
+        title={hasSelection ? 'Clip properties' : 'Select a clip first'}
+      >
+        <span className={iconBox}>
+          <SlidersHorizontal size={17} />
+        </span>
+        <span className="text-[10px] leading-none">Edit</span>
+      </button>
+    </div>
+  )
+})

--- a/apps/web/components/playground/shared/TimelineControls.tsx
+++ b/apps/web/components/playground/shared/TimelineControls.tsx
@@ -37,8 +37,15 @@ const sliderToZoom = (s: number) =>
 
 export const TimelineControls = memo(function TimelineControls({
   timelineRef,
+  compact = false,
 }: {
   timelineRef: React.RefObject<TimelineRef | null>
+  /**
+   * Touch-friendly variant: icon-only buttons and zoom +/- as the primary zoom
+   * control (the range slider's 12px thumb is untouchable on mobile). Default
+   * renders exactly as before — the Timeline playground passes nothing.
+   */
+  compact?: boolean
 }) {
   const engine = useTimelineEngine()
   const zoom = usePlaybackStore((s) => s.zoom)
@@ -81,16 +88,26 @@ export const TimelineControls = memo(function TimelineControls({
     engine.addTrack('audio', { name: `Audio ${n}` })
   }, [engine])
 
-  // Ghost toolbar buttons (flat icons, matching the Figma).
-  const ghostBtn =
-    'inline-flex items-center gap-1.5 px-2 py-1 rounded text-xs text-ed-text-muted hover:text-ed-text hover:bg-ed-elevated transition-colors cursor-pointer'
-  const ghostIcon =
-    'inline-flex items-center justify-center w-7 h-7 rounded text-ed-text-muted hover:text-ed-text hover:bg-ed-elevated transition-colors cursor-pointer'
+  // Ghost toolbar buttons (flat icons, matching the Figma). Compact swaps the
+  // 28px targets for 36px ones — the minimum comfortable touch size here.
+  const ghostBtn = cn(
+    'inline-flex items-center gap-1.5 px-2 py-1 rounded text-xs text-ed-text-muted hover:text-ed-text hover:bg-ed-elevated transition-colors cursor-pointer',
+    compact && 'h-9 px-2.5',
+  )
+  const ghostIcon = cn(
+    'inline-flex items-center justify-center rounded text-ed-text-muted hover:text-ed-text hover:bg-ed-elevated transition-colors cursor-pointer',
+    compact ? 'w-9 h-9' : 'w-7 h-7',
+  )
   const disabledMod =
     'opacity-40 cursor-not-allowed hover:bg-transparent hover:text-ed-text-muted'
 
   return (
-    <div className="flex items-center justify-between h-10 px-4 bg-ed-bg-2 border-t border-ed-border shrink-0">
+    <div
+      className={cn(
+        'flex items-center justify-between px-4 bg-ed-bg-2 border-t border-ed-border shrink-0',
+        compact ? 'h-12 px-2' : 'h-10',
+      )}
+    >
       {/* Left — track + clip tools */}
       <div className="flex items-center gap-0.5">
         <div className="relative">
@@ -100,7 +117,7 @@ export const TimelineControls = memo(function TimelineControls({
             onClick={() => setAddOpen((o) => !o)}
             title="Add a track"
           >
-            <Plus size={14} /> Add Track <ChevronDown size={12} />
+            <Plus size={14} /> {!compact && 'Add Track'} <ChevronDown size={12} />
           </button>
           {addOpen && (
             <>
@@ -132,7 +149,7 @@ export const TimelineControls = memo(function TimelineControls({
           onClick={splitAtPlayhead}
           title="Split at playhead (S)"
         >
-          <Scissors size={14} /> Split
+          <Scissors size={14} /> {!compact && 'Split'}
         </button>
         <button
           type="button"
@@ -164,15 +181,17 @@ export const TimelineControls = memo(function TimelineControls({
         >
           <Minus size={14} />
         </button>
-        <input
-          type="range"
-          className="elah-range w-24"
-          min={0}
-          max={1}
-          step={0.001}
-          value={zoomToSlider(zoom)}
-          onChange={(e) => setZoom(sliderToZoom(Number(e.target.value)))}
-        />
+        {!compact && (
+          <input
+            type="range"
+            className="elah-range w-24"
+            min={0}
+            max={1}
+            step={0.001}
+            value={zoomToSlider(zoom)}
+            onChange={(e) => setZoom(sliderToZoom(Number(e.target.value)))}
+          />
+        )}
         <button
           type="button"
           className={ghostIcon}
@@ -187,7 +206,7 @@ export const TimelineControls = memo(function TimelineControls({
           onClick={() => timelineRef.current?.fitToWindow()}
           title="Zoom to fit timeline"
         >
-          <Maximize2 size={13} /> Fit
+          <Maximize2 size={13} /> {!compact && 'Fit'}
         </button>
       </div>
     </div>

--- a/apps/web/styles/playground.css
+++ b/apps/web/styles/playground.css
@@ -188,10 +188,13 @@
   position: relative;
 }
 
-/* Touch layout: gesture surfaces own their pans — never rubber-band the shell. */
+/* Touch layout: gesture surfaces own their pans — never rubber-band the shell,
+   and two-finger pinch belongs to the editor (timeline zoom), not page zoom.
+   touch-action intersects down the chain, so one rule here covers the shell. */
 @media (max-width: 767px) {
   .pg-shell {
     overscroll-behavior: none;
+    touch-action: pan-x pan-y;
   }
 }
 

--- a/apps/web/styles/playground.css
+++ b/apps/web/styles/playground.css
@@ -185,6 +185,13 @@
   position: relative;
 }
 
+/* Touch layout: gesture surfaces own their pans — never rubber-band the shell. */
+@media (max-width: 767px) {
+  .pg-shell {
+    overscroll-behavior: none;
+  }
+}
+
 /* ── Editor chrome ───────────────────────────────────────────────────────── */
 /* Token definitions live in globals.css .elah-root; only presentational     */
 /* and scrollbar rules belong here.                                           */

--- a/apps/web/styles/playground.css
+++ b/apps/web/styles/playground.css
@@ -35,6 +35,9 @@
   display: flex;
   flex-direction: column;
   height: 100vh;
+  /* Mobile Chrome: 100vh is the large viewport (URL bar retracted), which
+     pushes the bottom bar behind the toolbar. dvh tracks the visible height. */
+  height: 100dvh;
   overflow: hidden;
   background: var(--pg-bg);
   color: var(--pg-text);

--- a/packages/editor/src/editor/AssetPanel/AssetPanel.tsx
+++ b/packages/editor/src/editor/AssetPanel/AssetPanel.tsx
@@ -20,10 +20,17 @@ import {
   type DragMediaPayload,
 } from '@elah/core'
 import { cn } from '@elah/timeline'
+import {
+  isActivationKey,
+  useAssetActivation,
+  type AssetActivationHandler,
+} from '../activation'
 
 export interface AssetPanelProps {
   style?: CSSProperties
   className?: string
+  activateOnTap?: boolean
+  onAssetActivate?: AssetActivationHandler
 }
 
 const KIND_ICONS: Record<MediaKind, string> = {
@@ -85,7 +92,15 @@ function buildImportToast(skipped: SkippedImport[]): ImportToast | null {
   }
 }
 
-function AssetThumbnail({ asset, onDelete }: { asset: MediaAsset; onDelete: (id: string) => void }) {
+function AssetThumbnail({
+  asset,
+  onDelete,
+  onActivate,
+}: {
+  asset: MediaAsset
+  onDelete: (id: string) => void
+  onActivate?: (asset: MediaAsset) => void
+}) {
   const [ctxMenu, setCtxMenu] = useState<{ x: number; y: number } | null>(null)
 
   const onDragStart = useCallback(
@@ -109,6 +124,15 @@ function AssetThumbnail({ asset, onDelete }: { asset: MediaAsset; onDelete: (id:
     onDelete(asset.id)
     setCtxMenu(null)
   }, [asset.id, onDelete])
+  const handleActivate = useCallback(() => onActivate?.(asset), [asset, onActivate])
+  const handleActivateKey = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (!onActivate || !isActivationKey(e.key)) return
+      e.preventDefault()
+      onActivate(asset)
+    },
+    [asset, onActivate],
+  )
 
   const tag = KIND_TOKEN[asset.kind]
 
@@ -116,8 +140,12 @@ function AssetThumbnail({ asset, onDelete }: { asset: MediaAsset; onDelete: (id:
     <>
       <div
         draggable
+        role={onActivate ? 'button' : undefined}
+        tabIndex={onActivate ? 0 : undefined}
         className="elah-media-card flex items-center gap-[10px] px-[10px] py-2 rounded-md cursor-grab select-none bg-ed-card border border-ed-border transition-[background,border-color] duration-[150ms]"
         onDragStart={onDragStart}
+        onClick={onActivate ? handleActivate : undefined}
+        onKeyDown={onActivate ? handleActivateKey : undefined}
         onContextMenu={handleContextMenu}
         title={asset.name}
       >
@@ -206,7 +234,12 @@ function AssetThumbnail({ asset, onDelete }: { asset: MediaAsset; onDelete: (id:
  *
  * Must be rendered inside `<EditorProvider>`.
  */
-export function AssetPanel({ style, className }: AssetPanelProps) {
+export function AssetPanel({
+  style,
+  className,
+  activateOnTap,
+  onAssetActivate,
+}: AssetPanelProps) {
   const { assets } = useMediaLibrary()
   const removeAsset = useMediaLibraryStore((s) => s.removeAsset)
   const fileInputRef = useRef<HTMLInputElement>(null)
@@ -215,10 +248,22 @@ export function AssetPanel({ style, className }: AssetPanelProps) {
   const [toast, setToast] = useState<ImportToast | null>(null)
   const [urlInputOpen, setUrlInputOpen] = useState(false)
   const [urlValue, setUrlValue] = useState('')
+  const activationEnabled = activateOnTap === true || Boolean(onAssetActivate)
+  const activateAsset = useAssetActivation({
+    activateOnTap,
+    onAssetActivate,
+    setToast,
+  })
 
   const handleDeleteAsset = useCallback((id: string) => {
     removeAsset(id)
   }, [removeAsset])
+  const handleAssetActivate = useCallback(
+    (asset: MediaAsset) => {
+      void activateAsset({ kind: 'media-asset', asset })
+    },
+    [activateAsset],
+  )
 
   useEffect(() => {
     if (!toast) return
@@ -445,7 +490,12 @@ export function AssetPanel({ style, className }: AssetPanelProps) {
         ) : (
           <div className="flex flex-col gap-[6px]">
             {assets.map((asset) => (
-              <AssetThumbnail key={asset.id} asset={asset} onDelete={handleDeleteAsset} />
+              <AssetThumbnail
+                key={asset.id}
+                asset={asset}
+                onDelete={handleDeleteAsset}
+                onActivate={activationEnabled ? handleAssetActivate : undefined}
+              />
             ))}
           </div>
         )}

--- a/packages/editor/src/editor/ElementsPanel/ElementsPanel.tsx
+++ b/packages/editor/src/editor/ElementsPanel/ElementsPanel.tsx
@@ -1,9 +1,17 @@
-import { useCallback, type CSSProperties, type DragEvent } from 'react'
+import { useCallback, useEffect, useState, type CSSProperties, type DragEvent } from 'react'
 import { ELEMENT_DRAG_MIME, cn, type DragElementPayload, type ElementKind, type ShapeVariant } from '@elah/timeline'
+import {
+  isActivationKey,
+  useAssetActivation,
+  type ActivationToast,
+  type AssetActivationHandler,
+} from '../activation'
 
 export interface ElementsPanelProps {
   style?: CSSProperties
   className?: string
+  activateOnTap?: boolean
+  onAssetActivate?: AssetActivationHandler
 }
 
 interface PaletteTile {
@@ -88,7 +96,28 @@ const TILES: PaletteTile[] = [
   },
 ]
 
-export function ElementsPanel({ style, className }: ElementsPanelProps) {
+const TOAST_DISMISS_MS = 3000
+
+export function ElementsPanel({
+  style,
+  className,
+  activateOnTap,
+  onAssetActivate,
+}: ElementsPanelProps) {
+  const [toast, setToast] = useState<ActivationToast | null>(null)
+  const activationEnabled = activateOnTap === true || Boolean(onAssetActivate)
+  const activateAsset = useAssetActivation({
+    activateOnTap,
+    onAssetActivate,
+    setToast,
+  })
+
+  useEffect(() => {
+    if (!toast) return
+    const timer = globalThis.setTimeout(() => setToast(null), TOAST_DISMISS_MS)
+    return () => globalThis.clearTimeout(timer)
+  }, [toast])
+
   const makeDragStart = useCallback(
     (element: ElementKind, shapeVariant?: ShapeVariant) => (e: DragEvent<HTMLDivElement>) => {
       const payload: DragElementPayload = { kind: 'element', element, shapeVariant }
@@ -96,6 +125,12 @@ export function ElementsPanel({ style, className }: ElementsPanelProps) {
       e.dataTransfer.effectAllowed = 'copy'
     },
     [],
+  )
+  const handleElementActivate = useCallback(
+    (element: ElementKind, shapeVariant: ShapeVariant | undefined, label: string) => {
+      void activateAsset({ kind: 'element', element, shapeVariant, label })
+    },
+    [activateAsset],
   )
 
   return (
@@ -109,14 +144,40 @@ export function ElementsPanel({ style, className }: ElementsPanelProps) {
         </span>
       </div>
 
+      {toast && (
+        <div
+          role="status"
+          className="mx-[10px] mt-[10px] rounded-sm px-[10px] py-2 text-[10px] font-mono leading-[1.4]"
+          style={{
+            color: toast.tone === 'warn' ? 'var(--elah-danger-text, #f5d0a9)' : 'var(--elah-info-text, #c8d8f0)',
+            background: toast.tone === 'warn' ? 'var(--elah-danger-bg, #3a2418)' : 'var(--elah-info-bg, #1a2433)',
+            border: `1px solid ${toast.tone === 'warn' ? 'var(--elah-danger-border, #7a4a2a)' : 'var(--elah-info-border, #355070)'}`,
+          }}
+        >
+          {toast.message}
+        </div>
+      )}
+
       {/* 2-column palette grid — grouping-ready, matches Media grid rhythm */}
       <div className="p-[10px] grid grid-cols-2 gap-[6px]">
         {TILES.map(({ element, shapeVariant, label, icon, iconStyle }) => (
           <div
             key={shapeVariant ? `${element}-${shapeVariant}` : element}
             draggable
+            role={activationEnabled ? 'button' : undefined}
+            tabIndex={activationEnabled ? 0 : undefined}
             className="elah-element-card flex flex-col items-center justify-center gap-[6px] px-2 py-3 rounded-md cursor-grab select-none bg-ed-card border border-ed-border transition-[background,border-color] duration-[150ms] min-h-[72px]"
             onDragStart={makeDragStart(element, shapeVariant)}
+            onClick={activationEnabled ? () => handleElementActivate(element, shapeVariant, label) : undefined}
+            onKeyDown={
+              activationEnabled
+                ? (e) => {
+                    if (!isActivationKey(e.key)) return
+                    e.preventDefault()
+                    handleElementActivate(element, shapeVariant, label)
+                  }
+                : undefined
+            }
             title={`Drag ${label} onto the elements track`}
           >
             <span

--- a/packages/editor/src/editor/SourcePanel/SourcePanel.tsx
+++ b/packages/editor/src/editor/SourcePanel/SourcePanel.tsx
@@ -20,6 +20,11 @@ import {
   type DragMediaPayload,
 } from '@elah/core'
 import { ELEMENT_DRAG_MIME, cn, type DragElementPayload, type ElementKind, type ShapeVariant } from '@elah/timeline'
+import {
+  isActivationKey,
+  useAssetActivation,
+  type AssetActivationHandler,
+} from '../activation'
 
 /**
  * Per-slot className overrides for SourcePanel.
@@ -80,6 +85,8 @@ export interface SourcePanelProps {
   className?: string
   defaultLane?: Lane
   classNames?: SourcePanelClassNames
+  activateOnTap?: boolean
+  onAssetActivate?: AssetActivationHandler
 }
 
 type Lane = 'media' | 'elements'
@@ -264,11 +271,13 @@ function ClipCard({
   asset,
   viewMode,
   onDelete,
+  onActivate,
   slots,
 }: {
   asset: MediaAsset
   viewMode: ViewMode
   onDelete: (id: string) => void
+  onActivate?: (asset: MediaAsset) => void
   slots?: ClipCardSlots
 }) {
   const [ctxMenu, setCtxMenu] = useState<{ x: number; y: number } | null>(null)
@@ -293,17 +302,30 @@ function ClipCard({
 
   const closeCtx = useCallback(() => setCtxMenu(null), [])
   const handleDelete = useCallback(() => { onDelete(asset.id); setCtxMenu(null) }, [asset.id, onDelete])
+  const handleActivate = useCallback(() => onActivate?.(asset), [asset, onActivate])
+  const handleActivateKey = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (!onActivate || !isActivationKey(e.key)) return
+      e.preventDefault()
+      onActivate(asset)
+    },
+    [asset, onActivate],
+  )
 
   if (viewMode === 'list') {
     return (
       <>
         <div
           draggable
+          role={onActivate ? 'button' : undefined}
+          tabIndex={onActivate ? 0 : undefined}
           className={cn(
             'elah-media-card flex items-center gap-2 px-[10px] py-[6px] rounded-sm cursor-grab select-none bg-ed-card border border-ed-border transition-[background,border-color] duration-[120ms]',
             slots?.card,
           )}
           onDragStart={onDragStart}
+          onClick={onActivate ? handleActivate : undefined}
+          onKeyDown={onActivate ? handleActivateKey : undefined}
           onContextMenu={(e) => { e.preventDefault(); setCtxMenu({ x: e.clientX, y: e.clientY }) }}
           title={asset.name}
         >
@@ -338,11 +360,15 @@ function ClipCard({
     <>
       <div
         draggable
+        role={onActivate ? 'button' : undefined}
+        tabIndex={onActivate ? 0 : undefined}
         className={cn(
           'elah-media-card flex items-center gap-[10px] px-[10px] py-2 rounded-md cursor-grab select-none bg-ed-card border border-ed-border transition-[background,border-color] duration-[150ms]',
           slots?.card,
         )}
         onDragStart={onDragStart}
+        onClick={onActivate ? handleActivate : undefined}
+        onKeyDown={onActivate ? handleActivateKey : undefined}
         onContextMenu={(e) => { e.preventDefault(); setCtxMenu({ x: e.clientX, y: e.clientY }) }}
         title={asset.name}
       >
@@ -445,7 +471,14 @@ function CtxMenu({
  *
  * Must be rendered inside `<EditorProvider>`.
  */
-export function SourcePanel({ style, className, defaultLane = 'media', classNames }: SourcePanelProps) {
+export function SourcePanel({
+  style,
+  className,
+  defaultLane = 'media',
+  classNames,
+  activateOnTap,
+  onAssetActivate,
+}: SourcePanelProps) {
   // ── Lane state
   const [lane, setLane] = useState<Lane>(defaultLane)
 
@@ -466,6 +499,12 @@ export function SourcePanel({ style, className, defaultLane = 'media', className
   const [toast, setToast] = useState<ImportToast | null>(null)
   const [urlInputOpen, setUrlInputOpen] = useState(false)
   const [urlValue, setUrlValue] = useState('')
+  const activationEnabled = activateOnTap === true || Boolean(onAssetActivate)
+  const activateAsset = useAssetActivation({
+    activateOnTap,
+    onAssetActivate,
+    setToast,
+  })
 
   // ── Toast auto-dismiss
   useEffect(() => {
@@ -475,6 +514,18 @@ export function SourcePanel({ style, className, defaultLane = 'media', className
   }, [toast])
 
   const handleDeleteAsset = useCallback((id: string) => removeAsset(id), [removeAsset])
+  const handleAssetActivate = useCallback(
+    (asset: MediaAsset) => {
+      void activateAsset({ kind: 'media-asset', asset })
+    },
+    [activateAsset],
+  )
+  const handleElementActivate = useCallback(
+    (element: ElementKind, shapeVariant: ShapeVariant | undefined, label: string) => {
+      void activateAsset({ kind: 'element', element, shapeVariant, label })
+    },
+    [activateAsset],
+  )
 
   const handleFiles = useCallback(async (files: FileList | File[]) => {
     const list = Array.from(files)
@@ -787,6 +838,7 @@ export function SourcePanel({ style, className, defaultLane = 'media', className
                     asset={asset}
                     viewMode={viewMode}
                     onDelete={handleDeleteAsset}
+                    onActivate={activationEnabled ? handleAssetActivate : undefined}
                     slots={cardSlots}
                   />
                 ))}
@@ -826,11 +878,23 @@ export function SourcePanel({ style, className, defaultLane = 'media', className
               <div
                 key={shapeVariant ? `${element}-${shapeVariant}` : element}
                 draggable
+                role={activationEnabled ? 'button' : undefined}
+                tabIndex={activationEnabled ? 0 : undefined}
                 className={cn(
                   'elah-element-card flex flex-col items-center justify-center gap-[6px] px-2 py-3 rounded-md cursor-grab select-none bg-ed-card border border-ed-border transition-[background,border-color] duration-[150ms] min-h-[72px]',
                   classNames?.tile,
                 )}
                 onDragStart={makeDragStart(element, shapeVariant)}
+                onClick={activationEnabled ? () => handleElementActivate(element, shapeVariant, label) : undefined}
+                onKeyDown={
+                  activationEnabled
+                    ? (e) => {
+                        if (!isActivationKey(e.key)) return
+                        e.preventDefault()
+                        handleElementActivate(element, shapeVariant, label)
+                      }
+                    : undefined
+                }
                 title={`Drag ${label} onto the elements track`}
               >
                 <span

--- a/packages/editor/src/editor/activation.ts
+++ b/packages/editor/src/editor/activation.ts
@@ -1,0 +1,114 @@
+import { useCallback, useContext } from 'react'
+import { EditorContext, type MediaAsset } from '@elah/core'
+import {
+  insertElement,
+  insertMediaAsset,
+  type DragElementPayload,
+  type ElementKind,
+  type InsertAssetResult,
+  type ShapeVariant,
+} from '@elah/timeline'
+
+export interface ActivationToast {
+  message: string
+  tone: 'info' | 'warn'
+}
+
+export interface MediaActivationPayload {
+  kind: 'media-asset'
+  asset: MediaAsset
+}
+
+export interface ElementActivationPayload {
+  kind: 'element'
+  element: ElementKind
+  shapeVariant?: ShapeVariant
+  label: string
+}
+
+export type AssetActivationPayload = MediaActivationPayload | ElementActivationPayload
+export type AssetActivationHandler = (payload: AssetActivationPayload) => void | Promise<void>
+
+interface UseAssetActivationOptions {
+  activateOnTap?: boolean
+  onAssetActivate?: AssetActivationHandler
+  setToast: (toast: ActivationToast) => void
+}
+
+export function isActivationKey(key: string): boolean {
+  return key === 'Enter' || key === ' '
+}
+
+/**
+ * Tap activation is opt-in for SDK consumers, so the engine context is read
+ * directly instead of via useTimelineEngine, which would throw when disabled.
+ */
+export function useAssetActivation({
+  activateOnTap,
+  onAssetActivate,
+  setToast,
+}: UseAssetActivationOptions) {
+  const editor = useContext(EditorContext)
+  const isActive = activateOnTap === true || Boolean(onAssetActivate)
+
+  return useCallback(
+    async (payload: AssetActivationPayload) => {
+      if (!isActive) return
+
+      if (onAssetActivate) {
+        await onAssetActivate(payload)
+        return
+      }
+
+      const engine = editor?.engine
+      if (!engine) {
+        setToast({ message: 'Timeline unavailable', tone: 'warn' })
+        return
+      }
+
+      const result =
+        payload.kind === 'media-asset'
+          ? await insertMediaAsset(engine, payload.asset.id)
+          : insertElement(engine, elementPayload(payload))
+
+      showActivationToast(payload, result, setToast)
+    },
+    [editor, isActive, onAssetActivate, setToast],
+  )
+}
+
+function elementPayload(payload: ElementActivationPayload): DragElementPayload {
+  return {
+    kind: 'element',
+    element: payload.element,
+    shapeVariant: payload.shapeVariant,
+  }
+}
+
+function showActivationToast(
+  payload: AssetActivationPayload,
+  result: InsertAssetResult,
+  setToast: (toast: ActivationToast) => void,
+) {
+  if (result.ok) {
+    setToast({ message: `Added ${payloadName(payload)}`, tone: 'info' })
+    return
+  }
+
+  if (result.reason === 'cancelled') return
+
+  if (result.reason === 'missing-asset') {
+    setToast({ message: 'Asset unavailable', tone: 'warn' })
+    return
+  }
+
+  setToast({ message: `No unlocked track for ${payloadKind(payload)}`, tone: 'warn' })
+}
+
+function payloadName(payload: AssetActivationPayload): string {
+  return payload.kind === 'media-asset' ? payload.asset.name : payload.label
+}
+
+function payloadKind(payload: AssetActivationPayload): string {
+  return payload.kind === 'media-asset' ? payload.asset.kind : 'element'
+}

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -89,8 +89,17 @@ export { useTracks } from '@elah/timeline'
 export { usePlayback } from '@elah/timeline'
 export { useSelection } from '@elah/timeline'
 export { useTimelineDrop } from '@elah/timeline'
+export { insertMediaAsset, insertElement } from '@elah/timeline'
 export { ELEMENT_DRAG_MIME } from '@elah/timeline'
-export type { DragElementPayload, ElementKind } from '@elah/timeline'
+export type {
+  DragElementPayload,
+  ElementKind,
+  ShapeVariant,
+  InsertAssetOptions,
+  InsertAssetResult,
+  InsertAssetFailureReason,
+  InsertedKind,
+} from '@elah/timeline'
 
 // --- Editor composition layer ---
 export { EditorProvider } from './editor/EditorProvider'
@@ -108,6 +117,7 @@ export type { ElementsPanelProps } from './editor/ElementsPanel'
 
 export { SourcePanel } from './editor/SourcePanel'
 export type { SourcePanelProps, SourcePanelClassNames } from './editor/SourcePanel'
+export type { AssetActivationPayload, AssetActivationHandler } from './editor/activation'
 
 export { Preview } from './editor/Preview'
 export type { PreviewProps, PreviewHandle } from './editor/Preview'

--- a/packages/timeline/src/ClipBlock.tsx
+++ b/packages/timeline/src/ClipBlock.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useRef, useState } from 'react'
+import { memo, useCallback, useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { Type, Square, Circle, Triangle, Pencil } from 'lucide-react'
 import type { Clip } from '@elah/core'
@@ -23,6 +23,7 @@ const WAVE_BARS = [
 ]
 
 const TRIM_HANDLE_WIDTH = 8
+const TOUCH_DRAG_THRESHOLD_PX = 6
 
 // Flat solid clip bodies — the design uses no gradient. Audio takes its darkest
 // token so the tinted waveform reads on top; the rest use their mid tone. Static
@@ -96,6 +97,7 @@ export const ClipBlock = memo(function ClipBlock({
 
   const blockRef = useRef<HTMLDivElement>(null)
   const isDragging = useRef(false)
+  const activeGestureCleanup = useRef<(() => void) | null>(null)
   const [ctxMenu, setCtxMenu] = useState<{ x: number; y: number } | null>(null)
 
   const left = clip.startFrame * zoom
@@ -140,26 +142,43 @@ export const ClipBlock = memo(function ClipBlock({
     waveBars = sampled
   }
 
-  const handleBodyMouseDown = useCallback(
-    (e: React.MouseEvent) => {
+  const clearActiveGesture = useCallback(() => {
+    activeGestureCleanup.current?.()
+    activeGestureCleanup.current = null
+  }, [])
+
+  useEffect(() => clearActiveGesture, [clearActiveGesture])
+
+  const handleBodyPointerDown = useCallback(
+    (e: React.PointerEvent) => {
       if (e.button !== 0) return
       e.stopPropagation()
       selectClip(clip.id)
+      clearActiveGesture()
       if (trackLocked) return // selectable, but not draggable
 
       const startX = e.clientX
+      const isTouchDrag = e.pointerType === 'touch'
       const originalStart = clip.startFrame
       let currentStart = originalStart
       isDragging.current = false
 
       const allClips = useTracksStore.getState().clips
 
-      const handleMove = (moveEvent: MouseEvent) => {
+      const handleMove = (moveEvent: PointerEvent) => {
+        const deltaX = moveEvent.clientX - startX
+        if (
+          isTouchDrag &&
+          !isDragging.current &&
+          Math.abs(deltaX) <= TOUCH_DRAG_THRESHOLD_PX
+        ) {
+          return
+        }
+
         isDragging.current = true
         if (blockRef.current) {
           blockRef.current.style.zIndex = '30'
         }
-        const deltaX = moveEvent.clientX - startX
         const deltaFrames = Math.round(deltaX / zoom)
         let nextStart = Math.max(0, originalStart + deltaFrames)
 
@@ -175,11 +194,17 @@ export const ClipBlock = memo(function ClipBlock({
         }
       }
 
-      const handleUp = () => {
-        window.removeEventListener('mousemove', handleMove)
-        window.removeEventListener('mouseup', handleUp)
+      const removeWindowListeners = () => {
+        window.removeEventListener('pointermove', handleMove)
+        window.removeEventListener('pointerup', handleUp)
+        window.removeEventListener('pointercancel', handleCancel)
+      }
 
-        if (isDragging.current && currentStart !== originalStart) {
+      const finish = (shouldCommit: boolean) => {
+        removeWindowListeners()
+        activeGestureCleanup.current = null
+
+        if (shouldCommit && isDragging.current && currentStart !== originalStart) {
           const trackClips =
             useTracksStore.getState().clips[clip.trackId] ?? []
           const settledStart = resolveOverlapEdgeSnap(
@@ -198,16 +223,23 @@ export const ClipBlock = memo(function ClipBlock({
         isDragging.current = false
       }
 
-      window.addEventListener('mousemove', handleMove)
-      window.addEventListener('mouseup', handleUp)
+      const handleUp = () => finish(true)
+      const handleCancel = () => finish(false)
+
+      activeGestureCleanup.current = handleCancel
+      window.addEventListener('pointermove', handleMove)
+      window.addEventListener('pointerup', handleUp)
+      window.addEventListener('pointercancel', handleCancel)
     },
-    [clip, zoom, engine, selectClip, left, snapEnabled, trackLocked],
+    [clip, zoom, engine, selectClip, clearActiveGesture, left, snapEnabled, trackLocked],
   )
 
-  const handleLeftTrimMouseDown = useCallback(
-    (e: React.MouseEvent) => {
+  const handleLeftTrimPointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      if (e.button !== 0) return
       e.stopPropagation()
       selectClip(clip.id)
+      clearActiveGesture()
       if (trackLocked) return
 
       const startX = e.clientX
@@ -229,7 +261,7 @@ export const ClipBlock = memo(function ClipBlock({
         return { newStart, newDuration }
       }
 
-      const handleMove = (moveEvent: MouseEvent) => {
+      const handleMove = (moveEvent: PointerEvent) => {
         const { newStart, newDuration } = calcLeftTrim(moveEvent.clientX)
         if (blockRef.current) {
           blockRef.current.style.left = `${newStart * zoom}px`
@@ -237,11 +269,29 @@ export const ClipBlock = memo(function ClipBlock({
         }
       }
 
-      const handleUp = (upEvent: MouseEvent) => {
-        window.removeEventListener('mousemove', handleMove)
-        window.removeEventListener('mouseup', handleUp)
+      const restoreOriginal = () => {
+        if (blockRef.current) {
+          blockRef.current.style.left = `${originalStart * zoom}px`
+          blockRef.current.style.width = `${Math.max(originalDuration * zoom, 4)}px`
+        }
+      }
 
-        const { newStart, newDuration } = calcLeftTrim(upEvent.clientX)
+      const removeWindowListeners = () => {
+        window.removeEventListener('pointermove', handleMove)
+        window.removeEventListener('pointerup', handleUp)
+        window.removeEventListener('pointercancel', handleCancel)
+      }
+
+      const finish = (clientX: number | null) => {
+        removeWindowListeners()
+        activeGestureCleanup.current = null
+
+        if (clientX === null) {
+          restoreOriginal()
+          return
+        }
+
+        const { newStart, newDuration } = calcLeftTrim(clientX)
 
         if (newStart !== originalStart || newDuration !== originalDuration) {
           engine.trimClip(clip.id, clip.trackId, newStart, newDuration)
@@ -256,16 +306,23 @@ export const ClipBlock = memo(function ClipBlock({
         }
       }
 
-      window.addEventListener('mousemove', handleMove)
-      window.addEventListener('mouseup', handleUp)
+      const handleUp = (upEvent: PointerEvent) => finish(upEvent.clientX)
+      const handleCancel = () => finish(null)
+
+      activeGestureCleanup.current = handleCancel
+      window.addEventListener('pointermove', handleMove)
+      window.addEventListener('pointerup', handleUp)
+      window.addEventListener('pointercancel', handleCancel)
     },
-    [clip, zoom, engine, selectClip, trackLocked],
+    [clip, zoom, engine, selectClip, clearActiveGesture, trackLocked],
   )
 
-  const handleRightTrimMouseDown = useCallback(
-    (e: React.MouseEvent) => {
+  const handleRightTrimPointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      if (e.button !== 0) return
       e.stopPropagation()
       selectClip(clip.id)
+      clearActiveGesture()
       if (trackLocked) return
 
       const startX = e.clientX
@@ -278,18 +335,35 @@ export const ClipBlock = memo(function ClipBlock({
         return Math.min(maxDuration, Math.max(minDuration, originalDuration + deltaFrames))
       }
 
-      const handleMove = (moveEvent: MouseEvent) => {
+      const handleMove = (moveEvent: PointerEvent) => {
         const newDuration = calcRightTrim(moveEvent.clientX)
         if (blockRef.current) {
           blockRef.current.style.width = `${newDuration * zoom}px`
         }
       }
 
-      const handleUp = (upEvent: MouseEvent) => {
-        window.removeEventListener('mousemove', handleMove)
-        window.removeEventListener('mouseup', handleUp)
+      const restoreOriginal = () => {
+        if (blockRef.current) {
+          blockRef.current.style.width = `${Math.max(originalDuration * zoom, 4)}px`
+        }
+      }
 
-        const newDuration = calcRightTrim(upEvent.clientX)
+      const removeWindowListeners = () => {
+        window.removeEventListener('pointermove', handleMove)
+        window.removeEventListener('pointerup', handleUp)
+        window.removeEventListener('pointercancel', handleCancel)
+      }
+
+      const finish = (clientX: number | null) => {
+        removeWindowListeners()
+        activeGestureCleanup.current = null
+
+        if (clientX === null) {
+          restoreOriginal()
+          return
+        }
+
+        const newDuration = calcRightTrim(clientX)
 
         if (newDuration !== originalDuration) {
           engine.trimClip(clip.id, clip.trackId, clip.startFrame, newDuration)
@@ -302,10 +376,15 @@ export const ClipBlock = memo(function ClipBlock({
         }
       }
 
-      window.addEventListener('mousemove', handleMove)
-      window.addEventListener('mouseup', handleUp)
+      const handleUp = (upEvent: PointerEvent) => finish(upEvent.clientX)
+      const handleCancel = () => finish(null)
+
+      activeGestureCleanup.current = handleCancel
+      window.addEventListener('pointermove', handleMove)
+      window.addEventListener('pointerup', handleUp)
+      window.addEventListener('pointercancel', handleCancel)
     },
-    [clip, zoom, engine, selectClip, trackLocked],
+    [clip, zoom, engine, selectClip, clearActiveGesture, trackLocked],
   )
 
   const handleContextMenu = useCallback(
@@ -329,7 +408,7 @@ export const ClipBlock = memo(function ClipBlock({
   return (
     <div
       ref={blockRef}
-      onMouseDown={handleBodyMouseDown}
+      onPointerDown={handleBodyPointerDown}
       onContextMenu={handleContextMenu}
       // Styling hooks (inert): let CSS retint per clip type / selection state —
       // e.g. audio waveform tint and the blue selected-audio body.
@@ -356,6 +435,7 @@ export const ClipBlock = memo(function ClipBlock({
           : `inset 0 1px 0 var(--elah-effect-inner-highlight), var(--elah-effect-clip-shadow)`,
         cursor: trackLocked ? 'default' : 'grab',
         overflow: 'hidden',
+        touchAction: 'none',
         userSelect: 'none',
         willChange: 'transform',
         zIndex: isSelected ? 5 : 1,
@@ -475,7 +555,8 @@ export const ClipBlock = memo(function ClipBlock({
 
       {/* Left trim handle */}
       <div
-        onMouseDown={handleLeftTrimMouseDown}
+        className="elah-trim-handle elah-trim-handle-left"
+        onPointerDown={handleLeftTrimPointerDown}
         style={{
           position: 'absolute',
           left: 0,
@@ -483,10 +564,24 @@ export const ClipBlock = memo(function ClipBlock({
           width: TRIM_HANDLE_WIDTH,
           height: '100%',
           cursor: trackLocked ? 'default' : 'ew-resize',
-          background: `linear-gradient(90deg, var(--elah-effect-trim-scrim) 0%, transparent 100%)`,
+          background: 'transparent',
+          touchAction: 'none',
           zIndex: 2,
         }}
-      />
+      >
+        <div
+          className="elah-trim-handle-visual"
+          style={{
+            position: 'absolute',
+            left: 0,
+            top: 0,
+            bottom: 0,
+            width: TRIM_HANDLE_WIDTH,
+            pointerEvents: 'none',
+            background: `linear-gradient(90deg, var(--elah-effect-trim-scrim) 0%, transparent 100%)`,
+          }}
+        />
+      </div>
 
       {/* Clip label — audio, text, shape, freehand show a name + glyph.
           Video/image clips show their thumbnail filmstrip instead. */}
@@ -538,7 +633,8 @@ export const ClipBlock = memo(function ClipBlock({
 
       {/* Right trim handle */}
       <div
-        onMouseDown={handleRightTrimMouseDown}
+        className="elah-trim-handle elah-trim-handle-right"
+        onPointerDown={handleRightTrimPointerDown}
         style={{
           position: 'absolute',
           right: 0,
@@ -546,10 +642,24 @@ export const ClipBlock = memo(function ClipBlock({
           width: TRIM_HANDLE_WIDTH,
           height: '100%',
           cursor: trackLocked ? 'default' : 'ew-resize',
-          background: `linear-gradient(270deg, var(--elah-effect-trim-scrim) 0%, transparent 100%)`,
+          background: 'transparent',
+          touchAction: 'none',
           zIndex: 2,
         }}
-      />
+      >
+        <div
+          className="elah-trim-handle-visual"
+          style={{
+            position: 'absolute',
+            right: 0,
+            top: 0,
+            bottom: 0,
+            width: TRIM_HANDLE_WIDTH,
+            pointerEvents: 'none',
+            background: `linear-gradient(270deg, var(--elah-effect-trim-scrim) 0%, transparent 100%)`,
+          }}
+        />
+      </div>
 
       {ctxMenu && createPortal(
         <>

--- a/packages/timeline/src/Playhead.tsx
+++ b/packages/timeline/src/Playhead.tsx
@@ -45,6 +45,7 @@ export function Playhead({
   className,
 }: PlayheadProps) {
   const needleRef = useRef<HTMLDivElement>(null)
+  const activeGestureCleanup = useRef<(() => void) | null>(null)
 
   // Always-fresh refs so every callback always reads the latest prop values
   // without creating new closures or re-registering subscriptions.
@@ -97,9 +98,18 @@ export function Playhead({
     return () => el.removeEventListener('scroll', handleScroll)
   }, [])
 
-  const handleMouseDown = useCallback(
-    (e: React.MouseEvent) => {
+  const clearActiveGesture = useCallback(() => {
+    activeGestureCleanup.current?.()
+    activeGestureCleanup.current = null
+  }, [])
+
+  useEffect(() => clearActiveGesture, [clearActiveGesture])
+
+  const handlePointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      if (e.button !== 0) return
       e.preventDefault()
+      clearActiveGesture()
       const store = usePlaybackStore.getState()
       const { setCurrentFrame } = store
 
@@ -108,7 +118,7 @@ export function Playhead({
       const wasPlaying = store.isPlaying
       if (wasPlaying) store.pause()
 
-      const handleMove = (moveEvent: MouseEvent) => {
+      const handleMove = (moveEvent: PointerEvent) => {
         const container = scrollContainerRef?.current
         const scrollLeft = container?.scrollLeft ?? 0
         const parent = needleRef.current?.parentElement
@@ -118,22 +128,33 @@ export function Playhead({
         setCurrentFrame(Math.max(0, Math.round(x / zoomRef.current)))
       }
 
-      const handleUp = () => {
-        window.removeEventListener('mousemove', handleMove)
-        window.removeEventListener('mouseup', handleUp)
+      const removeWindowListeners = () => {
+        window.removeEventListener('pointermove', handleMove)
+        window.removeEventListener('pointerup', handleUp)
+        window.removeEventListener('pointercancel', handleCancel)
+      }
+
+      const finish = () => {
+        removeWindowListeners()
+        activeGestureCleanup.current = null
         if (wasPlaying) usePlaybackStore.getState().play()
       }
 
-      window.addEventListener('mousemove', handleMove)
-      window.addEventListener('mouseup', handleUp)
+      const handleUp = () => finish()
+      const handleCancel = () => finish()
+
+      activeGestureCleanup.current = handleCancel
+      window.addEventListener('pointermove', handleMove)
+      window.addEventListener('pointerup', handleUp)
+      window.addEventListener('pointercancel', handleCancel)
     },
-    [scrollContainerRef],
+    [scrollContainerRef, clearActiveGesture],
   )
 
   return (
     <div
       ref={needleRef}
-      onMouseDown={handleMouseDown}
+      onPointerDown={handlePointerDown}
       className={cn('text-playhead', className)}
       style={{
         position: 'absolute',
@@ -148,24 +169,39 @@ export function Playhead({
         ...(color ? { color } : null),
         zIndex: 50,
         cursor: 'col-resize',
+        touchAction: 'none',
         willChange: 'left',
         pointerEvents: 'all',
       }}
     >
       <div
+        className="elah-playhead-head-hit"
         style={{
           position: 'absolute',
           top: -2,
           left: -7,
           width: 16,
           height: 14,
-          // Inherits the parent's currentColor, so it tracks the playhead color.
-          background: 'currentColor',
-          borderRadius: '3px 3px 0 0',
-          clipPath: 'polygon(50% 100%, 0 0, 100% 0)',
-          boxShadow: '0 0 8px currentColor',
+          touchAction: 'none',
         }}
-      />
+      >
+        <div
+          className="elah-playhead-head-visual"
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            width: 16,
+            height: 14,
+            // Inherits the parent's currentColor, so it tracks the playhead color.
+            background: 'currentColor',
+            borderRadius: '3px 3px 0 0',
+            clipPath: 'polygon(50% 100%, 0 0, 100% 0)',
+            boxShadow: '0 0 8px currentColor',
+            pointerEvents: 'none',
+          }}
+        />
+      </div>
     </div>
   )
 }

--- a/packages/timeline/src/Ruler.tsx
+++ b/packages/timeline/src/Ruler.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo } from 'react'
+import { memo, useCallback, useEffect, useMemo, useRef } from 'react'
 import { cn } from './cn'
 
 /**
@@ -70,12 +70,54 @@ export const Ruler = memo(function Ruler({
     return result
   }, [fps, totalFrames, zoom])
 
-  const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
-    if (!onSeek) return
-    const rect = e.currentTarget.getBoundingClientRect()
-    const x = e.clientX - rect.left
-    onSeek(Math.max(0, Math.round(x / zoom)))
-  }
+  const activeGestureCleanup = useRef<(() => void) | null>(null)
+
+  const clearActiveGesture = useCallback(() => {
+    activeGestureCleanup.current?.()
+    activeGestureCleanup.current = null
+  }, [])
+
+  useEffect(() => clearActiveGesture, [clearActiveGesture])
+
+  const handlePointerDown = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      if (e.button !== 0 || !onSeek) return
+      clearActiveGesture()
+
+      const rulerEl = e.currentTarget
+      const seekFromClientX = (clientX: number) => {
+        const rect = rulerEl.getBoundingClientRect()
+        const x = clientX - rect.left
+        onSeek(Math.max(0, Math.round(x / zoom)))
+      }
+
+      seekFromClientX(e.clientX)
+
+      const handleMove = (moveEvent: PointerEvent) => {
+        seekFromClientX(moveEvent.clientX)
+      }
+
+      const removeWindowListeners = () => {
+        window.removeEventListener('pointermove', handleMove)
+        window.removeEventListener('pointerup', handleUp)
+        window.removeEventListener('pointercancel', handleCancel)
+      }
+
+      const finish = () => {
+        removeWindowListeners()
+        activeGestureCleanup.current = null
+      }
+
+      const handleUp = () => finish()
+      const handleCancel = () => finish()
+
+      activeGestureCleanup.current = handleCancel
+      window.addEventListener('pointermove', handleMove)
+      window.addEventListener('pointerup', handleUp)
+      window.addEventListener('pointercancel', handleCancel)
+    },
+    [onSeek, zoom, clearActiveGesture],
+  )
 
   return (
     <div
@@ -87,9 +129,10 @@ export const Ruler = memo(function Ruler({
         height,
         flexShrink: 0,
         cursor: onSeek ? 'pointer' : 'default',
+        touchAction: 'none',
         userSelect: 'none',
       }}
-      onClick={handleClick}
+      onPointerDown={handlePointerDown}
     >
       {ticks.map(({ frame, label }) => (
         <div

--- a/packages/timeline/src/Timeline.tsx
+++ b/packages/timeline/src/Timeline.tsx
@@ -74,6 +74,17 @@ export interface TimelineProps {
   style?: React.CSSProperties
   /** Per-slot Tailwind class overrides for the timeline subtree. */
   classNames?: TimelineClassNames
+  /**
+   * Width of the track-label sidebar in px. Ruler offset, playhead origin, and
+   * fit-to-window math all derive from it, which is why it is a prop and not a
+   * class override. Defaults to the desktop width.
+   */
+  sidebarWidth?: number
+  /**
+   * Icon-only track labels for narrow sidebars (~48px). Track name and header
+   * controls are hidden; pair with a small `sidebarWidth`.
+   */
+  compactSidebar?: boolean
 }
 
 /**
@@ -95,7 +106,7 @@ export interface TimelineProps {
  */
 export const Timeline = memo(
   forwardRef<TimelineRef, TimelineProps>(function Timeline(
-    { fps = 30, className, style, classNames },
+    { fps = 30, className, style, classNames, sidebarWidth = SIDEBAR_WIDTH, compactSidebar = false },
     ref,
   ) {
     const { engine, playback } = useEditor()
@@ -109,12 +120,12 @@ export const Timeline = memo(
     const fitToWindow = useCallback(() => {
       const el = scrollRef.current
       if (!el) return
-      const available = el.clientWidth - SIDEBAR_WIDTH
+      const available = el.clientWidth - sidebarWidth
       if (available <= 0) return
       const totalFrames = useTracksStore.getState().totalFrames
       const frames = Math.max(totalFrames, fps * 10)
       usePlaybackStore.getState().setZoom(available / frames)
-    }, [fps])
+    }, [fps, sidebarWidth])
 
     useImperativeHandle(
       ref,
@@ -286,7 +297,7 @@ export const Timeline = memo(
           <div
             className="bg-ed-panel border-ed-border border-ed-border-subtle"
             style={{
-              width: SIDEBAR_WIDTH,
+              width: sidebarWidth,
               flexShrink: 0,
               height: rulerHeight,
               borderRightWidth: 1,
@@ -328,6 +339,8 @@ export const Timeline = memo(
               totalFrames={Math.max(totalFrames, fps * 10)}
               zoom={zoom}
               fps={fps}
+              sidebarWidth={sidebarWidth}
+              compact={compactSidebar}
               className={classNames?.track}
               labelClassName={classNames?.trackLabel}
               laneClassName={classNames?.lane}
@@ -362,7 +375,7 @@ export const Timeline = memo(
           zoom={zoom}
           height="100%"
           scrollContainerRef={scrollRef}
-          sidebarWidth={SIDEBAR_WIDTH}
+          sidebarWidth={sidebarWidth}
           className={classNames?.playhead}
         />
 

--- a/packages/timeline/src/Timeline.tsx
+++ b/packages/timeline/src/Timeline.tsx
@@ -163,6 +163,58 @@ export const Timeline = memo(
       return () => el.removeEventListener('wheel', handleWheel)
     }, [setZoom])
 
+    // Pinch → timeline zoom, anchored at the finger midpoint so the frame
+    // under the pinch stays put. preventDefault stops the browser from
+    // zooming the page instead; single-finger pan keeps native scrolling.
+    useEffect(() => {
+      const el = scrollRef.current
+      if (!el) return
+
+      let pinching = false
+      let startDist = 0
+      let startZoom = 1
+
+      const dist = (t: TouchList) =>
+        Math.hypot(t[0].clientX - t[1].clientX, t[0].clientY - t[1].clientY)
+
+      const handleTouchStart = (e: TouchEvent) => {
+        if (e.touches.length !== 2) return
+        pinching = true
+        startDist = dist(e.touches)
+        startZoom = usePlaybackStore.getState().zoom
+        e.preventDefault()
+      }
+
+      const handleTouchMove = (e: TouchEvent) => {
+        if (!pinching || e.touches.length !== 2 || startDist === 0) return
+        e.preventDefault()
+        const rect = el.getBoundingClientRect()
+        // Lane x of the pinch midpoint (content coords minus the sticky sidebar).
+        const midX =
+          (e.touches[0].clientX + e.touches[1].clientX) / 2 - rect.left - sidebarWidth
+        const prevZoom = usePlaybackStore.getState().zoom
+        const anchorFrame = (el.scrollLeft + midX) / prevZoom
+        usePlaybackStore.getState().setZoom((startZoom * dist(e.touches)) / startDist)
+        const nextZoom = usePlaybackStore.getState().zoom // store-clamped
+        el.scrollLeft = anchorFrame * nextZoom - midX
+      }
+
+      const handleTouchEnd = (e: TouchEvent) => {
+        if (e.touches.length < 2) pinching = false
+      }
+
+      el.addEventListener('touchstart', handleTouchStart, { passive: false })
+      el.addEventListener('touchmove', handleTouchMove, { passive: false })
+      el.addEventListener('touchend', handleTouchEnd)
+      el.addEventListener('touchcancel', handleTouchEnd)
+      return () => {
+        el.removeEventListener('touchstart', handleTouchStart)
+        el.removeEventListener('touchmove', handleTouchMove)
+        el.removeEventListener('touchend', handleTouchEnd)
+        el.removeEventListener('touchcancel', handleTouchEnd)
+      }
+    }, [sidebarWidth])
+
     // Keyboard shortcuts: Space = play/pause, Ctrl+Z/Y = undo/redo
     useEffect(() => {
       const handleKey = (e: KeyboardEvent) => {
@@ -330,6 +382,9 @@ export const Timeline = memo(
             overflow: 'auto',
             position: 'relative',
             minHeight: 0,
+            // pan only — two-finger pinch belongs to the zoom handler above,
+            // and must never trigger the browser's page zoom.
+            touchAction: 'pan-x pan-y',
           }}
         >
           {tracks.map((track) => (

--- a/packages/timeline/src/TrackRow.tsx
+++ b/packages/timeline/src/TrackRow.tsx
@@ -44,6 +44,10 @@ interface TrackRowProps {
   totalFrames: number
   zoom: number
   fps: number
+  /** Sidebar width in px — must match Timeline's ruler offset. */
+  sidebarWidth?: number
+  /** Icon-only label for narrow sidebars: name and header controls hidden. */
+  compact?: boolean
   /** Override class for the row container. */
   className?: string
   /** Override class for the track-label sidebar. */
@@ -72,6 +76,8 @@ export const TrackRow = memo(function TrackRow({
   totalFrames,
   zoom,
   fps,
+  sidebarWidth = SIDEBAR_WIDTH,
+  compact = false,
   className,
   labelClassName,
   laneClassName,
@@ -192,7 +198,7 @@ export const TrackRow = memo(function TrackRow({
           position: 'sticky',
           left: 0,
           zIndex: 6,
-          width: SIDEBAR_WIDTH,
+          width: sidebarWidth,
           flexShrink: 0,
           // The left bar paints from currentColor (set by kindAccentClass above).
           borderLeft: '3px solid currentColor',
@@ -202,32 +208,38 @@ export const TrackRow = memo(function TrackRow({
           borderBottomStyle: 'solid',
           display: 'flex',
           alignItems: 'center',
-          gap: 8,
-          paddingLeft: 10,
-          paddingRight: 6,
+          justifyContent: compact ? 'center' : undefined,
+          gap: compact ? 0 : 8,
+          paddingLeft: compact ? 0 : 10,
+          paddingRight: compact ? 0 : 6,
           cursor: 'pointer',
           userSelect: 'none',
         }}
+        title={compact ? track.name : undefined}
       >
         {/* Type glyph — paints from currentColor (the track accent). */}
-        <TypeIcon size={13} strokeWidth={2} style={{ flexShrink: 0 }} aria-hidden />
+        <TypeIcon size={compact ? 15 : 13} strokeWidth={2} style={{ flexShrink: 0 }} aria-hidden />
 
-        <span
-          style={{
-            flex: 1,
-            minWidth: 0,
-            fontSize: 13,
-            color: isActive ? `var(--elah-text)` : `var(--elah-text-muted)`,
-            fontWeight: isActive ? 600 : 500,
-            overflow: 'hidden',
-            whiteSpace: 'nowrap',
-            textOverflow: 'ellipsis',
-          }}
-        >
-          {track.name}
-        </span>
+        {!compact && (
+          <span
+            style={{
+              flex: 1,
+              minWidth: 0,
+              fontSize: 13,
+              color: isActive ? `var(--elah-text)` : `var(--elah-text-muted)`,
+              fontWeight: isActive ? 600 : 500,
+              overflow: 'hidden',
+              whiteSpace: 'nowrap',
+              textOverflow: 'ellipsis',
+            }}
+          >
+            {track.name}
+          </span>
+        )}
 
-        {/* Per-track controls — visibility, mute (audio only), lock. */}
+        {/* Per-track controls — visibility, mute (audio only), lock.
+            Hidden in compact mode: a ~48px sidebar fits only the kind glyph. */}
+        {!compact && (
         <span style={{ display: 'inline-flex', gap: 1, flexShrink: 0 }}>
           <button
             type="button"
@@ -297,6 +309,7 @@ export const TrackRow = memo(function TrackRow({
             </button>
           )}
         </span>
+        )}
       </div>
 
       {/* Clip area — bottom border is static */}

--- a/packages/timeline/src/TransitionChip.tsx
+++ b/packages/timeline/src/TransitionChip.tsx
@@ -111,6 +111,7 @@ export const TransitionChip = memo(function TransitionChip({ fromClip, toClip, z
       >
         {/* Diamond icon — always visible when transition exists, visible on hover otherwise */}
         <div
+          className="elah-transition-chip-affordance"
           style={{
             position: 'absolute',
             top: diamondTop,

--- a/packages/timeline/src/TransitionPicker.tsx
+++ b/packages/timeline/src/TransitionPicker.tsx
@@ -74,11 +74,11 @@ export function TransitionPicker({
   )
 
   useEffect(() => {
-    const handleClick = (e: MouseEvent) => {
+    const handlePointerDown = (e: PointerEvent) => {
       if (ref.current && !ref.current.contains(e.target as Node)) onClose()
     }
-    document.addEventListener('mousedown', handleClick)
-    return () => document.removeEventListener('mousedown', handleClick)
+    document.addEventListener('pointerdown', handlePointerDown)
+    return () => document.removeEventListener('pointerdown', handlePointerDown)
   }, [onClose])
 
   const half = Math.max(1, Math.floor(durationFrames / 2))

--- a/packages/timeline/src/index.ts
+++ b/packages/timeline/src/index.ts
@@ -17,6 +17,13 @@ export { useTracks } from './hooks/useTracks'
 export { usePlayback } from './hooks/usePlayback'
 export { useSelection } from './hooks/useSelection'
 export { useTimelineDrop } from './useTimelineDrop'
+export { insertMediaAsset, insertElement } from './insertAsset'
+export type {
+  InsertAssetOptions,
+  InsertAssetResult,
+  InsertAssetFailureReason,
+  InsertedKind,
+} from './insertAsset'
 
 // --- Element drag infrastructure (public API) ---
 export { ELEMENT_DRAG_MIME } from './elementDrag'

--- a/packages/timeline/src/insertAsset.test.ts
+++ b/packages/timeline/src/insertAsset.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  TimelineEngine,
+  useMediaLibraryStore,
+  usePlaybackStore,
+  type MediaAsset,
+} from '@elah/core'
+import { useAudioDropDialogStore } from './audioDropDialog.store'
+import { insertElement, insertMediaAsset } from './insertAsset'
+
+const originalAudioRequest = useAudioDropDialogStore.getState().request
+const originalAudioRespond = useAudioDropDialogStore.getState().respond
+
+afterEach(() => {
+  useMediaLibraryStore.setState({ assets: {}, order: [] })
+  usePlaybackStore.setState({ currentFrame: 0 })
+  useAudioDropDialogStore.setState({
+    open: false,
+    assetName: '',
+    resolve: null,
+    request: originalAudioRequest,
+    respond: originalAudioRespond,
+  })
+  vi.restoreAllMocks()
+})
+
+describe('insertMediaAsset', () => {
+  it('inserts media into the first compatible unlocked track at the playhead', async () => {
+    const engine = new TimelineEngine({ fps: 30 })
+    const videoTrack = engine.getProject().tracks[0]
+    addAsset({ id: 'asset-video', kind: 'video', durationSec: 2 })
+    usePlaybackStore.setState({ currentFrame: 12 })
+
+    const result = await insertMediaAsset(engine, 'asset-video')
+
+    expect(result).toMatchObject({ ok: true, kind: 'video', trackId: videoTrack.id })
+    expect(engine.getClipsOnTrack(videoTrack.id)).toMatchObject([
+      {
+        type: 'video',
+        assetId: 'asset-video',
+        startFrame: 12,
+        durationFrames: 60,
+      },
+    ])
+  })
+
+  it('skips locked compatible tracks', async () => {
+    const engine = new TimelineEngine({ fps: 30 })
+    const lockedAudio = engine.addTrack('audio', { name: 'Locked audio' })
+    engine.updateTrack(lockedAudio.id, { locked: true })
+    const unlockedAudio = engine.addTrack('audio', { name: 'Open audio' })
+    addAsset({ id: 'asset-audio', kind: 'audio', durationSec: 1 })
+    usePlaybackStore.setState({ currentFrame: 7 })
+
+    const result = await insertMediaAsset(engine, 'asset-audio')
+
+    expect(result).toMatchObject({ ok: true, kind: 'audio', trackId: unlockedAudio.id })
+    expect(engine.getClipsOnTrack(lockedAudio.id)).toHaveLength(0)
+    expect(engine.getClipsOnTrack(unlockedAudio.id)[0]).toMatchObject({
+      type: 'audio',
+      startFrame: 7,
+      durationFrames: 30,
+    })
+  })
+
+  it('creates an audio track when inserting audio with no audio lane', async () => {
+    const engine = new TimelineEngine({ fps: 30 })
+    addAsset({ id: 'asset-audio', kind: 'audio', durationSec: 1 })
+
+    const result = await insertMediaAsset(engine, 'asset-audio', { desiredStartFrame: 4 })
+
+    const audioTrack = engine.getProject().tracks.find((t) => t.kind === 'audio')
+    expect(audioTrack).toBeDefined()
+    expect(result).toMatchObject({ ok: true, kind: 'audio', trackId: audioTrack?.id })
+    expect(engine.getClipsOnTrack(audioTrack!.id)[0]).toMatchObject({
+      type: 'audio',
+      startFrame: 4,
+    })
+  })
+
+  it('returns a refusal when no compatible track can receive the asset', async () => {
+    const engine = new TimelineEngine({
+      fps: 30,
+      initialTracks: [{ kind: 'audio', name: 'Audio only' }],
+    })
+    addAsset({ id: 'asset-image', kind: 'image', durationSec: 0 })
+
+    const result = await insertMediaAsset(engine, 'asset-image')
+
+    expect(result).toEqual({ ok: false, kind: 'image', reason: 'no-track' })
+    expect(Object.values(engine.getProject().clips).flat()).toHaveLength(0)
+  })
+
+  it('resolves desiredStartFrame overlaps with the existing drop placement behavior', async () => {
+    const engine = new TimelineEngine({ fps: 30 })
+    const videoTrack = engine.getProject().tracks[0]
+    engine.addClip({
+      trackId: videoTrack.id,
+      type: 'video',
+      name: 'Existing',
+      src: 'existing.mp4',
+      startFrame: 10,
+      durationFrames: 20,
+    })
+    addAsset({ id: 'asset-image', kind: 'image', durationSec: 1 })
+
+    const result = await insertMediaAsset(engine, 'asset-image', { desiredStartFrame: 15 })
+
+    expect(result).toMatchObject({ ok: true, kind: 'image' })
+    expect(engine.getClipsOnTrack(videoTrack.id).map((clip) => ({
+      type: clip.type,
+      startFrame: clip.startFrame,
+      durationFrames: clip.durationFrames,
+    }))).toEqual([
+      { type: 'video', startFrame: 10, durationFrames: 20 },
+      { type: 'image', startFrame: 30, durationFrames: 30 },
+    ])
+  })
+
+  it('keeps video-with-audio insertion in one undo batch', async () => {
+    const engine = new TimelineEngine({ fps: 30 })
+    const videoTrack = engine.getProject().tracks[0]
+    addAsset({
+      id: 'asset-video-audio',
+      kind: 'video',
+      durationSec: 2,
+      hasAudio: true,
+    })
+    const request = vi.fn(async () => 'both' as const)
+    useAudioDropDialogStore.setState({ request })
+
+    const result = await insertMediaAsset(engine, 'asset-video-audio', { desiredStartFrame: 3 })
+
+    expect(request).toHaveBeenCalledWith('asset-video-audio.mov')
+    expect(result).toMatchObject({ ok: true, kind: 'video', trackId: videoTrack.id })
+    const audioTrack = engine.getProject().tracks.find((t) => t.kind === 'audio')
+    expect(audioTrack).toBeDefined()
+    expect(engine.getClipsOnTrack(videoTrack.id)[0]).toMatchObject({
+      type: 'video',
+      startFrame: 3,
+      durationFrames: 60,
+    })
+    expect(engine.getClipsOnTrack(audioTrack!.id)[0]).toMatchObject({
+      type: 'audio',
+      startFrame: 3,
+      durationFrames: 60,
+    })
+
+    expect(engine.undo()).toBe(true)
+    expect(engine.canUndo()).toBe(false)
+    expect(engine.getProject().tracks.some((t) => t.kind === 'audio')).toBe(false)
+    expect(engine.getClipsOnTrack(videoTrack.id)).toHaveLength(0)
+  })
+})
+
+describe('insertElement', () => {
+  it('creates an elements track when inserting an element with no elements lane', () => {
+    const engine = new TimelineEngine({ fps: 30 })
+    usePlaybackStore.setState({ currentFrame: 9 })
+
+    const result = insertElement(engine, { kind: 'element', element: 'text' })
+
+    const elementsTrack = engine.getProject().tracks.find((t) => t.kind === 'elements')
+    expect(elementsTrack).toBeDefined()
+    expect(result).toMatchObject({ ok: true, kind: 'element', trackId: elementsTrack?.id })
+    expect(engine.getClipsOnTrack(elementsTrack!.id)[0]).toMatchObject({
+      type: 'text',
+      name: 'Text 1',
+      startFrame: 9,
+      durationFrames: 90,
+    })
+  })
+})
+
+function addAsset(overrides: Partial<MediaAsset> & Pick<MediaAsset, 'id' | 'kind'>) {
+  const asset: MediaAsset = {
+    id: overrides.id,
+    kind: overrides.kind,
+    name: overrides.name ?? `${overrides.id}.mov`,
+    src: overrides.src ?? `${overrides.id}.mov`,
+    durationSec: overrides.durationSec ?? 0,
+    byteSize: overrides.byteSize ?? 1024,
+    lastModified: overrides.lastModified ?? 0,
+    addedAt: overrides.addedAt ?? 0,
+    hasAudio: overrides.hasAudio,
+    thumbnailUrl: overrides.thumbnailUrl,
+    width: overrides.width,
+    height: overrides.height,
+    sourceFps: overrides.sourceFps,
+    thumbnailStrip: overrides.thumbnailStrip,
+    waveform: overrides.waveform,
+  }
+  useMediaLibraryStore.getState().addAsset(asset)
+}

--- a/packages/timeline/src/insertAsset.ts
+++ b/packages/timeline/src/insertAsset.ts
@@ -1,0 +1,433 @@
+import type {
+  Clip,
+  ClipType,
+  MediaAsset,
+  MediaKind,
+  TimelineEngine,
+  Track,
+  TrackKind,
+} from '@elah/core'
+import { clipsOverlap, secondsToFrames, useMediaLibraryStore, usePlaybackStore } from '@elah/core'
+import { useAudioDropDialogStore } from './audioDropDialog.store'
+import type { DragElementPayload } from './elementDrag'
+
+/** Default on-timeline length for a freshly inserted synthetic element, in seconds. */
+const DEFAULT_TEXT_DURATION_SEC = 3
+
+type MediaClipType = Extract<ClipType, 'video' | 'audio' | 'image'>
+
+export interface InsertAssetOptions {
+  desiredStartFrame?: number
+  targetTrackId?: string
+}
+
+export type InsertAssetFailureReason =
+  | 'missing-asset'
+  | 'no-track'
+  | 'locked'
+  | 'incompatible-track'
+  | 'cancelled'
+
+export type InsertedKind = MediaKind | 'element'
+
+export type InsertAssetResult =
+  | {
+      ok: true
+      kind: InsertedKind
+      trackId: string
+      clipIds: string[]
+    }
+  | {
+      ok: false
+      kind: InsertedKind
+      reason: InsertAssetFailureReason
+    }
+
+interface TargetResolution {
+  ok: true
+  trackId: string
+  created: boolean
+}
+
+interface TargetRefusal {
+  ok: false
+  reason: Exclude<InsertAssetFailureReason, 'missing-asset' | 'cancelled'>
+}
+
+/**
+ * Resolve a drop position so the new clip never overlaps an existing one.
+ *
+ * - If there's no overlap at desiredStart -> returns unchanged.
+ * - If the drop lands in a gap that's too small for the clip -> trims to fill
+ *   exactly that gap.
+ * - If the drop lands on top of an existing clip -> pushes start to just after
+ *   the last overlapping clip, trimming if the next clip immediately follows.
+ */
+export function resolveDropPosition(
+  existingClips: { startFrame: number; durationFrames: number }[],
+  desiredStart: number,
+  durationFrames: number,
+): { startFrame: number; durationFrames: number } {
+  const sorted = [...existingClips].sort((a, b) => a.startFrame - b.startFrame)
+
+  const overlapping = sorted.filter((c) =>
+    clipsOverlap(c, { startFrame: desiredStart, durationFrames }),
+  )
+
+  if (overlapping.length === 0) return { startFrame: desiredStart, durationFrames }
+
+  const firstOverlap = overlapping[0]
+
+  if (desiredStart < firstOverlap.startFrame) {
+    const prevEnd = Math.max(
+      0,
+      ...sorted
+        .filter((c) => c.startFrame + c.durationFrames <= desiredStart)
+        .map((c) => c.startFrame + c.durationFrames),
+    )
+    const gapSize = firstOverlap.startFrame - prevEnd
+    return { startFrame: prevEnd, durationFrames: Math.min(durationFrames, gapSize) }
+  }
+
+  const lastOverlapEnd = Math.max(
+    ...overlapping.map((c) => c.startFrame + c.durationFrames),
+  )
+  const nextClip = sorted.find((c) => c.startFrame >= lastOverlapEnd)
+  if (nextClip) {
+    const available = nextClip.startFrame - lastOverlapEnd
+    return { startFrame: lastOverlapEnd, durationFrames: Math.min(durationFrames, available) }
+  }
+  return { startFrame: lastOverlapEnd, durationFrames }
+}
+
+/** Map MediaAsset kind to ClipType (identical for video/audio/image). */
+function mediaKindToClipType(kind: MediaKind): MediaClipType {
+  return kind
+}
+
+/** Whether a media asset can be placed on a track of the given kind. */
+export function isCompatibleTrackKind(trackKind: TrackKind, mediaKind: MediaKind): boolean {
+  if (trackKind === 'audio') return mediaKind === 'audio'
+  if (trackKind === 'video') return mediaKind === 'video' || mediaKind === 'image'
+  return false
+}
+
+function currentDesiredStart(opts: InsertAssetOptions | undefined): number {
+  return opts?.desiredStartFrame ?? usePlaybackStore.getState().currentFrame
+}
+
+function getProjectTracks(engine: TimelineEngine): Track[] {
+  return engine.getProject().tracks
+}
+
+function getTrack(engine: TimelineEngine, trackId: string): Track | undefined {
+  return getProjectTracks(engine).find((t) => t.id === trackId)
+}
+
+function clipsOn(engine: TimelineEngine, trackId: string): Clip[] {
+  return engine.getProject().clips[trackId] ?? []
+}
+
+function compatibleTracks(engine: TimelineEngine, mediaKind: MediaKind): Track[] {
+  return getProjectTracks(engine).filter((t) => isCompatibleTrackKind(t.kind, mediaKind))
+}
+
+/**
+ * Ensure auto-created audio lanes do not route new clips into a locked lane.
+ * If every existing audio lane is locked, insertion refuses instead of silently
+ * bypassing the user's lock by creating another lane.
+ */
+function ensureAudioTrack(engine: TimelineEngine): TargetResolution | TargetRefusal {
+  const audioTracks = getProjectTracks(engine).filter((t) => t.kind === 'audio')
+  const unlocked = audioTracks.find((t) => !t.locked)
+  if (unlocked) return { ok: true, trackId: unlocked.id, created: false }
+  if (audioTracks.length > 0) return { ok: false, reason: 'locked' }
+  return { ok: true, trackId: engine.addTrack('audio').id, created: true }
+}
+
+/**
+ * Elements tracks are optional in host apps, so tap insertion can create the
+ * first one while still respecting an intentional all-locked elements setup.
+ */
+function ensureElementsTrack(engine: TimelineEngine): TargetResolution | TargetRefusal {
+  const elementTracks = getProjectTracks(engine).filter((t) => t.kind === 'elements')
+  const unlocked = elementTracks.find((t) => !t.locked)
+  if (unlocked) return { ok: true, trackId: unlocked.id, created: false }
+  if (elementTracks.length > 0) return { ok: false, reason: 'locked' }
+  return { ok: true, trackId: engine.addTrack('elements').id, created: true }
+}
+
+function resolveMediaTarget(
+  engine: TimelineEngine,
+  mediaKind: MediaKind,
+  targetTrackId: string | undefined,
+): TargetResolution | TargetRefusal {
+  if (targetTrackId) {
+    const track = getTrack(engine, targetTrackId)
+    if (!track) return { ok: false, reason: 'no-track' }
+    if (track.locked) return { ok: false, reason: 'locked' }
+    if (!isCompatibleTrackKind(track.kind, mediaKind)) {
+      return { ok: false, reason: 'incompatible-track' }
+    }
+    return { ok: true, trackId: track.id, created: false }
+  }
+
+  const unlocked = compatibleTracks(engine, mediaKind).find((t) => !t.locked)
+  if (unlocked) return { ok: true, trackId: unlocked.id, created: false }
+
+  if (mediaKind === 'audio') return ensureAudioTrack(engine)
+
+  const existingCompatible = compatibleTracks(engine, mediaKind)
+  if (existingCompatible.some((t) => t.locked)) return { ok: false, reason: 'locked' }
+  return { ok: false, reason: 'no-track' }
+}
+
+function resolveElementTarget(
+  engine: TimelineEngine,
+  targetTrackId: string | undefined,
+): TargetResolution | TargetRefusal {
+  if (targetTrackId) {
+    const track = getTrack(engine, targetTrackId)
+    if (!track) return { ok: false, reason: 'no-track' }
+    if (track.locked) return { ok: false, reason: 'locked' }
+    if (track.kind !== 'elements') return { ok: false, reason: 'incompatible-track' }
+    return { ok: true, trackId: track.id, created: false }
+  }
+
+  const unlocked = getProjectTracks(engine).find((t) => t.kind === 'elements' && !t.locked)
+  if (unlocked) return { ok: true, trackId: unlocked.id, created: false }
+  return ensureElementsTrack(engine)
+}
+
+/** Resolve a non-overlapping placement for `desired` on a track. */
+function resolveOn(
+  engine: TimelineEngine,
+  trackId: string,
+  desired: number,
+  durationFrames: number,
+) {
+  return resolveDropPosition(clipsOn(engine, trackId), desired, durationFrames)
+}
+
+/** Add one media clip. MediaKind is never text, so `src` is always valid. */
+function addMediaClip(
+  engine: TimelineEngine,
+  trackId: string,
+  type: MediaClipType,
+  asset: MediaAsset,
+  startFrame: number,
+  durationFrames: number,
+) {
+  return engine.addClip({
+    trackId,
+    type,
+    name: asset.name,
+    startFrame,
+    durationFrames,
+    src: asset.src,
+    assetId: asset.id,
+  })
+}
+
+function addElementClip(
+  engine: TimelineEngine,
+  trackId: string,
+  payload: DragElementPayload,
+  startFrame: number,
+  durationFrames: number,
+) {
+  const existing = clipsOn(engine, trackId)
+  const n = existing.length + 1
+
+  if (payload.element === 'text') {
+    return engine.addClip({
+      trackId,
+      type: 'text',
+      name: `Text ${n}`,
+      startFrame,
+      durationFrames,
+      text: {
+        content: `Text ${n}`,
+        fontSize: 200,
+        color: '#ffffff',
+        fontFamily: 'sans-serif',
+        fontWeight: 'normal',
+        textAlign: 'center',
+      },
+    })
+  }
+
+  if (payload.element === 'shape') {
+    const shapeKind = payload.shapeVariant ?? 'rect'
+    return engine.addClip({
+      trackId,
+      type: 'shape',
+      name: `${shapeKind.charAt(0).toUpperCase() + shapeKind.slice(1)} ${n}`,
+      startFrame,
+      durationFrames,
+      // Explicit transform matches ShapeLayer's render defaults so the canvas,
+      // selection overlay, and Transform properties panel agree immediately.
+      transform: { x: 0.5, y: 0.5, scale: 0.5, rotation: 0, anchor: { x: 0.5, y: 0.5 } },
+      shape: {
+        shapeKind,
+        shapeFill: 'transparent',
+        shapeStroke: '#4f9cf9',
+        shapeStrokeWidth: 4,
+      },
+    })
+  }
+
+  return engine.addClip({
+    trackId,
+    type: 'freehand',
+    name: `Drawing ${n}`,
+    startFrame,
+    durationFrames,
+    freehand: {
+      pathData: '',
+      strokeColor: '#ffffff',
+      strokeWidth: 4,
+    },
+  })
+}
+
+function mediaRefusal(
+  kind: MediaKind,
+  reason: InsertAssetFailureReason,
+): InsertAssetResult {
+  return { ok: false, kind, reason }
+}
+
+function elementRefusal(reason: InsertAssetFailureReason): InsertAssetResult {
+  return { ok: false, kind: 'element', reason }
+}
+
+/**
+ * Insert a media asset using the same adapter that backs timeline drag-drop.
+ * The helper owns target-track lookup for tap insertion, keeping SDK panels
+ * from duplicating timeline placement and audio-dialog rules.
+ */
+export async function insertMediaAsset(
+  engine: TimelineEngine,
+  assetId: string,
+  opts: InsertAssetOptions = {},
+): Promise<InsertAssetResult> {
+  const asset = useMediaLibraryStore.getState().getAsset(assetId)
+  if (!asset) return mediaRefusal('video', 'missing-asset')
+
+  const target = resolveMediaTarget(engine, asset.kind, opts.targetTrackId)
+  if (!target.ok) return mediaRefusal(asset.kind, target.reason)
+
+  const desiredStart = currentDesiredStart(opts)
+  const fps = engine.getProject().fps
+  const fullDuration = Math.max(
+    1,
+    asset.durationSec > 0 ? secondsToFrames(asset.durationSec, fps) : fps * 5,
+  )
+
+  if (asset.kind !== 'video' || !asset.hasAudio) {
+    const run = (): InsertAssetResult => {
+      const r = resolveOn(engine, target.trackId, desiredStart, fullDuration)
+      const clip = addMediaClip(
+        engine,
+        target.trackId,
+        mediaKindToClipType(asset.kind),
+        asset,
+        r.startFrame,
+        r.durationFrames,
+      )
+      return { ok: true, kind: asset.kind, trackId: target.trackId, clipIds: [clip.id] }
+    }
+
+    if (!target.created) return run()
+
+    let result: InsertAssetResult = mediaRefusal(asset.kind, 'no-track')
+    engine.batch(() => {
+      result = run()
+    }, 'Add media')
+    return result
+  }
+
+  const choice = await useAudioDropDialogStore.getState().request(asset.name)
+  if (!choice) return mediaRefusal(asset.kind, 'cancelled')
+
+  let result: InsertAssetResult = mediaRefusal(asset.kind, 'cancelled')
+  engine.batch(() => {
+    if (choice === 'video-only') {
+      const v = resolveOn(engine, target.trackId, desiredStart, fullDuration)
+      const clip = addMediaClip(engine, target.trackId, 'video', asset, v.startFrame, v.durationFrames)
+      result = { ok: true, kind: asset.kind, trackId: target.trackId, clipIds: [clip.id] }
+    } else if (choice === 'both') {
+      // Resolve against BOTH tracks at once so the pair lands where neither
+      // track is occupied; they stay frame-synced and never overlap.
+      const audioTarget = ensureAudioTrack(engine)
+      if (!audioTarget.ok) {
+        result = mediaRefusal(asset.kind, audioTarget.reason)
+        return
+      }
+      const videoClips = clipsOn(engine, target.trackId)
+      const audioClips = clipsOn(engine, audioTarget.trackId)
+      const r = resolveDropPosition(
+        [...videoClips, ...audioClips],
+        desiredStart,
+        fullDuration,
+      )
+      const video = addMediaClip(engine, target.trackId, 'video', asset, r.startFrame, r.durationFrames)
+      const audio = addMediaClip(engine, audioTarget.trackId, 'audio', asset, r.startFrame, r.durationFrames)
+      result = {
+        ok: true,
+        kind: asset.kind,
+        trackId: target.trackId,
+        clipIds: [video.id, audio.id],
+      }
+    } else {
+      const audioTarget = ensureAudioTrack(engine)
+      if (!audioTarget.ok) {
+        result = mediaRefusal(asset.kind, audioTarget.reason)
+        return
+      }
+      const a = resolveOn(engine, audioTarget.trackId, desiredStart, fullDuration)
+      const clip = addMediaClip(engine, audioTarget.trackId, 'audio', asset, a.startFrame, a.durationFrames)
+      result = { ok: true, kind: asset.kind, trackId: audioTarget.trackId, clipIds: [clip.id] }
+    }
+  }, 'Add media')
+
+  return result
+}
+
+/**
+ * Insert a generated element from the published element drag payload. Keeping
+ * the templates here means drag-drop and tap insertion always create identical
+ * text, shape, and freehand clips.
+ */
+export function insertElement(
+  engine: TimelineEngine,
+  payload: DragElementPayload,
+  opts: InsertAssetOptions = {},
+): InsertAssetResult {
+  if (payload.kind !== 'element') return elementRefusal('incompatible-track')
+
+  const target = resolveElementTarget(engine, opts.targetTrackId)
+  if (!target.ok) return elementRefusal(target.reason)
+
+  const run = (): InsertAssetResult => {
+    const fps = engine.getProject().fps
+    const elemDuration = Math.max(1, fps * DEFAULT_TEXT_DURATION_SEC)
+    const { startFrame, durationFrames } = resolveOn(
+      engine,
+      target.trackId,
+      currentDesiredStart(opts),
+      elemDuration,
+    )
+    const clip = addElementClip(engine, target.trackId, payload, startFrame, durationFrames)
+    return { ok: true, kind: 'element', trackId: target.trackId, clipIds: [clip.id] }
+  }
+
+  if (!target.created) return run()
+
+  let result: InsertAssetResult = elementRefusal('no-track')
+  engine.batch(() => {
+    result = run()
+  }, 'Add element')
+  return result
+}

--- a/packages/timeline/src/pointerInteractions.test.ts
+++ b/packages/timeline/src/pointerInteractions.test.ts
@@ -1,0 +1,392 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { act, createElement, type ReactElement } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import {
+  EditorContext,
+  PlaybackEngine,
+  TimelineEngine,
+  usePlaybackStore,
+  useSelectionStore,
+  useTracksStore,
+  type Clip,
+} from '@elah/core'
+import { ClipBlock } from './ClipBlock'
+import { Playhead } from './Playhead'
+import { Ruler } from './Ruler'
+
+interface Rendered {
+  container: HTMLElement
+  root: Root
+}
+
+const mounted: Rendered[] = []
+const playbacks: PlaybackEngine[] = []
+
+afterEach(() => {
+  for (const { root, container } of mounted.splice(0).reverse()) {
+    act(() => root.unmount())
+    container.remove()
+  }
+  for (const playback of playbacks.splice(0)) {
+    playback.destroy()
+  }
+  document.body.replaceChildren()
+  resetStores()
+  vi.restoreAllMocks()
+})
+
+describe('ClipBlock pointer gestures', () => {
+  it('commits clip body drag on pointerup', () => {
+    const { block, clip, engine } = setupClip()
+
+    dispatchPointer(block, 'pointerdown', { clientX: 100 })
+    dispatchPointer(window, 'pointermove', { clientX: 110 })
+    dispatchPointer(window, 'pointerup', { clientX: 110 })
+
+    expect(currentClip(engine, clip.id).startFrame).toBe(20)
+  })
+
+  it('reverts clip body drag on pointercancel', () => {
+    const { block, clip, engine } = setupClip()
+
+    dispatchPointer(block, 'pointerdown', { clientX: 100 })
+    dispatchPointer(window, 'pointermove', { clientX: 110 })
+    dispatchPointer(window, 'pointercancel', { clientX: 110 })
+
+    expect(currentClip(engine, clip.id).startFrame).toBe(10)
+    expect(block.style.transform).toBe('')
+  })
+
+  it('commits and reverts left trim gestures', () => {
+    const commit = setupClip()
+    const commitLeftHandle = commit.block.querySelector(
+      '.elah-trim-handle-left',
+    ) as HTMLElement
+
+    dispatchPointer(commitLeftHandle, 'pointerdown', { clientX: 100 })
+    dispatchPointer(window, 'pointermove', { clientX: 110 })
+    dispatchPointer(window, 'pointerup', { clientX: 110 })
+
+    expect(currentClip(commit.engine, commit.clip.id).startFrame).toBe(20)
+    expect(currentClip(commit.engine, commit.clip.id).durationFrames).toBe(30)
+
+    const cancel = setupClip()
+    const cancelLeftHandle = cancel.block.querySelector(
+      '.elah-trim-handle-left',
+    ) as HTMLElement
+
+    dispatchPointer(cancelLeftHandle, 'pointerdown', { clientX: 100 })
+    dispatchPointer(window, 'pointermove', { clientX: 110 })
+    dispatchPointer(window, 'pointercancel', { clientX: 110 })
+
+    expect(currentClip(cancel.engine, cancel.clip.id).startFrame).toBe(10)
+    expect(currentClip(cancel.engine, cancel.clip.id).durationFrames).toBe(40)
+    expect(cancel.block.style.left).toBe('10px')
+    expect(cancel.block.style.width).toBe('40px')
+  })
+
+  it('commits and reverts right trim gestures', () => {
+    const commit = setupClip()
+    const commitRightHandle = commit.block.querySelector(
+      '.elah-trim-handle-right',
+    ) as HTMLElement
+
+    dispatchPointer(commitRightHandle, 'pointerdown', { clientX: 100 })
+    dispatchPointer(window, 'pointermove', { clientX: 110 })
+    dispatchPointer(window, 'pointerup', { clientX: 110 })
+
+    expect(currentClip(commit.engine, commit.clip.id).durationFrames).toBe(50)
+
+    const cancel = setupClip()
+    const cancelRightHandle = cancel.block.querySelector(
+      '.elah-trim-handle-right',
+    ) as HTMLElement
+
+    dispatchPointer(cancelRightHandle, 'pointerdown', { clientX: 100 })
+    dispatchPointer(window, 'pointermove', { clientX: 110 })
+    dispatchPointer(window, 'pointercancel', { clientX: 110 })
+
+    expect(currentClip(cancel.engine, cancel.clip.id).startFrame).toBe(10)
+    expect(currentClip(cancel.engine, cancel.clip.id).durationFrames).toBe(40)
+    expect(cancel.block.style.width).toBe('40px')
+  })
+
+  it('applies the touch threshold while mouse drags move immediately', () => {
+    const smallTouch = setupClip()
+
+    dispatchPointer(smallTouch.block, 'pointerdown', {
+      clientX: 100,
+      pointerType: 'touch',
+    })
+    dispatchPointer(window, 'pointermove', {
+      clientX: 105,
+      pointerType: 'touch',
+    })
+    dispatchPointer(window, 'pointerup', {
+      clientX: 105,
+      pointerType: 'touch',
+    })
+
+    expect(currentClip(smallTouch.engine, smallTouch.clip.id).startFrame).toBe(10)
+    expect(smallTouch.block.style.transform).toBe('')
+
+    const largeTouch = setupClip()
+
+    dispatchPointer(largeTouch.block, 'pointerdown', {
+      clientX: 100,
+      pointerType: 'touch',
+    })
+    dispatchPointer(window, 'pointermove', {
+      clientX: 107,
+      pointerType: 'touch',
+    })
+    dispatchPointer(window, 'pointerup', {
+      clientX: 107,
+      pointerType: 'touch',
+    })
+
+    expect(currentClip(largeTouch.engine, largeTouch.clip.id).startFrame).toBe(17)
+
+    const mouse = setupClip()
+
+    dispatchPointer(mouse.block, 'pointerdown', { clientX: 100 })
+    dispatchPointer(window, 'pointermove', { clientX: 105 })
+    dispatchPointer(window, 'pointerup', { clientX: 105 })
+
+    expect(currentClip(mouse.engine, mouse.clip.id).startFrame).toBe(15)
+  })
+
+  it('removes window listeners after pointerup and pointercancel', () => {
+    const removeSpy = vi.spyOn(window, 'removeEventListener')
+    const up = setupClip()
+
+    dispatchPointer(up.block, 'pointerdown', { clientX: 100 })
+    dispatchPointer(window, 'pointerup', { clientX: 100 })
+
+    expect(pointerRemoves(removeSpy.mock.calls, 'pointermove')).toHaveLength(1)
+    expect(pointerRemoves(removeSpy.mock.calls, 'pointerup')).toHaveLength(1)
+    expect(pointerRemoves(removeSpy.mock.calls, 'pointercancel')).toHaveLength(1)
+
+    const cancel = setupClip()
+
+    dispatchPointer(cancel.block, 'pointerdown', { clientX: 100 })
+    dispatchPointer(window, 'pointercancel', { clientX: 100 })
+
+    expect(pointerRemoves(removeSpy.mock.calls, 'pointermove')).toHaveLength(2)
+    expect(pointerRemoves(removeSpy.mock.calls, 'pointerup')).toHaveLength(2)
+    expect(pointerRemoves(removeSpy.mock.calls, 'pointercancel')).toHaveLength(2)
+  })
+})
+
+describe('Playhead pointer gestures', () => {
+  it('seeks while the playhead is dragged', () => {
+    resetStores({ zoom: 2 })
+    const parent = document.createElement('div')
+    mockRect(parent, { left: 100 })
+
+    const { container } = render(
+      createElement(Playhead, { zoom: 2, height: 100 }),
+      parent,
+    )
+    const needle = container.firstElementChild as HTMLElement
+
+    dispatchPointer(needle, 'pointerdown', { clientX: 100 })
+    dispatchPointer(window, 'pointermove', { clientX: 130 })
+    dispatchPointer(window, 'pointerup', { clientX: 130 })
+
+    expect(usePlaybackStore.getState().currentFrame).toBe(15)
+  })
+})
+
+describe('Ruler pointer gestures', () => {
+  it('seeks once per tap and ignores the synthesized click', () => {
+    const onSeek = vi.fn()
+    const { container } = render(
+      createElement(Ruler, {
+        fps: 30,
+        totalFrames: 120,
+        zoom: 2,
+        onSeek,
+      }),
+    )
+    const ruler = container.firstElementChild as HTMLElement
+    mockRect(ruler, { left: 50 })
+
+    dispatchPointer(ruler, 'pointerdown', { clientX: 70 })
+    dispatchPointer(window, 'pointerup', { clientX: 70 })
+    dispatchMouse(ruler, 'click', { clientX: 70 })
+
+    expect(onSeek).toHaveBeenCalledTimes(1)
+    expect(onSeek).toHaveBeenLastCalledWith(10)
+  })
+
+  it('scrubs continuously on pointermove', () => {
+    const onSeek = vi.fn()
+    const { container } = render(
+      createElement(Ruler, {
+        fps: 30,
+        totalFrames: 120,
+        zoom: 2,
+        onSeek,
+      }),
+    )
+    const ruler = container.firstElementChild as HTMLElement
+    mockRect(ruler, { left: 50 })
+
+    dispatchPointer(ruler, 'pointerdown', { clientX: 70 })
+    dispatchPointer(window, 'pointermove', { clientX: 90 })
+    dispatchPointer(window, 'pointerup', { clientX: 90 })
+
+    expect(onSeek.mock.calls.map(([frame]) => frame)).toEqual([10, 20])
+  })
+})
+
+function render(element: ReactElement, container = document.createElement('div')): Rendered {
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  act(() => root.render(element))
+  const rendered = { container, root }
+  mounted.push(rendered)
+  return rendered
+}
+
+function setupClip(): {
+  block: HTMLElement
+  clip: Clip
+  engine: TimelineEngine
+} {
+  resetStores()
+  const engine = new TimelineEngine({ fps: 30 })
+  const playback = new PlaybackEngine({
+    fps: 30,
+    getTotalFrames: () => engine.getTotalFrames(),
+    now: () => 0,
+  })
+  playbacks.push(playback)
+  const track = engine.addTrack('elements')
+  const clip = engine.addClip({
+    trackId: track.id,
+    type: 'text',
+    name: 'Caption',
+    text: { content: 'Caption' },
+    startFrame: 10,
+    durationFrames: 40,
+  })
+  syncTracks(engine)
+
+  const { container } = render(
+    createElement(
+      EditorContext.Provider,
+      { value: { engine, playback } },
+      createElement(ClipBlock, {
+        clip,
+        zoom: 1,
+        trackHeight: track.height,
+      }),
+    ),
+  )
+  const block = container.firstElementChild as HTMLElement
+  return { block, clip, engine }
+}
+
+function resetStores(overrides: Partial<ReturnType<typeof usePlaybackStore.getState>> = {}) {
+  act(() => {
+    useTracksStore.setState({
+      tracks: [],
+      clips: {},
+      stage: { width: 1080, height: 1920 },
+      totalFrames: 0,
+      canUndo: false,
+      canRedo: false,
+    })
+    useSelectionStore.setState({
+      selectedClipIds: new Set(),
+      activeTrackId: null,
+    })
+    usePlaybackStore.setState({
+      currentFrame: 0,
+      currentFrameEpoch: 0,
+      isPlaying: false,
+      playbackRate: 1,
+      loop: false,
+      volume: 1,
+      muted: false,
+      zoom: 4,
+      snapEnabled: false,
+      ...overrides,
+    })
+  })
+}
+
+function syncTracks(engine: TimelineEngine) {
+  useTracksStore.getState().sync(engine.getProject(), {
+    canUndo: engine.canUndo(),
+    canRedo: engine.canRedo(),
+  })
+}
+
+function currentClip(engine: TimelineEngine, clipId: string): Clip {
+  const found = engine.findClip(clipId)
+  if (!found) throw new Error(`Missing clip ${clipId}`)
+  return found.clip
+}
+
+function dispatchPointer(
+  target: EventTarget,
+  type: string,
+  init: PointerEventInit = {},
+) {
+  act(() => {
+    target.dispatchEvent(
+      new PointerEvent(type, {
+        bubbles: true,
+        cancelable: true,
+        button: 0,
+        buttons: type === 'pointerup' || type === 'pointercancel' ? 0 : 1,
+        clientX: 0,
+        clientY: 0,
+        pointerId: 1,
+        pointerType: 'mouse',
+        isPrimary: true,
+        ...init,
+      }),
+    )
+  })
+}
+
+function dispatchMouse(target: EventTarget, type: string, init: MouseEventInit = {}) {
+  act(() => {
+    target.dispatchEvent(
+      new MouseEvent(type, {
+        bubbles: true,
+        cancelable: true,
+        button: 0,
+        clientX: 0,
+        clientY: 0,
+        ...init,
+      }),
+    )
+  })
+}
+
+function mockRect(element: Element, rect: Partial<DOMRect>) {
+  const fullRect = {
+    bottom: rect.bottom ?? 0,
+    height: rect.height ?? 0,
+    left: rect.left ?? 0,
+    right: rect.right ?? 0,
+    top: rect.top ?? 0,
+    width: rect.width ?? 0,
+    x: rect.x ?? rect.left ?? 0,
+    y: rect.y ?? rect.top ?? 0,
+    toJSON: () => ({}),
+  }
+  Object.defineProperty(element, 'getBoundingClientRect', {
+    configurable: true,
+    value: () => fullRect,
+  })
+}
+
+function pointerRemoves(calls: ReadonlyArray<readonly [unknown, ...unknown[]]>, type: string) {
+  return calls.filter(([eventType]) => eventType === type)
+}

--- a/packages/timeline/src/styles/index.css
+++ b/packages/timeline/src/styles/index.css
@@ -1,3 +1,27 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer components {
+  @media (pointer: coarse) {
+    .elah-trim-handle {
+      width: 28px !important;
+    }
+
+    .elah-playhead-head-hit {
+      left: -11px !important;
+      top: -7px !important;
+      width: 24px !important;
+      height: 24px !important;
+    }
+
+    .elah-playhead-head-visual {
+      left: 4px !important;
+      top: 5px !important;
+    }
+
+    .elah-transition-chip-affordance {
+      opacity: 1 !important;
+    }
+  }
+}

--- a/packages/timeline/src/useTimelineDrop.ts
+++ b/packages/timeline/src/useTimelineDrop.ts
@@ -1,86 +1,19 @@
 import { useEffect } from 'react'
-import type { ClipType, TrackKind } from '@elah/core'
 import {
+  buildSnapPoints,
   MEDIA_DRAG_MIME,
+  snapFrame,
+  usePlaybackStore,
+  useTracksStore,
   type DragMediaPayload,
-  type MediaAsset,
-  type MediaKind,
 } from '@elah/core'
-import { useAudioDropDialogStore } from './audioDropDialog.store'
 import { ELEMENT_DRAG_MIME, type DragElementPayload } from './elementDrag'
-import { useMediaLibraryStore } from '@elah/core'
-import { useTracksStore } from '@elah/core'
-import { usePlaybackStore } from '@elah/core'
-import { buildSnapPoints, snapFrame } from '@elah/core'
-import { secondsToFrames, clipsOverlap } from '@elah/core'
 import { useTimeline } from './engine-context'
-
-/** Default on-timeline length for a freshly dropped text block, in seconds. */
-const DEFAULT_TEXT_DURATION_SEC = 3
+import { insertElement, insertMediaAsset } from './insertAsset'
 
 /**
- * Resolve a drop position so the new clip never overlaps an existing one.
- *
- * - If there's no overlap at desiredStart → returns unchanged.
- * - If the drop lands in a gap that's too small for the clip → trims to fill
- *   exactly that gap (bug 4).
- * - If the drop lands on top of an existing clip → pushes start to just after
- *   the last overlapping clip, trimming if the next clip immediately follows
- *   (bugs 2 & 3).
- */
-function resolveDropPosition(
-  existingClips: { startFrame: number; durationFrames: number }[],
-  desiredStart: number,
-  durationFrames: number,
-): { startFrame: number; durationFrames: number } {
-  const sorted = [...existingClips].sort((a, b) => a.startFrame - b.startFrame)
-
-  const overlapping = sorted.filter((c) =>
-    clipsOverlap(c, { startFrame: desiredStart, durationFrames }),
-  )
-
-  if (overlapping.length === 0) return { startFrame: desiredStart, durationFrames }
-
-  const firstOverlap = overlapping[0]
-
-  // desiredStart is in a gap but the clip extends into the next clip → trim to gap
-  if (desiredStart < firstOverlap.startFrame) {
-    const prevEnd = Math.max(
-      0,
-      ...sorted
-        .filter((c) => c.startFrame + c.durationFrames <= desiredStart)
-        .map((c) => c.startFrame + c.durationFrames),
-    )
-    const gapSize = firstOverlap.startFrame - prevEnd
-    return { startFrame: prevEnd, durationFrames: Math.min(durationFrames, gapSize) }
-  }
-
-  // desiredStart is inside an existing clip → push to after all overlapping clips
-  const lastOverlapEnd = Math.max(
-    ...overlapping.map((c) => c.startFrame + c.durationFrames),
-  )
-  const nextClip = sorted.find((c) => c.startFrame >= lastOverlapEnd)
-  if (nextClip) {
-    const available = nextClip.startFrame - lastOverlapEnd
-    return { startFrame: lastOverlapEnd, durationFrames: Math.min(durationFrames, available) }
-  }
-  return { startFrame: lastOverlapEnd, durationFrames }
-}
-
-/** Map MediaAsset kind to ClipType (identical for video/audio/image). */
-function mediaKindToClipType(kind: MediaKind): ClipType {
-  return kind
-}
-
-/** Whether a media asset can be placed on a track of the given kind. */
-function isCompatibleTrackKind(trackKind: TrackKind, mediaKind: MediaKind): boolean {
-  if (trackKind === 'audio') return mediaKind === 'audio'
-  if (trackKind === 'video') return mediaKind === 'video' || mediaKind === 'image'
-  return false
-}
-
-/**
- * Listen for media drag-drop events on a timeline lane and create clips.
+ * Listen for drag-drop events on a timeline lane and delegate insertion to the
+ * shared helper so pointer drops and tap activation use the same placement path.
  *
  * @param trackId  The id of the track this lane represents.
  * @param lane     The DOM element to attach drop listeners to (e.g. the lane's content div).
@@ -96,7 +29,7 @@ export function useTimelineDrop(trackId: string, lane: HTMLElement | null): void
       e.dataTransfer?.types.includes(MEDIA_DRAG_MIME) ||
       e.dataTransfer?.types.includes(ELEMENT_DRAG_MIME)
 
-    /** Pointer x → timeline frame, snapped to clips + the playhead when enabled. */
+    /** Pointer x -> timeline frame, snapped to clips + the playhead when enabled. */
     const startFrameAt = (clientX: number): number => {
       const zoom = usePlaybackStore.getState().zoom
       const rect = lane.getBoundingClientRect()
@@ -125,38 +58,7 @@ export function useTimelineDrop(trackId: string, lane: HTMLElement | null): void
       e.dataTransfer!.dropEffect = 'copy'
     }
 
-    /** Find the first audio track, creating one if none exists. */
-    const ensureAudioTrack = (): string => {
-      const existing = useTracksStore
-        .getState()
-        .tracks.find((t) => t.kind === 'audio')
-      return existing ? existing.id : engine.addTrack('audio').id
-    }
-
-    /** Resolve a non-overlapping placement for `desired` on a track. */
-    const resolveOn = (tid: string, desired: number, dur: number) =>
-      resolveDropPosition(useTracksStore.getState().clips[tid] ?? [], desired, dur)
-
-    /** Add one media clip. MediaKind is never 'text', so `src` is always valid. */
-    const addMediaClip = (
-      tid: string,
-      type: 'video' | 'audio' | 'image',
-      asset: MediaAsset,
-      startFrame: number,
-      durationFrames: number,
-    ) => {
-      engine.addClip({
-        trackId: tid,
-        type,
-        name: asset.name,
-        startFrame,
-        durationFrames,
-        src: asset.src,
-        assetId: asset.id,
-      })
-    }
-
-    const dropMediaAsset = async (e: DragEvent, track: { kind: TrackKind }) => {
+    const dropMediaAsset = (e: DragEvent, desiredStartFrame: number) => {
       let payload: DragMediaPayload
       try {
         payload = JSON.parse(
@@ -167,64 +69,13 @@ export function useTimelineDrop(trackId: string, lane: HTMLElement | null): void
       }
 
       if (payload.kind !== 'media-asset' || !payload.assetId) return
-
-      const asset = useMediaLibraryStore.getState().getAsset(payload.assetId)
-      if (!asset) return
-      if (!isCompatibleTrackKind(track.kind, asset.kind)) return
-
-      const fps = engine.getProject().fps
-      const fullDuration = Math.max(
-        1,
-        asset.durationSec > 0 ? secondsToFrames(asset.durationSec, fps) : fps * 5,
-      )
-      // clientX must be read before any await — the DragEvent is dead afterwards.
-      const desiredStart = startFrameAt(e.clientX)
-
-      // Only a video that actually carries audio prompts; everything else keeps
-      // the original single-clip behaviour (no regression for audio/image/silent video).
-      if (asset.kind !== 'video' || !asset.hasAudio) {
-        const r = resolveOn(trackId, desiredStart, fullDuration)
-        addMediaClip(
-          trackId,
-          mediaKindToClipType(asset.kind) as 'video' | 'audio' | 'image',
-          asset,
-          r.startFrame,
-          r.durationFrames,
-        )
-        return
-      }
-
-      const choice = await useAudioDropDialogStore.getState().request(asset.name)
-      if (!choice) return // superseded by a newer drop
-
-      engine.batch(() => {
-        if (choice === 'video-only') {
-          const v = resolveOn(trackId, desiredStart, fullDuration)
-          addMediaClip(trackId, 'video', asset, v.startFrame, v.durationFrames)
-        } else if (choice === 'both') {
-          // Resolve against BOTH tracks at once so the pair lands where neither
-          // track is occupied — they stay frame-synced and never overlap.
-          // (Linked-clip ripple edits are a deferred follow-on.)
-          const audioTrackId = ensureAudioTrack()
-          const videoClips = useTracksStore.getState().clips[trackId] ?? []
-          const audioClips = useTracksStore.getState().clips[audioTrackId] ?? []
-          const r = resolveDropPosition(
-            [...videoClips, ...audioClips],
-            desiredStart,
-            fullDuration,
-          )
-          addMediaClip(trackId, 'video', asset, r.startFrame, r.durationFrames)
-          addMediaClip(audioTrackId, 'audio', asset, r.startFrame, r.durationFrames)
-        } else {
-          // audio-only: resolve independently against the audio track.
-          const audioTrackId = ensureAudioTrack()
-          const a = resolveOn(audioTrackId, desiredStart, fullDuration)
-          addMediaClip(audioTrackId, 'audio', asset, a.startFrame, a.durationFrames)
-        }
-      }, 'Add media')
+      void insertMediaAsset(engine, payload.assetId, {
+        desiredStartFrame,
+        targetTrackId: trackId,
+      })
     }
 
-    const dropElement = (e: DragEvent, track: { kind: TrackKind }) => {
+    const dropElement = (e: DragEvent, desiredStartFrame: number) => {
       let payload: DragElementPayload
       try {
         payload = JSON.parse(
@@ -234,72 +85,10 @@ export function useTimelineDrop(trackId: string, lane: HTMLElement | null): void
         return
       }
 
-      // All synthetic elements live on 'elements' tracks.
-      if (track.kind !== 'elements') return
-
-      const fps = engine.getProject().fps
-      const existing = useTracksStore.getState().clips[trackId] ?? []
-      const n = existing.length + 1
-      const elemDuration = Math.max(1, fps * DEFAULT_TEXT_DURATION_SEC)
-      const { startFrame, durationFrames } =
-        resolveDropPosition(existing, startFrameAt(e.clientX), elemDuration)
-
-      if (payload.element === 'text') {
-        engine.addClip({
-          trackId,
-          type: 'text',
-          name: `Text ${n}`,
-          startFrame,
-          durationFrames,
-          text: {
-            content: `Text ${n}`,
-            fontSize: 200,
-            color: '#ffffff',
-            fontFamily: 'sans-serif',
-            fontWeight: 'normal',
-            textAlign: 'center',
-          },
-        })
-        return
-      }
-
-      if (payload.element === 'shape') {
-        const shapeKind = payload.shapeVariant ?? 'rect'
-        engine.addClip({
-          trackId,
-          type: 'shape',
-          name: `${shapeKind.charAt(0).toUpperCase() + shapeKind.slice(1)} ${n}`,
-          startFrame,
-          durationFrames,
-          // Explicit transform matches ShapeLayer's render defaults (centre,
-          // half the short side) so the canvas, the selection overlay, and the
-          // Transform properties panel all agree from the first frame.
-          transform: { x: 0.5, y: 0.5, scale: 0.5, rotation: 0, anchor: { x: 0.5, y: 0.5 } },
-          shape: {
-            shapeKind,
-            // Hollow by default: only a border is drawn, no fill.
-            shapeFill: 'transparent',
-            shapeStroke: '#4f9cf9',
-            shapeStrokeWidth: 4,
-          },
-        })
-        return
-      }
-
-      if (payload.element === 'freehand') {
-        engine.addClip({
-          trackId,
-          type: 'freehand',
-          name: `Drawing ${n}`,
-          startFrame,
-          durationFrames,
-          freehand: {
-            pathData: '',
-            strokeColor: '#ffffff',
-            strokeWidth: 4,
-          },
-        })
-      }
+      insertElement(engine, payload, {
+        desiredStartFrame,
+        targetTrackId: trackId,
+      })
     }
 
     const handleDrop = (e: DragEvent) => {
@@ -312,12 +101,12 @@ export function useTimelineDrop(trackId: string, lane: HTMLElement | null): void
       if (!track) return
       if (track.locked) return // locked tracks reject new clips
 
+      // clientX must be read before any await in the insertion helper.
+      const desiredStartFrame = startFrameAt(e.clientX)
       if (e.dataTransfer!.types.includes(ELEMENT_DRAG_MIME)) {
-        dropElement(e, track)
+        dropElement(e, desiredStartFrame)
       } else {
-        // Fire-and-forget: all DragEvent reads happen synchronously before the
-        // first await inside dropMediaAsset.
-        void dropMediaAsset(e, track)
+        dropMediaAsset(e, desiredStartFrame)
       }
     }
 
@@ -330,5 +119,3 @@ export function useTimelineDrop(trackId: string, lane: HTMLElement | null): void
     }
   }, [trackId, lane, engine])
 }
-
-

--- a/packages/timeline/vitest.config.ts
+++ b/packages/timeline/vitest.config.ts
@@ -4,5 +4,6 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
+    setupFiles: ['./vitest.setup.ts'],
   },
 })

--- a/packages/timeline/vitest.setup.ts
+++ b/packages/timeline/vitest.setup.ts
@@ -1,0 +1,69 @@
+class TestPointerEvent extends MouseEvent {
+  readonly pointerId: number
+  readonly width: number
+  readonly height: number
+  readonly pressure: number
+  readonly tangentialPressure: number
+  readonly tiltX: number
+  readonly tiltY: number
+  readonly twist: number
+  readonly pointerType: string
+  readonly isPrimary: boolean
+
+  constructor(type: string, init: PointerEventInit = {}) {
+    super(type, init)
+    this.pointerId = init.pointerId ?? 1
+    this.width = init.width ?? 1
+    this.height = init.height ?? 1
+    this.pressure = init.pressure ?? 0
+    this.tangentialPressure = init.tangentialPressure ?? 0
+    this.tiltX = init.tiltX ?? 0
+    this.tiltY = init.tiltY ?? 0
+    this.twist = init.twist ?? 0
+    this.pointerType = init.pointerType ?? 'mouse'
+    this.isPrimary = init.isPrimary ?? true
+  }
+
+  getCoalescedEvents(): PointerEvent[] {
+    return [this as unknown as PointerEvent]
+  }
+
+  getPredictedEvents(): PointerEvent[] {
+    return []
+  }
+}
+
+declare global {
+  var IS_REACT_ACT_ENVIRONMENT: boolean | undefined
+}
+
+Object.defineProperty(globalThis, 'PointerEvent', {
+  configurable: true,
+  writable: true,
+  value: TestPointerEvent,
+})
+
+Object.defineProperty(window, 'PointerEvent', {
+  configurable: true,
+  writable: true,
+  value: TestPointerEvent,
+})
+
+Object.defineProperty(HTMLElement.prototype, 'setPointerCapture', {
+  configurable: true,
+  value: () => {},
+})
+
+Object.defineProperty(HTMLElement.prototype, 'releasePointerCapture', {
+  configurable: true,
+  value: () => {},
+})
+
+Object.defineProperty(HTMLElement.prototype, 'hasPointerCapture', {
+  configurable: true,
+  value: () => false,
+})
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
+export {}


### PR DESCRIPTION
## What does this PR do?

Makes the production playground editor usable on mobile (target: 402×874, Figma mobile design) in three layers: touch-capable timeline gestures, tap-to-add asset insertion, and a responsive editor shell with bottom sheets.

Closes # — n/a

---

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Performance improvement

---

## What's in it

**1. `ui: migrate timeline gestures to pointer events`** (`@elah/timeline`)
ClipBlock drag + both trims, Playhead, and Ruler move from mouse events to pointer events (window-level listeners, no capture): `pointercancel` reverts in-flight moves/trims, a 6px drag threshold applies to touch only (mouse drags stay immediate), ruler seek becomes press + scrub with the old `onClick` removed so a synthesized click can't double-seek. Trim handles/playhead grow to 28px/24px hit areas under `@media (pointer: coarse)` only — visuals unchanged. TransitionPicker closes on `pointerdown`; the chip affordance is always visible on coarse pointers. New vitest interaction suite (9 tests) with a jsdom PointerEvent polyfill.

**2. `ui: add tap-to-add asset insertion`** (`@elah/timeline` + `@elah/editor` + app)
The insertion logic moves out of `useTimelineDrop` into `insertAsset.ts` (`insertMediaAsset`/`insertElement`); the drop hook becomes a thin DragEvent adapter over the same code, so drag-drop placement, clip templates, and undo batching are unchanged (placement resolver is byte-identical; locked in by 7 new tests). Tap inserts at the playhead into the first compatible **unlocked** track, creating audio/elements tracks when needed — note this also makes the existing drag path refuse locked audio tracks instead of silently inserting into them (deliberate). SDK panels (SourcePanel/ElementsPanel/AssetPanel) get opt-in `activateOnTap` / `onAssetActivate` props, default **off** — existing consumers render identical DOM. The app's MediaPanel enables tap-to-add.

**3. `ui: make production editor responsive for mobile`** (app + small `@elah/timeline` API)
`Timeline` gains `sidebarWidth` (default 184) and `compactSidebar` (default false) — ruler offset, playhead origin, and fit math derive from it. `TimelineControls` gains `compact` (default false; the timeline playground passes nothing and renders exactly as before). Below 768px the production editor becomes the Figma layout: compact header (back · aspect-ratio dropdown · Export · overflow menu), full-width preview with a floating fullscreen toggle (`requestFullscreen`, wired), transport row with undo/redo on the right, icon-only 48px track sidebar, compact timeline controls (zoom ± primary, slider hidden), and a bottom bar with the full desktop rail (Media/Stock/Photos/Audio/Elements) + Edit — each opening the *same* panel components in bottom sheets. Safe-area inset on the bottom bar, `overscroll-behavior: none`, `viewport-fit=cover`.

**Not included (deliberate):** Save button (no persistence backend), long-press menus, iOS Safari fullscreen (no element fullscreen API there).

---

## How to test

1. `npm install && npm run build:packages && npm run dev`, open `localhost:3001/playground/production`
2. Narrow the viewport below 768px (device toolbar, 402×874): side panels collapse, bottom bar appears
3. Tap Elements → tap a tile → clip lands at the playhead with a toast; tap a clip → Edit opens the properties sheet
4. Drag the playhead / scrub the ruler / drag + trim clips by touch; `pointercancel` (e.g. browser gesture takeover) reverts instead of committing
5. Desktop ≥768px: production editor renders as before; timeline playground toolbar unchanged
6. `npm run test --workspace=packages/timeline` → 18/18 (16 new); core suite: 372/385, the 13 failures are the pre-existing `PlaybackStress`/`RenderSynchronization` ones reproducible on `dev` (see #23)

---

## Screenshots / Recording

Verified live in Chrome at 402×874 (tap-to-add, scrub, drag, trim, sheets, fullscreen) and desktop regression at 1920px. Happy to attach screenshots on request.

---

## Checklist

- [x] `npm test` passes (timeline fully incl. 16 new tests; core except the 13 pre-existing failures on `dev`)
- [x] `npm run typecheck` passes for changed packages (timeline/editor `tsc --noEmit` + apps/web)
- [x] I've tested this in the playground (mobile viewport + desktop regression, both playgrounds)
- [x] No `any` types introduced without justification

`packages/core` is untouched. Published-package API is additive-only with back-compat defaults.


**Post-review additions from real-device testing (Pixel 8 Pro over adb):** `100dvh` shell height (mobile Chrome URL-bar crop), three-field `MM:SS:FF` mobile timecode with a true-centered transport, full-width properties sheet, working floating fullscreen toggle on the preview, aspect-ratio dropdown in the mobile header, bottom bar carrying the full desktop rail (Media/Stock/Photos/Audio/Elements/Edit), and **pinch-to-zoom on the timeline** (midpoint-anchored, page pinch-zoom blocked inside the editor via touch-action).
