### PR TITLE
chore: add GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main, dev]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build packages (core -> timeline -> editor)
+        run: npm run build:packages
+
+      # Root `npm run typecheck` isn't scoped correctly across the monorepo yet
+      # (it can pull in apps/* and playground/* under the wrong tsconfig), so
+      # each workspace is typechecked individually against its own tsconfig.
+      - name: Typecheck packages/core
+        run: npm run typecheck --workspace=packages/core
+
+      - name: Typecheck packages/timeline
+        run: npm run typecheck --workspace=packages/timeline
+
+      - name: Typecheck packages/editor
+        run: npm run typecheck --workspace=packages/editor
+
+      - name: Typecheck apps/web
+        run: npm run typecheck --workspace=apps/web
+
+      - name: Test
+        run: npm test
+
+      - name: Check design-token drift
+        run: npm run lint:tokens
+
+      - name: Build apps/web
+        run: npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,16 +56,6 @@
         "typescript": "^5"
       }
     },
-    "apps/web/node_modules/@types/node": {
-      "version": "20.19.42",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.42.tgz",
-      "integrity": "sha512-5L7SUaFC1RyDraj2yRhyBzHTobyXHmohD100CChNtyPyleoq37Mqab5Gn8XEKI04dfN/oqPdpHk38MgcQWHbZg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
     "apps/web/node_modules/@types/react": {
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
@@ -111,13 +101,6 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "license": "MIT"
-    },
-    "apps/web/node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
@@ -2938,7 +2921,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.60.3",
@@ -2952,7 +2936,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.60.3",
@@ -2966,7 +2951,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.60.3",
@@ -2980,7 +2966,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.60.3",
@@ -2994,7 +2981,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.60.3",
@@ -3008,7 +2996,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.60.3",
@@ -3022,7 +3011,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.60.3",
@@ -3036,7 +3026,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.60.3",
@@ -3050,7 +3041,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.60.3",
@@ -3064,7 +3056,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
       "version": "4.60.3",
@@ -3078,7 +3071,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
       "version": "4.60.3",
@@ -3092,7 +3086,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.60.3",
@@ -3106,7 +3101,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
       "version": "4.60.3",
@@ -3120,7 +3116,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.60.3",
@@ -3134,7 +3131,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.60.3",
@@ -3148,7 +3146,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.60.3",
@@ -3162,7 +3161,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.60.3",
@@ -3176,7 +3176,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.60.3",
@@ -3190,7 +3191,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
       "version": "4.60.3",
@@ -3204,7 +3206,8 @@
       "optional": true,
       "os": [
         "openbsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
       "version": "4.60.3",
@@ -3218,7 +3221,8 @@
       "optional": true,
       "os": [
         "openharmony"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.60.3",
@@ -3232,7 +3236,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.60.3",
@@ -3246,7 +3251,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.60.3",
@@ -3260,7 +3266,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.60.3",
@@ -3274,7 +3281,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
@@ -3744,6 +3752,16 @@
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
@@ -12505,6 +12523,13 @@
         "node": ">=20.18.1"
       }
     },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/unified": {
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
@@ -13404,6 +13429,7 @@
         "zustand": "^5.0.3"
       },
       "devDependencies": {
+        "@types/node": "^20",
         "typescript": "^5.7.3",
         "vitest": "^3.0.6"
       }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -55,6 +55,7 @@
     "zustand": "^5.0.3"
   },
   "devDependencies": {
+    "@types/node": "^20",
     "typescript": "^5.7.3",
     "vitest": "^3.0.6"
   }

