### PR TITLE
ui: add standalone /editor route for the production editor

### DIFF
--- a/apps/web/app/editor/layout.tsx
+++ b/apps/web/app/editor/layout.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from 'next'
+// Published-package stylesheets: each @elah package ships its own compiled
+// Tailwind utilities (the app's Tailwind does not scan node_modules). The
+// --elah-* variables these classes consume are defined in globals.css .elah-root.
+import '@elah/timeline/styles.css'
+import '@elah/editor/styles.css'
+import '@/styles/playground.css'
+
+export const metadata: Metadata = {
+  title: 'Editor',
+}
+
+export default function EditorLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <div className="pg-shell">
+      <div className="pg-content">{children}</div>
+    </div>
+  )
+}

--- a/apps/web/app/editor/page.tsx
+++ b/apps/web/app/editor/page.tsx
@@ -1,0 +1,12 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+
+const ProductionEditor = dynamic(
+  () => import('@/components/playground/production/ProductionEditor'),
+  { ssr: false },
+)
+
+export default function EditorPage() {
+  return <ProductionEditor />
+}

--- a/apps/web/components/marketing/HeroSection.tsx
+++ b/apps/web/components/marketing/HeroSection.tsx
@@ -116,7 +116,7 @@ export function HeroSection() {
           {/* CTAs */}
           <motion.div variants={FADE_UP} className="mt-8 flex flex-wrap items-center gap-3">
             <Link
-              href="/playground/production"
+              href="/editor"
               className="inline-flex items-center gap-2 rounded bg-primary px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-primary-hover"
             >
               Try Now


### PR DESCRIPTION
## What does this PR do?

Adds a standalone `/editor` route that renders the production editor directly (no playground chrome), and repoints the landing page's "Try Now" CTA to it.

Closes #

---

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Performance improvement

---

## How to test

1. `npm run dev`, open `http://localhost:3001/editor`
2. Confirm the full editor UI renders (asset panel, preview, timeline, export/trace controls) and fills the viewport with no page-level scroll (only internal panels scroll), matching `/playground/production`
3. From the homepage (`/`), click "Try Now" and confirm it navigates to `/editor`

---

## Screenshots / Recording

-

---

## Checklist

- [x] `npm test` passes (44 files / 397 tests in `packages/core`, 3 files / 20 tests in `packages/timeline`)
- [x] I've tested this in the playground
- [x] No `any` types introduced without justification

---

## Note on known gaps (surfaced during self-review)

- `PlaygroundTabs` (rendered inside `ProductionEditor`'s header) hardcodes `/playground/*` hrefs and has no active-state match for `/editor`; clicking "Timeline"/"Raw" from `/editor` navigates away to `/playground/timeline`/`/playground/raw` since there's no `/editor` equivalent. Desktop-only (component is hidden on mobile).
- Other existing CTAs (homepage playground cards, `/playgrounds` listing, `/showcase`, docs getting-started) still link to `/playground/production`, so the editor is now reachable at two live, uncanonicalized URLs.
- `apps/web/app/editor/layout.tsx` and `apps/web/app/editor/page.tsx` are near-exact duplicates of `apps/web/app/playground/layout.tsx` and `apps/web/app/playground/production/page.tsx` respectively — open to extracting a shared wrapper if that's preferred over the current copy.