--- a/packages/core/src/media/audio/__tests__/AudioPlaybackController.test.ts
+++ b/packages/core/src/media/audio/__tests__/AudioPlaybackController.test.ts
@@ -62,7 +62,12 @@ function makeMockAudioContext() {
   function makeGain(initialValue = 1) {
     const gains: ReturnType<typeof makeGainParam>[] = []
 
-    function makeGainParam(v: number) {
+    function makeGainParam(v: number): {
+      value: number
+      cancelScheduledValues: ReturnType<typeof vi.fn>
+      setValueAtTime: ReturnType<typeof vi.fn>
+      linearRampToValueAtTime: ReturnType<typeof vi.fn>
+    } {
       const param = {
         value: v,
         cancelScheduledValues: vi.fn(),
@@ -443,7 +448,7 @@ describe('AudioPlaybackController', () => {
 
     // Grab the statechange handler registered on the mock context.
     const stateChangeCall = raw.addEventListener.mock.calls.find(
-      ([event]: [string]) => event === 'statechange',
+      (call: unknown[]) => call[0] === 'statechange',
     )
     expect(stateChangeCall).toBeDefined()
     const stateChangeHandler = stateChangeCall![1] as () => void
@@ -633,7 +638,7 @@ describe('AudioPlaybackController', () => {
 
     // trackGain is created after masterGain and clipGain → it's the 3rd gain.
     const rampedGains = gainInstances.filter(
-      (g) => g.gain.linearRampToValueAtTime.mock.calls.some(([v]: [number]) => v === 0.3),
+      (g) => g.gain.linearRampToValueAtTime.mock.calls.some((call: unknown[]) => call[0] === 0.3),
     )
     expect(rampedGains.length).toBeGreaterThan(0)
   })
@@ -690,7 +695,7 @@ describe('AudioPlaybackController', () => {
 
     // The clip gain should have been ramped to 0 (muted track → effective volume 0).
     const clipGain = gainInstances.find((g) =>
-      g.gain.linearRampToValueAtTime.mock.calls.some(([v]: [number]) => v === 0),
+      g.gain.linearRampToValueAtTime.mock.calls.some((call: unknown[]) => call[0] === 0),
     )
     expect(clipGain).toBeDefined()
   })

--- a/packages/core/src/renderer/gpu/__tests__/GoldenFrameHash.test.ts
+++ b/packages/core/src/renderer/gpu/__tests__/GoldenFrameHash.test.ts
@@ -54,6 +54,8 @@ function makeScene(overrides: Partial<Scene> = {}): Scene {
     audios: [],
     texts: [],
     images: [],
+    shapes: [],
+    freehand: [],
     transitions: [],
     ...overrides,
   }

--- a/packages/core/src/renderer/gpu/__tests__/RenderGraph.test.ts
+++ b/packages/core/src/renderer/gpu/__tests__/RenderGraph.test.ts
@@ -21,6 +21,8 @@ const STUB_SCENE: Scene = {
   audios: [],
   texts: [],
   images: [],
+  shapes: [],
+  freehand: [],
   transitions: [],
 }
 


### PR DESCRIPTION
## What does this PR do?

Adds a GitHub Actions CI workflow that runs on every PR (and on pushes to `main`/`dev`): install → build packages (core→timeline→editor) → typecheck each workspace → run tests → check design-token drift → build the website. Also fixes a handful of pre-existing `packages/core` type errors (test-only) that would otherwise make the new CI fail on day one for reasons unrelated to any given PR.

Closes #6

---

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Performance improvement

---

## How to test

1. Open this PR and confirm the "CI" check runs and passes.
2. Locally: `npm ci && npm run build:packages && npm run typecheck --workspace=packages/core --workspace=packages/timeline --workspace=packages/editor --workspace=apps/web && npm test && npm run lint:tokens && npm run build`
3. All steps should succeed with no errors.

---

## Notes

- Deviated slightly from issue #6: root-level `npm run typecheck` (`tsc --noEmit` with no `include`/`exclude`) isn't scoped correctly across the monorepo — it pulls in `apps/web` and `playground/*` under the wrong tsconfig context (missing path aliases, out-of-workspace deps). Typechecking is done per-workspace instead (`packages/core`, `packages/timeline`, `packages/editor`, `apps/web`), each against its own tsconfig, which is what's actually correct and green today.
- Added a website build step beyond the issue's ask, since a broken `next build` is a real regression worth catching per-PR.
- `packages/core` was missing `@types/node` (needed by a few test files using `node:fs`/`node:path`/`node:url`), and had 3 pre-existing type errors in test files (a circular-type inference issue, mock-call tuple destructuring, and `Scene` test fixtures missing `shapes`/`freehand`). Fixed all of them — test-only changes, no production code touched, all tests still pass (390 in core + 18 in timeline).

## Checklist

- [x] `npm test` passes
- [x] `npm run typecheck` passes (per-workspace, see above)
- [ ] I've tested this in the playground
- [x] No `any` types introduced without justification