### PR TITLE
ui: SEO/AEO coverage + landing page Lighthouse fixes (100s on desktop)

### DIFF
--- a/apps/web/app/blog/[slug]/page.tsx
+++ b/apps/web/app/blog/[slug]/page.tsx
@@ -5,6 +5,8 @@ import { ArrowLeft } from 'lucide-react'
 import { Navbar } from '@/components/marketing/Navbar'
 import { Footer } from '@/components/marketing/Footer'
 import { CodeBlock, InlineCode } from '@/components/docs/CodeBlock'
+import { JsonLd } from '@/components/seo/JsonLd'
+import { siteConfig } from '@/config/site'
 import { posts, getPost, categoryColors, type Block } from '../posts'
 
 export function generateStaticParams() {
@@ -22,11 +24,14 @@ export async function generateMetadata({
   return {
     title: post.title,
     description: post.excerpt,
+    alternates: { canonical: `/blog/${post.slug}` },
     openGraph: {
       type: 'article',
+      url: `/blog/${post.slug}`,
       title: post.title,
       description: post.excerpt,
       publishedTime: post.date,
+      authors: ['elah'],
     },
     twitter: { card: 'summary_large_image', title: post.title, description: post.excerpt },
   }
@@ -68,7 +73,7 @@ function renderBlock(block: Block, i: number) {
       return (
         <div key={i} className="mb-5 rounded-md border border-outline-variant bg-surface-low p-4">
           {block.title && (
-            <div className="label-mono mb-1 text-2xs text-on-surface-variant opacity-60">
+            <div className="label-mono mb-1 text-2xs text-on-surface-variant opacity-90">
               {block.title}
             </div>
           )}
@@ -108,8 +113,21 @@ export default async function BlogPostPage({
 
   const toc = post.content.filter((b): b is Extract<Block, { type: 'h2' }> => b.type === 'h2')
 
+  const articleJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'BlogPosting',
+    headline: post.title,
+    description: post.excerpt,
+    datePublished: post.date,
+    articleSection: post.category,
+    author: { '@type': 'Organization', name: 'elah', url: siteConfig.url },
+    publisher: { '@type': 'Organization', name: 'elah', url: siteConfig.url },
+    mainEntityOfPage: `${siteConfig.url}/blog/${post.slug}`,
+  }
+
   return (
     <div className="flex min-h-screen flex-col bg-surface">
+      <JsonLd data={articleJsonLd} />
       <Navbar />
 
       <main className="flex-1">
@@ -179,7 +197,7 @@ export default async function BlogPostPage({
             {toc.length > 0 && (
               <nav className="hidden w-48 shrink-0 lg:block">
                 <div className="sticky top-24">
-                  <div className="label-mono mb-3 text-2xs text-on-surface-variant opacity-60">
+                  <div className="label-mono mb-3 text-2xs text-on-surface-variant opacity-90">
                     On this page
                   </div>
                   <ul className="space-y-2">

--- a/apps/web/app/blog/page.tsx
+++ b/apps/web/app/blog/page.tsx
@@ -8,6 +8,7 @@ import { posts, categoryColors } from './posts'
 export const metadata: Metadata = {
   title: 'Blog',
   description: 'Engineering deep-dives, architecture decisions, and release notes from elah.',
+  alternates: { canonical: '/blog' },
 }
 
 export default function BlogPage() {
@@ -19,7 +20,7 @@ export default function BlogPage() {
         {/* Header */}
         <div className="border-b border-outline-variant bg-surface py-14">
           <div className="mx-auto max-w-7xl px-4 sm:px-6">
-            <div className="label-mono mb-3 text-2xs text-on-surface-variant opacity-60">Engineering</div>
+            <div className="label-mono mb-3 text-2xs text-on-surface-variant opacity-90">Engineering</div>
             <h1
               className="text-3xl font-semibold tracking-tight text-on-surface md:text-4xl"
               style={{ fontFamily: 'var(--font-inter), sans-serif' }}

--- a/apps/web/app/changelog/page.tsx
+++ b/apps/web/app/changelog/page.tsx
@@ -9,6 +9,7 @@ import { formatDate, cn } from '@/lib/utils'
 export const metadata: Metadata = {
   title: 'Changelog',
   description: `What's new in the elah packages (@elah/core, @elah/timeline, @elah/editor). Currently v${currentVersion}.`,
+  alternates: { canonical: '/changelog' },
 }
 
 const kindLabel: Record<ChangeKind, string> = {
@@ -32,7 +33,7 @@ export default function ChangelogPage() {
         {/* Header */}
         <div className="border-b border-outline-variant bg-surface py-14">
           <div className="mx-auto max-w-3xl px-4 sm:px-6">
-            <div className="label-mono mb-3 text-2xs text-on-surface-variant opacity-60">
+            <div className="label-mono mb-3 text-2xs text-on-surface-variant opacity-90">
               Changelog
             </div>
             <h1

--- a/apps/web/app/docs/api/page.tsx
+++ b/apps/web/app/docs/api/page.tsx
@@ -2,7 +2,12 @@ import type { Metadata } from 'next'
 import { CodeBlock } from '@/components/docs/CodeBlock'
 import { DocsToc } from '@/components/docs/DocsToc'
 
-export const metadata: Metadata = { title: 'API Reference' }
+export const metadata: Metadata = {
+  title: 'API Reference',
+  description:
+    'API reference for @elah/core, @elah/timeline, and @elah/editor: TimelineEngine, PlaybackEngine, resolveTimeline, GpuRenderer, hooks, and types.',
+  alternates: { canonical: '/docs/api' },
+}
 
 const toc = [
   { id: 'timeline-engine', title: 'TimelineEngine', level: 2 },
@@ -65,7 +70,7 @@ export default function ApiPage() {
     <div className="flex gap-12">
       <article className="min-w-0 flex-1 max-w-3xl">
         <div className="mb-8 pb-6 border-b border-outline-variant">
-          <div className="label-mono mb-2 text-2xs text-on-surface-variant opacity-60">Reference</div>
+          <div className="label-mono mb-2 text-2xs text-on-surface-variant opacity-90">Reference</div>
           <h1 className="text-3xl font-semibold tracking-tight text-on-surface" style={{ fontFamily: 'var(--font-inter), sans-serif' }}>
             API Reference
           </h1>

--- a/apps/web/app/docs/architecture/page.tsx
+++ b/apps/web/app/docs/architecture/page.tsx
@@ -2,7 +2,12 @@ import type { Metadata } from 'next'
 import { DocsToc } from '@/components/docs/DocsToc'
 import { MermaidDiagram } from '@/components/docs/MermaidDiagram'
 
-export const metadata: Metadata = { title: 'Architecture' }
+export const metadata: Metadata = {
+  title: 'Architecture',
+  description:
+    'How elah works: the three-ring state model, the timeline engine and its one mutation funnel, the playback clock, and the rendering engine built on a pure resolver.',
+  alternates: { canonical: '/docs/architecture' },
+}
 
 const toc = [
   { id: 'ring-states', title: 'Three-Ring State Model', level: 2 },
@@ -86,7 +91,7 @@ export default function ArchitecturePage() {
     <div className="flex gap-12">
       <article className="min-w-0 flex-1 max-w-3xl">
         <div className="mb-8 pb-6 border-b border-outline-variant">
-          <div className="label-mono mb-2 text-2xs text-on-surface-variant opacity-60">Architecture</div>
+          <div className="label-mono mb-2 text-2xs text-on-surface-variant opacity-90">Architecture</div>
           <h1 className="text-3xl font-semibold tracking-tight text-on-surface" style={{ fontFamily: 'var(--font-inter), sans-serif' }}>
             Architecture Overview
           </h1>
@@ -263,7 +268,7 @@ export default function ArchitecturePage() {
                         >
                           <span className="font-mono text-xs text-on-surface">{item.name}</span>
                           {item.note && (
-                            <span className="text-2xs text-on-surface-variant opacity-60">{item.note}</span>
+                            <span className="text-2xs text-on-surface-variant opacity-90">{item.note}</span>
                           )}
                         </div>
                       ))}

--- a/apps/web/app/docs/editor/page.tsx
+++ b/apps/web/app/docs/editor/page.tsx
@@ -2,7 +2,12 @@ import type { Metadata } from 'next'
 import { CodeBlock } from '@/components/docs/CodeBlock'
 import { DocsToc } from '@/components/docs/DocsToc'
 
-export const metadata: Metadata = { title: 'Editor' }
+export const metadata: Metadata = {
+  title: 'Editor',
+  description:
+    'The @elah/editor SDK: EditorProvider, Preview, AssetPanel, interactive transforms, text overlays, transitions, and stage aspect ratio.',
+  alternates: { canonical: '/docs/editor' },
+}
 
 const toc = [
   { id: 'editor-provider', title: 'EditorProvider', level: 2 },
@@ -19,7 +24,7 @@ export default function EditorPage() {
     <div className="flex gap-12">
       <article className="min-w-0 flex-1 max-w-3xl">
         <div className="mb-8 pb-6 border-b border-outline-variant">
-          <div className="label-mono mb-2 text-2xs text-on-surface-variant opacity-60">Editor</div>
+          <div className="label-mono mb-2 text-2xs text-on-surface-variant opacity-90">Editor</div>
           <h1 className="text-3xl font-semibold tracking-tight text-on-surface" style={{ fontFamily: 'var(--font-inter), sans-serif' }}>
             Editor
           </h1>
@@ -193,7 +198,7 @@ engine.updateClip(clipId, trackId, {
 // ExportWorker: applies via resolveDrawRect() placement math`}
           />
           <div className="mt-4 rounded-md border border-outline-variant bg-surface-low p-4">
-            <div className="label-mono mb-1 text-2xs text-on-surface-variant opacity-60">Status</div>
+            <div className="label-mono mb-1 text-2xs text-on-surface-variant opacity-90">Status</div>
             <p className="text-xs leading-relaxed text-on-surface-variant">
               Move and uniform scale are fully interactive. Rotation handle is partial — <code className="rounded bg-surface-container px-1.5 py-0.5 font-mono">transform.rotation</code> flows through both renderers but the interactive drag handle is not yet built.
             </p>

--- a/apps/web/app/docs/export/page.tsx
+++ b/apps/web/app/docs/export/page.tsx
@@ -2,7 +2,12 @@ import type { Metadata } from 'next'
 import { CodeBlock } from '@/components/docs/CodeBlock'
 import { DocsToc } from '@/components/docs/DocsToc'
 
-export const metadata: Metadata = { title: 'Export' }
+export const metadata: Metadata = {
+  title: 'Export',
+  description:
+    'Export a timeline to MP4 entirely in the browser with exportVideo(): Web Worker rendering on OffscreenCanvas, the audio pipeline, progress tracking, and browser limits.',
+  alternates: { canonical: '/docs/export' },
+}
 
 const toc = [
   { id: 'export-video', title: 'exportVideo()', level: 2 },
@@ -17,7 +22,7 @@ export default function ExportPage() {
     <div className="flex gap-12">
       <article className="min-w-0 flex-1 max-w-3xl">
         <div className="mb-8 pb-6 border-b border-outline-variant">
-          <div className="label-mono mb-2 text-2xs text-on-surface-variant opacity-60">Export</div>
+          <div className="label-mono mb-2 text-2xs text-on-surface-variant opacity-90">Export</div>
           <h1 className="text-3xl font-semibold tracking-tight text-on-surface" style={{ fontFamily: 'var(--font-inter), sans-serif' }}>
             Export Pipeline
           </h1>

--- a/apps/web/app/docs/getting-started/page.tsx
+++ b/apps/web/app/docs/getting-started/page.tsx
@@ -3,7 +3,12 @@ import Link from 'next/link'
 import { CodeBlock } from '@/components/docs/CodeBlock'
 import { DocsToc } from '@/components/docs/DocsToc'
 
-export const metadata: Metadata = { title: 'Quick Start' }
+export const metadata: Metadata = {
+  title: 'Quick Start',
+  description:
+    'Build a working browser video editor in minutes: mount EditorProvider, Preview, and Timeline, learn the keyboard shortcuts, and add clips programmatically.',
+  alternates: { canonical: '/docs/getting-started' },
+}
 
 const toc = [
   { id: 'timeline-only', title: 'Timeline Only', level: 2 },
@@ -18,7 +23,7 @@ export default function GettingStartedPage() {
     <div className="flex gap-12">
       <article className="min-w-0 flex-1 max-w-3xl">
         <div className="mb-8 pb-6 border-b border-outline-variant">
-          <div className="label-mono mb-2 text-2xs text-on-surface-variant opacity-60">Getting Started</div>
+          <div className="label-mono mb-2 text-2xs text-on-surface-variant opacity-90">Getting Started</div>
           <h1
             className="text-3xl font-semibold tracking-tight text-on-surface"
             style={{ fontFamily: 'var(--font-inter), sans-serif' }}
@@ -166,7 +171,7 @@ export default function App() {
 }`}
           />
           <div className="mt-4 rounded-md border border-outline-variant bg-surface-low p-4">
-            <div className="label-mono mb-1 text-2xs text-on-surface-variant opacity-60">Note</div>
+            <div className="label-mono mb-1 text-2xs text-on-surface-variant opacity-90">Note</div>
             <p className="text-xs leading-relaxed text-on-surface-variant">
               <code className="rounded bg-surface-container px-1.5 py-0.5 font-mono">{'<Preview>'}</code> paints interactive transform overlays automatically — drag/resize for video and image clips, inline-edit for text clips. No additional wiring needed.
             </p>
@@ -395,7 +400,7 @@ export function AddClipButton() {
 }`}
           />
           <div className="mt-4 rounded-md border border-outline-variant bg-surface-low p-4">
-            <div className="label-mono mb-1 text-2xs text-on-surface-variant opacity-60">Batch edits</div>
+            <div className="label-mono mb-1 text-2xs text-on-surface-variant opacity-90">Batch edits</div>
             <p className="mb-3 text-xs leading-relaxed text-on-surface-variant">
               Wrap multiple mutations in <code className="rounded bg-surface-container px-1.5 py-0.5 font-mono">engine.batch()</code> to commit them as a single undo entry:
             </p>

--- a/apps/web/app/docs/installation/page.tsx
+++ b/apps/web/app/docs/installation/page.tsx
@@ -2,7 +2,12 @@ import type { Metadata } from 'next'
 import { CodeBlock } from '@/components/docs/CodeBlock'
 import { DocsToc } from '@/components/docs/DocsToc'
 
-export const metadata: Metadata = { title: 'Installation' }
+export const metadata: Metadata = {
+  title: 'Installation',
+  description:
+    'Install @elah/editor and its peer dependencies, and configure Next.js or Vite to run the elah video editor SDK.',
+  alternates: { canonical: '/docs/installation' },
+}
 
 const toc = [
   { id: 'requirements', title: 'Requirements', level: 2 },
@@ -17,7 +22,7 @@ export default function InstallationPage() {
     <div className="flex gap-12">
       <article className="min-w-0 flex-1 max-w-3xl">
         <div className="mb-8 pb-6 border-b border-outline-variant">
-          <div className="label-mono mb-2 text-2xs text-on-surface-variant opacity-60">Getting Started</div>
+          <div className="label-mono mb-2 text-2xs text-on-surface-variant opacity-90">Getting Started</div>
           <h1
             id="installation"
             className="text-3xl font-semibold tracking-tight text-on-surface"
@@ -177,7 +182,7 @@ export default defineConfig({
 
         {/* Next */}
         <div className="rounded-md border border-outline-variant bg-surface-low p-5">
-          <div className="label-mono mb-1 text-2xs text-on-surface-variant opacity-60">Up Next</div>
+          <div className="label-mono mb-1 text-2xs text-on-surface-variant opacity-90">Up Next</div>
           <div className="text-sm font-medium text-on-surface mb-1">Quick Start</div>
           <p className="text-xs leading-relaxed text-on-surface-variant mb-3">
             Build the full editor in under 20 lines — wire your demuxer, mount Preview, and add the Timeline.

--- a/apps/web/app/docs/page.tsx
+++ b/apps/web/app/docs/page.tsx
@@ -5,7 +5,9 @@ import { DocsToc } from '@/components/docs/DocsToc'
 
 export const metadata: Metadata = {
   title: 'Documentation',
-  description: 'elah documentation. Browser-native video infrastructure.',
+  description:
+    'Documentation for elah, the browser-native video editing engine: installation, quick start, timeline and editor components, MP4 export, architecture, and API reference.',
+  alternates: { canonical: '/docs' },
 }
 
 const toc = [
@@ -22,7 +24,7 @@ export default function DocsPage() {
       <article className="min-w-0 flex-1 max-w-3xl">
         {/* Page header */}
         <div className="mb-8 pb-6 border-b border-outline-variant">
-          <div className="label-mono mb-2 text-2xs text-on-surface-variant opacity-60">
+          <div className="label-mono mb-2 text-2xs text-on-surface-variant opacity-90">
             elah
           </div>
           <h1

--- a/apps/web/app/docs/plugins/page.tsx
+++ b/apps/web/app/docs/plugins/page.tsx
@@ -2,7 +2,12 @@ import type { Metadata } from 'next'
 import { CodeBlock } from '@/components/docs/CodeBlock'
 import { DocsToc } from '@/components/docs/DocsToc'
 
-export const metadata: Metadata = { title: 'Plugins & Custom Renderers' }
+export const metadata: Metadata = {
+  title: 'Plugins & Custom Renderers',
+  description:
+    'Extend elah with custom renderers, custom layers, and custom demuxers — the supported extension points of the engine.',
+  alternates: { canonical: '/docs/plugins' },
+}
 
 const toc = [
   { id: 'custom-renderers', title: 'Custom Renderers', level: 2 },
@@ -15,7 +20,7 @@ export default function PluginsPage() {
     <div className="flex gap-12">
       <article className="min-w-0 flex-1 max-w-3xl">
         <div className="mb-8 pb-6 border-b border-outline-variant">
-          <div className="label-mono mb-2 text-2xs text-on-surface-variant opacity-60">Plugins</div>
+          <div className="label-mono mb-2 text-2xs text-on-surface-variant opacity-90">Plugins</div>
           <h1 className="text-3xl font-semibold tracking-tight text-on-surface" style={{ fontFamily: 'var(--font-inter), sans-serif' }}>
             Plugins & Custom Renderers
           </h1>

--- a/apps/web/app/docs/timeline/page.tsx
+++ b/apps/web/app/docs/timeline/page.tsx
@@ -2,7 +2,12 @@ import type { Metadata } from 'next'
 import { CodeBlock } from '@/components/docs/CodeBlock'
 import { DocsToc } from '@/components/docs/DocsToc'
 
-export const metadata: Metadata = { title: 'Timeline' }
+export const metadata: Metadata = {
+  title: 'Timeline',
+  description:
+    'The @elah/timeline React components: tracks and clips, playback, zooming and snapping, transitions, and keyboard shortcuts for drag, trim, and split.',
+  alternates: { canonical: '/docs/timeline' },
+}
 
 const toc = [
   { id: 'overview', title: 'Overview', level: 2 },
@@ -18,7 +23,7 @@ export default function TimelinePage() {
     <div className="flex gap-12">
       <article className="min-w-0 flex-1 max-w-3xl">
         <div className="mb-8 pb-6 border-b border-outline-variant">
-          <div className="label-mono mb-2 text-2xs text-on-surface-variant opacity-60">Timeline</div>
+          <div className="label-mono mb-2 text-2xs text-on-surface-variant opacity-90">Timeline</div>
           <h1 className="text-3xl font-semibold tracking-tight text-on-surface" style={{ fontFamily: 'var(--font-inter), sans-serif' }}>
             Timeline
           </h1>

--- a/apps/web/app/examples/page.tsx
+++ b/apps/web/app/examples/page.tsx
@@ -26,6 +26,7 @@ const fullExamples = [
 export const metadata: Metadata = {
   title: 'Examples',
   description: 'Code examples showing how to integrate elah for specific use cases.',
+  alternates: { canonical: '/examples' },
 }
 
 const examples = [
@@ -281,7 +282,7 @@ export default function ExamplesPage() {
         {/* Header */}
         <div className="border-b border-outline-variant bg-surface py-14">
           <div className="mx-auto max-w-7xl px-4 sm:px-6">
-            <div className="label-mono mb-3 text-2xs text-on-surface-variant opacity-60">Code</div>
+            <div className="label-mono mb-3 text-2xs text-on-surface-variant opacity-90">Code</div>
             <h1
               className="text-3xl font-semibold tracking-tight text-on-surface md:text-4xl"
               style={{ fontFamily: 'var(--font-inter), sans-serif' }}
@@ -297,7 +298,7 @@ export default function ExamplesPage() {
         {/* Complete example apps */}
         <div className="border-b border-outline-variant bg-surface-low py-12">
           <div className="mx-auto max-w-7xl px-4 sm:px-6">
-            <div className="label-mono mb-3 text-2xs text-on-surface-variant opacity-60">
+            <div className="label-mono mb-3 text-2xs text-on-surface-variant opacity-90">
               Full apps
             </div>
             <h2
@@ -330,7 +331,7 @@ export default function ExamplesPage() {
                     </h3>
                     <Github className="h-4 w-4 shrink-0 text-on-surface-variant transition-colors group-hover:text-on-surface" />
                   </div>
-                  <div className="label-mono mb-3 text-2xs text-on-surface-variant opacity-60">
+                  <div className="label-mono mb-3 text-2xs text-on-surface-variant opacity-90">
                     {ex.runtime}
                   </div>
                   <p className="flex-1 text-xs leading-relaxed text-on-surface-variant">

--- a/apps/web/app/feed.xml/route.ts
+++ b/apps/web/app/feed.xml/route.ts
@@ -1,0 +1,49 @@
+import { siteConfig } from '@/config/site'
+import { posts } from '../blog/posts'
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}
+
+export function GET(): Response {
+  const base = siteConfig.url
+
+  const items = [...posts]
+    .sort((a, b) => b.date.localeCompare(a.date))
+    .map((post) => {
+      const url = `${base}/blog/${post.slug}`
+      return `    <item>
+      <title>${escapeXml(post.title)}</title>
+      <link>${url}</link>
+      <guid isPermaLink="true">${url}</guid>
+      <pubDate>${new Date(post.date).toUTCString()}</pubDate>
+      <category>${escapeXml(post.category)}</category>
+      <description>${escapeXml(post.excerpt)}</description>
+    </item>`
+    })
+    .join('\n')
+
+  const body = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>${escapeXml(siteConfig.name)} blog</title>
+    <link>${base}/blog</link>
+    <description>Engineering deep-dives, architecture decisions, and release notes from elah.</description>
+    <language>en</language>
+    <atom:link href="${base}/feed.xml" rel="self" type="application/rss+xml"/>
+${items}
+  </channel>
+</rss>
+`
+
+  return new Response(body, {
+    headers: {
+      'Content-Type': 'application/rss+xml; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600, s-maxage=3600',
+    },
+  })
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -3,6 +3,7 @@ import { Inter, JetBrains_Mono } from 'next/font/google'
 import '@/styles/globals.css'
 import { siteConfig } from '@/config/site'
 import { ThemeProvider } from '@/components/ThemeProvider'
+import { JsonLd } from '@/components/seo/JsonLd'
 
 const inter = Inter({
   subsets: ['latin'],
@@ -18,6 +19,10 @@ const jetbrainsMono = JetBrains_Mono({
 })
 
 export const metadata: Metadata = {
+  // Required for canonical URLs and og:image/twitter:image resolution — every
+  // relative URL in metadata (including the file-based opengraph-image route)
+  // resolves against this.
+  metadataBase: new URL(siteConfig.url),
   title: {
     default: siteConfig.name,
     template: `%s — ${siteConfig.name}`,
@@ -49,6 +54,29 @@ export const viewport: Viewport = {
   width: 'device-width',
   initialScale: 1,
   viewportFit: 'cover',
+  themeColor: [
+    { media: '(prefers-color-scheme: light)', color: '#fcf9f8' },
+    { media: '(prefers-color-scheme: dark)', color: '#111010' },
+  ],
+}
+
+// Site-wide schema.org entities. Page-specific schema (SoftwareApplication,
+// FAQPage, BlogPosting) lives with the pages that own it.
+const organizationJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'Organization',
+  name: siteConfig.name,
+  url: siteConfig.url,
+  logo: `${siteConfig.url}/icon.png`,
+  sameAs: [siteConfig.links.github, 'https://www.npmjs.com/package/@elah/editor'],
+}
+
+const webSiteJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'WebSite',
+  name: siteConfig.name,
+  url: siteConfig.url,
+  description: siteConfig.description,
 }
 
 // Runs synchronously before first paint to avoid flash of wrong theme.
@@ -73,11 +101,21 @@ export default function RootLayout({
     <html lang="en" suppressHydrationWarning>
       <head>
         <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
+        {/* Plain <link> rather than metadata alternates.types: pages that set
+            their own `alternates` (canonicals) would replace it entirely. */}
+        <link
+          rel="alternate"
+          type="application/rss+xml"
+          title="elah blog"
+          href="/feed.xml"
+        />
       </head>
       <body
         className={`${inter.variable} ${jetbrainsMono.variable} bg-surface text-on-surface antialiased`}
         style={{ fontFamily: 'var(--font-inter), system-ui, sans-serif' }}
       >
+        <JsonLd data={organizationJsonLd} />
+        <JsonLd data={webSiteJsonLd} />
         <ThemeProvider>
           {children}
         </ThemeProvider>

--- a/apps/web/app/llms.txt/route.ts
+++ b/apps/web/app/llms.txt/route.ts
@@ -1,4 +1,5 @@
 import { siteConfig } from '@/config/site'
+import { posts } from '../blog/posts'
 
 /**
  * Generates /llms.txt — a curated, LLM-friendly index of the site's docs, per
@@ -32,11 +33,23 @@ const RESOURCES: DocLink[] = [
   { title: 'Playgrounds', path: '/playgrounds', description: 'Live, editable examples running the SDK in the browser.' },
   { title: 'Examples', path: '/examples', description: 'Focused code samples for common tasks.' },
   { title: 'Blog', path: '/blog', description: 'Engineering notes and release posts.' },
+  { title: 'Changelog', path: '/changelog', description: 'Release history for @elah/core, @elah/timeline, and @elah/editor.' },
+  { title: 'Pricing & licensing', path: '/pricing', description: 'Elah Community License terms: free to build on; commercial licensing for hosted/white-label products.' },
+  { title: 'Showcase', path: '/showcase', description: 'Projects and tools built with elah.' },
 ]
+
+// Derived from the blog source of truth so new posts appear automatically.
+const POSTS: DocLink[] = posts.map((post) => ({
+  title: post.title,
+  path: `/blog/${post.slug}`,
+  description: post.excerpt,
+}))
 
 const EXTERNAL: DocLink[] = [
   { title: 'GitHub repository', path: siteConfig.links.github, description: 'Source, ARCHITECTURE.md, and AGENTS.md (the brief for coding agents in the checkout).' },
   { title: '@elah/editor on npm', path: 'https://www.npmjs.com/package/@elah/editor', description: 'The full React editor SDK package.' },
+  { title: '@elah/timeline on npm', path: 'https://www.npmjs.com/package/@elah/timeline', description: 'React timeline UI components and hooks.' },
+  { title: '@elah/core on npm', path: 'https://www.npmjs.com/package/@elah/core', description: 'The framework-agnostic headless engine, resolver, renderer, and export pipeline.' },
 ]
 
 function section(title: string, links: DocLink[], base: string): string {
@@ -62,6 +75,8 @@ engine; \`resolveTimeline(frame, project) → Scene\` is the pure bridge to any 
 ${section('Documentation', DOCS, base)}
 
 ${section('Resources', RESOURCES, base)}
+
+${section('Blog posts', POSTS, base)}
 
 ${section('Source & packages', EXTERNAL, base)}
 `

--- a/apps/web/app/manifest.ts
+++ b/apps/web/app/manifest.ts
@@ -1,0 +1,15 @@
+import { type MetadataRoute } from 'next'
+import { siteConfig } from '@/config/site'
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: siteConfig.name,
+    short_name: siteConfig.name,
+    description: siteConfig.description,
+    start_url: '/',
+    display: 'standalone',
+    background_color: '#111010',
+    theme_color: '#111010',
+    icons: [{ src: '/icon.png', sizes: 'any', type: 'image/png' }],
+  }
+}

--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -1,6 +1,12 @@
+import type { Metadata } from 'next'
 import Link from 'next/link'
 import { Navbar } from '@/components/marketing/Navbar'
 import { Footer } from '@/components/marketing/Footer'
+
+export const metadata: Metadata = {
+  title: 'Page not found',
+  robots: { index: false },
+}
 
 export default function NotFound() {
   return (
@@ -8,7 +14,7 @@ export default function NotFound() {
       <Navbar />
       <main className="flex flex-1 items-center justify-center px-4">
         <div className="text-center">
-          <div className="label-mono mb-4 text-2xs text-on-surface-variant opacity-60">404</div>
+          <div className="label-mono mb-4 text-2xs text-on-surface-variant opacity-90">404</div>
           <h1
             className="text-3xl font-semibold tracking-tight text-on-surface"
             style={{ fontFamily: 'var(--font-inter), sans-serif' }}

--- a/apps/web/app/opengraph-image.tsx
+++ b/apps/web/app/opengraph-image.tsx
@@ -1,0 +1,81 @@
+import { ImageResponse } from 'next/og'
+
+// File-based OG image: Next serves this at /opengraph-image and injects
+// og:image + twitter:image tags for every route (root segment convention).
+export const alt = 'elah — a browser-native, frame-accurate video editing engine for the web'
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+
+export default function OpengraphImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          backgroundColor: '#111010',
+          padding: 72,
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
+          <div
+            style={{
+              width: 14,
+              height: 14,
+              borderRadius: 3,
+              backgroundColor: '#fcf9f8',
+            }}
+          />
+          <div style={{ fontSize: 28, color: '#9b9391', letterSpacing: 4 }}>
+            BROWSER-NATIVE VIDEO INFRASTRUCTURE
+          </div>
+        </div>
+
+        <div style={{ display: 'flex', flexDirection: 'column' }}>
+          <div
+            style={{
+              fontSize: 148,
+              fontWeight: 700,
+              color: '#fcf9f8',
+              letterSpacing: -6,
+              lineHeight: 1,
+            }}
+          >
+            elah
+          </div>
+          <div
+            style={{
+              marginTop: 28,
+              fontSize: 38,
+              color: '#c9c3c1',
+              lineHeight: 1.35,
+              maxWidth: 900,
+            }}
+          >
+            A browser-native, frame-accurate video editing engine. No servers.
+            Same frame, same pixels — always.
+          </div>
+        </div>
+
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            borderTop: '1px solid #312d2d',
+            paddingTop: 32,
+          }}
+        >
+          <div style={{ fontSize: 28, color: '#9b9391' }}>elah.dev</div>
+          <div style={{ fontSize: 28, color: '#9b9391' }}>
+            npm install @elah/editor
+          </div>
+        </div>
+      </div>
+    ),
+    size,
+  )
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,9 +1,32 @@
+import type { Metadata } from 'next'
 import { Navbar } from '@/components/marketing/Navbar'
 import { Footer } from '@/components/marketing/Footer'
 import { HeroSection } from '@/components/marketing/HeroSection'
 import { FeatureCard } from '@/components/marketing/FeatureCard'
 import { PlaygroundCard } from '@/components/marketing/PlaygroundCard'
 import { CTASection } from '@/components/marketing/CTASection'
+import { FAQSection } from '@/components/marketing/FAQSection'
+import { JsonLd } from '@/components/seo/JsonLd'
+import { siteConfig } from '@/config/site'
+import { currentVersion } from '@/config/changelog'
+
+export const metadata: Metadata = {
+  title: { absolute: 'elah — browser-native, frame-accurate video editing engine' },
+  alternates: { canonical: '/' },
+}
+
+const softwareJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'SoftwareApplication',
+  name: 'elah',
+  applicationCategory: 'DeveloperApplication',
+  operatingSystem: 'Any (web browser)',
+  description: siteConfig.description,
+  url: siteConfig.url,
+  softwareVersion: currentVersion,
+  offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+}
+
 const features = [
   {
     iconName: 'Clock',
@@ -103,6 +126,7 @@ const playgrounds = [
 export default function HomePage() {
   return (
     <div className="flex min-h-screen flex-col bg-surface">
+      <JsonLd data={softwareJsonLd} />
       <Navbar />
 
       <main className="flex-1">
@@ -112,7 +136,7 @@ export default function HomePage() {
         <section className="border-b border-outline-variant bg-surface py-20">
           <div className="mx-auto max-w-7xl px-4 sm:px-6">
             <div className="mb-10">
-              <div className="label-mono mb-3 text-2xs text-on-surface-variant opacity-60">
+              <div className="label-mono mb-3 text-2xs text-on-surface-variant opacity-90">
                 Architecture
               </div>
               <h2
@@ -137,7 +161,7 @@ export default function HomePage() {
         <section className="border-b border-outline-variant bg-surface-low py-20">
           <div className="mx-auto max-w-7xl px-4 sm:px-6">
             <div className="mb-10">
-              <div className="label-mono mb-3 text-2xs text-on-surface-variant opacity-60">
+              <div className="label-mono mb-3 text-2xs text-on-surface-variant opacity-90">
                 Data Flow
               </div>
               <h2
@@ -158,7 +182,7 @@ export default function HomePage() {
           <div className="mx-auto max-w-7xl px-4 sm:px-6">
             <div className="mb-10 flex items-end justify-between gap-4">
               <div>
-                <div className="label-mono mb-3 text-2xs text-on-surface-variant opacity-60">
+                <div className="label-mono mb-3 text-2xs text-on-surface-variant opacity-90">
                   Interactive
                 </div>
                 <h2
@@ -185,7 +209,7 @@ export default function HomePage() {
           <div className="mx-auto max-w-7xl px-4 sm:px-6">
             <div className="grid grid-cols-1 gap-10 lg:grid-cols-2">
               <div>
-                <div className="label-mono mb-3 text-2xs text-on-surface-variant opacity-60">
+                <div className="label-mono mb-3 text-2xs text-on-surface-variant opacity-90">
                   Integration
                 </div>
                 <h2
@@ -217,6 +241,8 @@ export default function HomePage() {
           </div>
         </section>
 
+        <FAQSection />
+
         <CTASection />
       </main>
 
@@ -243,10 +269,7 @@ function ArchitectureDiagram() {
           style={{ backgroundColor: i % 2 === 0 ? 'var(--color-surface-container)' : 'var(--color-surface-high)' }}
         >
           <div className="w-28 shrink-0">
-            <span
-              className="label-mono text-2xs text-on-surface-variant"
-              style={{ opacity: 0.7 }}
-            >
+            <span className="label-mono text-2xs text-on-surface-variant">
               {layer.label.toUpperCase()}
             </span>
           </div>
@@ -298,8 +321,8 @@ export default function App() {
   return (
     <div className="overflow-hidden rounded-md border border-outline-variant bg-[#0d0d0d]">
       <div className="flex items-center justify-between border-b border-white/10 px-4 py-2">
-        <span className="font-mono text-xs text-white/30">App.tsx</span>
-        <span className="label-mono text-2xs text-white/20">@elah/editor</span>
+        <span className="font-mono text-xs text-white/60">App.tsx</span>
+        <span className="label-mono text-2xs text-white/50">@elah/editor</span>
       </div>
       <pre
         className="overflow-x-auto p-4 text-xs leading-relaxed text-white/80"

--- a/apps/web/app/playground/production/layout.tsx
+++ b/apps/web/app/playground/production/layout.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from 'next'
+
+// The page itself is a client component, so metadata lives in this layout.
+export const metadata: Metadata = {
+  title: 'Full Editor',
+  description:
+    'The complete @elah/editor composition running live: asset panel, GPU-accelerated preview, interactive overlays, timeline, audio, and MP4 export.',
+  alternates: { canonical: '/playground/production' },
+}
+
+export default function ProductionLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return children
+}

--- a/apps/web/app/playground/raw/layout.tsx
+++ b/apps/web/app/playground/raw/layout.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from 'next'
+
+// The page itself is a client component, so metadata lives in this layout.
+export const metadata: Metadata = {
+  title: 'Full Editor Demo',
+  description:
+    'A guided elah demo with pre-loaded sample media — cut, trim, text, transitions, and export in a single session.',
+  alternates: { canonical: '/playground/raw' },
+}
+
+export default function RawPlaygroundLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return children
+}

--- a/apps/web/app/playground/timeline/layout.tsx
+++ b/apps/web/app/playground/timeline/layout.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from 'next'
+
+// The page itself is a client component, so metadata lives in this layout.
+export const metadata: Metadata = {
+  title: 'Timeline Only',
+  description:
+    'An isolated @elah/timeline demo: tracks, clips, snapping, keyboard shortcuts, and the TimelineEngine without the full editor stack.',
+  alternates: { canonical: '/playground/timeline' },
+}
+
+export default function TimelinePlaygroundLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return children
+}

--- a/apps/web/app/playgrounds/page.tsx
+++ b/apps/web/app/playgrounds/page.tsx
@@ -7,6 +7,7 @@ import { Terminal } from 'lucide-react'
 export const metadata: Metadata = {
   title: 'Playgrounds',
   description: 'Interactive playground environments for elah. Explore the full editor, timeline-only, and demo modes.',
+  alternates: { canonical: '/playgrounds' },
 }
 
 const playgrounds = [
@@ -69,7 +70,7 @@ export default function PlaygroundsPage() {
         {/* Header */}
         <div className="border-b border-outline-variant bg-surface">
           <div className="mx-auto max-w-7xl px-4 py-12 sm:px-6">
-            <div className="label-mono mb-3 text-2xs text-on-surface-variant opacity-60">
+            <div className="label-mono mb-3 text-2xs text-on-surface-variant opacity-90">
               Interactive
             </div>
             <h1
@@ -105,7 +106,7 @@ export default function PlaygroundsPage() {
 
                 {/* Feature list */}
                 <div className="rounded-md border border-outline-variant bg-surface-low p-4">
-                  <div className="label-mono mb-2 text-2xs text-on-surface-variant opacity-60">
+                  <div className="label-mono mb-2 text-2xs text-on-surface-variant opacity-90">
                     What you can explore
                   </div>
                   <ul className="space-y-1.5">
@@ -125,7 +126,7 @@ export default function PlaygroundsPage() {
         {/* Tech breakdown */}
         <div className="border-t border-outline-variant bg-surface-low py-16">
           <div className="mx-auto max-w-7xl px-4 sm:px-6">
-            <div className="label-mono mb-6 text-2xs text-on-surface-variant opacity-60">
+            <div className="label-mono mb-6 text-2xs text-on-surface-variant opacity-90">
               What powers the playgrounds
             </div>
             <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
@@ -140,7 +141,7 @@ export default function PlaygroundsPage() {
                 { label: 'Audio', value: 'Web Audio API', sub: 'Main-thread scheduling' },
               ].map(({ label, value, sub }) => (
                 <div key={label} className="rounded-md border border-outline-variant bg-surface-container p-4">
-                  <div className="label-mono mb-1 text-2xs text-on-surface-variant opacity-60">{label}</div>
+                  <div className="label-mono mb-1 text-2xs text-on-surface-variant opacity-90">{label}</div>
                   <div className="text-sm font-medium text-on-surface">{value}</div>
                   <div className="mt-0.5 text-xs text-on-surface-variant">{sub}</div>
                 </div>

--- a/apps/web/app/pricing/page.tsx
+++ b/apps/web/app/pricing/page.tsx
@@ -8,6 +8,7 @@ export const metadata: Metadata = {
   title: 'Pricing',
   description:
     'elah is open source and free to build on. Commercial licensing is available — get in touch.',
+  alternates: { canonical: '/pricing' },
 }
 
 const openSourceIncludes = [
@@ -26,7 +27,7 @@ export default function PricingPage() {
         {/* Header */}
         <div className="border-b border-outline-variant bg-surface py-14">
           <div className="mx-auto max-w-7xl px-4 sm:px-6">
-            <div className="label-mono mb-3 text-2xs text-on-surface-variant opacity-60">
+            <div className="label-mono mb-3 text-2xs text-on-surface-variant opacity-90">
               Pricing
             </div>
             <h1
@@ -48,7 +49,7 @@ export default function PricingPage() {
           <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
             {/* Open source */}
             <div className="flex flex-col rounded-lg border border-outline-variant bg-surface-container p-7">
-              <div className="label-mono mb-2 text-2xs text-on-surface-variant opacity-60">
+              <div className="label-mono mb-2 text-2xs text-on-surface-variant opacity-90">
                 Open source
               </div>
               <h2
@@ -92,7 +93,7 @@ export default function PricingPage() {
 
             {/* Commercial / contact */}
             <div className="flex flex-col rounded-lg border border-primary/40 bg-surface-low p-7">
-              <div className="label-mono mb-2 text-2xs text-on-surface-variant opacity-60">
+              <div className="label-mono mb-2 text-2xs text-on-surface-variant opacity-90">
                 Commercial &amp; support
               </div>
               <h2

--- a/apps/web/app/showcase/page.tsx
+++ b/apps/web/app/showcase/page.tsx
@@ -6,6 +6,7 @@ import { ExternalLink, Layers, Clock, FileVideo, Cpu } from 'lucide-react'
 export const metadata: Metadata = {
   title: 'Showcase',
   description: 'Projects and tools built with elah.',
+  alternates: { canonical: '/showcase' },
 }
 
 const showcaseItems = [
@@ -56,7 +57,7 @@ export default function ShowcasePage() {
         {/* Header */}
         <div className="border-b border-outline-variant bg-surface py-14">
           <div className="mx-auto max-w-7xl px-4 sm:px-6">
-            <div className="label-mono mb-3 text-2xs text-on-surface-variant opacity-60">Showcase</div>
+            <div className="label-mono mb-3 text-2xs text-on-surface-variant opacity-90">Showcase</div>
             <h1
               className="text-3xl font-semibold tracking-tight text-on-surface md:text-4xl"
               style={{ fontFamily: 'var(--font-inter), sans-serif' }}
@@ -155,7 +156,7 @@ export default function ShowcasePage() {
 
           {/* Submit */}
           <div className="mt-12 rounded-md border border-outline-variant bg-surface-low p-6">
-            <div className="label-mono mb-2 text-2xs text-on-surface-variant opacity-60">Built something?</div>
+            <div className="label-mono mb-2 text-2xs text-on-surface-variant opacity-90">Built something?</div>
             <h3 className="mb-1 text-sm font-semibold text-on-surface">
               Share your project
             </h3>

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -1,5 +1,20 @@
 import { type MetadataRoute } from 'next'
 import { siteConfig } from '@/config/site'
+import { posts } from './blog/posts'
+
+// Keep in sync with the route tree and with app/llms.txt/route.ts.
+const DOCS_PAGES = [
+  'installation',
+  'getting-started',
+  'timeline',
+  'editor',
+  'export',
+  'api',
+  'architecture',
+  'plugins',
+]
+
+const PLAYGROUND_PAGES = ['production', 'timeline', 'raw']
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const base = siteConfig.url
@@ -7,16 +22,29 @@ export default function sitemap(): MetadataRoute.Sitemap {
   return [
     { url: base, lastModified: new Date(), changeFrequency: 'weekly', priority: 1 },
     { url: `${base}/docs`, lastModified: new Date(), changeFrequency: 'weekly', priority: 0.9 },
-    { url: `${base}/docs/installation`, lastModified: new Date(), changeFrequency: 'monthly', priority: 0.8 },
-    { url: `${base}/docs/getting-started`, lastModified: new Date(), changeFrequency: 'monthly', priority: 0.8 },
-    { url: `${base}/docs/timeline`, lastModified: new Date(), changeFrequency: 'monthly', priority: 0.8 },
-    { url: `${base}/docs/editor`, lastModified: new Date(), changeFrequency: 'monthly', priority: 0.8 },
-    { url: `${base}/docs/export`, lastModified: new Date(), changeFrequency: 'monthly', priority: 0.8 },
-    { url: `${base}/docs/api`, lastModified: new Date(), changeFrequency: 'monthly', priority: 0.8 },
+    ...DOCS_PAGES.map((slug) => ({
+      url: `${base}/docs/${slug}`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly' as const,
+      priority: 0.8,
+    })),
     { url: `${base}/playgrounds`, lastModified: new Date(), changeFrequency: 'weekly', priority: 0.7 },
     { url: `${base}/examples`, lastModified: new Date(), changeFrequency: 'weekly', priority: 0.7 },
+    ...PLAYGROUND_PAGES.map((slug) => ({
+      url: `${base}/playground/${slug}`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly' as const,
+      priority: 0.6,
+    })),
     { url: `${base}/showcase`, lastModified: new Date(), changeFrequency: 'weekly', priority: 0.6 },
     { url: `${base}/blog`, lastModified: new Date(), changeFrequency: 'weekly', priority: 0.6 },
+    ...posts.map((post) => ({
+      url: `${base}/blog/${post.slug}`,
+      lastModified: new Date(post.date),
+      changeFrequency: 'yearly' as const,
+      priority: 0.6,
+    })),
+    { url: `${base}/changelog`, lastModified: new Date(), changeFrequency: 'weekly', priority: 0.5 },
     { url: `${base}/pricing`, lastModified: new Date(), changeFrequency: 'monthly', priority: 0.5 },
   ]
 }

--- a/apps/web/components/docs/CodeBlock.tsx
+++ b/apps/web/components/docs/CodeBlock.tsx
@@ -35,7 +35,7 @@ export function CodeBlock({
           {filename ? (
             <span className="font-mono text-xs text-on-surface-variant">{filename}</span>
           ) : (
-            <span className="label-mono text-2xs text-on-surface-variant opacity-60">{language}</span>
+            <span className="label-mono text-2xs text-on-surface-variant opacity-90">{language}</span>
           )}
         </div>
         <button

--- a/apps/web/components/marketing/CTASection.tsx
+++ b/apps/web/components/marketing/CTASection.tsx
@@ -16,7 +16,7 @@ export function CTASection() {
           className="flex flex-col items-start gap-8 md:flex-row md:items-center md:justify-between"
         >
           <div>
-            <div className="label-mono mb-3 text-2xs text-on-surface-variant opacity-60">
+            <div className="label-mono mb-3 text-2xs text-on-surface-variant opacity-90">
               Ready to build
             </div>
             <h2

--- a/apps/web/components/marketing/FAQSection.tsx
+++ b/apps/web/components/marketing/FAQSection.tsx
@@ -1,0 +1,89 @@
+import { ChevronDown } from 'lucide-react'
+import { JsonLd } from '@/components/seo/JsonLd'
+
+// Rendered as native <details> so the answers are crawlable without JS, and
+// mirrored as FAQPage JSON-LD for answer engines. Keep both lists in sync.
+const faqs = [
+  {
+    question: 'Does elah need a server to edit or export video?',
+    answer:
+      'No. Decoding (WebCodecs), rendering (WebGL2), and MP4 export (a Web Worker drawing to an OffscreenCanvas) all run in the browser. Footage never leaves the user’s machine, and there is no render farm to pay for.',
+  },
+  {
+    question: 'What can I build with elah?',
+    answer:
+      'An embeddable video editor inside your own product: the SDK ships EditorProvider, Preview, AssetPanel, and Timeline React components on top of a headless TypeScript engine, so you can compose a full editor in under 20 lines or drive the engine directly.',
+  },
+  {
+    question: 'Is the exported video identical to the preview?',
+    answer:
+      'Yes. Preview and export run the same pure resolver — resolveTimeline(frame, project) → Scene — and the same placement math, so the frame you scrub is the frame you ship. Same project, same frame, same pixels.',
+  },
+  {
+    question: 'How is elah different from Remotion?',
+    answer:
+      'Remotion turns React components into video, typically rendered by headless Chromium on a server. elah is an editing engine: an integer-frame timeline data model with undo history, drag/trim/split UI, and in-browser GPU export — the foundation for a user-facing editor rather than programmatic composition.',
+  },
+  {
+    question: 'Which frameworks does elah support?',
+    answer:
+      'The core engine is framework-agnostic TypeScript with zero React imports. React and Next.js bindings ship today via @elah/editor and @elah/timeline; React Native support is experimental, with more frameworks planned.',
+  },
+  {
+    question: 'Is elah open source?',
+    answer:
+      'elah is source-available under the Elah Community License: free for personal, educational, research, and commercial internal use, and free to embed in your own applications. Offering elah as a hosted or white-label editor product requires a commercial license.',
+  },
+  {
+    question: 'What export formats does elah support?',
+    answer:
+      'MP4 with H.264 video by default (VP9 and VP8 are also available) and AAC or Opus audio, at any aspect ratio — 9:16, 16:9, 1:1, or a custom stage — up to the project’s native resolution.',
+  },
+]
+
+const faqJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqs.map(({ question, answer }) => ({
+    '@type': 'Question',
+    name: question,
+    acceptedAnswer: { '@type': 'Answer', text: answer },
+  })),
+}
+
+export function FAQSection() {
+  return (
+    <section id="faq" className="border-b border-outline-variant bg-surface py-20">
+      <JsonLd data={faqJsonLd} />
+      <div className="mx-auto max-w-7xl px-4 sm:px-6">
+        <div className="mb-10">
+          <div className="label-mono mb-3 text-2xs text-on-surface-variant opacity-90">
+            FAQ
+          </div>
+          <h2
+            className="text-2xl font-semibold tracking-tight text-on-surface md:text-3xl"
+            style={{ fontFamily: 'var(--font-inter), sans-serif' }}
+          >
+            Common questions.
+          </h2>
+        </div>
+        <div className="mx-auto max-w-3xl space-y-2">
+          {faqs.map(({ question, answer }) => (
+            <details
+              key={question}
+              className="group rounded-md border border-outline-variant bg-surface-container"
+            >
+              <summary className="flex cursor-pointer list-none items-center justify-between gap-4 px-5 py-4 text-sm font-medium text-on-surface [&::-webkit-details-marker]:hidden">
+                {question}
+                <ChevronDown className="h-4 w-4 shrink-0 text-on-surface-variant transition-transform group-open:rotate-180" />
+              </summary>
+              <p className="px-5 pb-4 text-sm leading-relaxed text-on-surface-variant">
+                {answer}
+              </p>
+            </details>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/apps/web/components/marketing/Footer.tsx
+++ b/apps/web/components/marketing/Footer.tsx
@@ -81,7 +81,7 @@ export function Footer() {
           <p className="text-xs text-on-surface-variant">
             © {new Date().getFullYear()} Elah Labs Private Limited. Source-available under the ECL v1.0 license.
           </p>
-          <p className="label-mono text-2xs text-on-surface-variant opacity-60">
+          <p className="label-mono text-2xs text-on-surface-variant opacity-90">
             Built with Next.js · Deployed on Vercel
           </p>
         </div>

--- a/apps/web/components/marketing/HeroSection.tsx
+++ b/apps/web/components/marketing/HeroSection.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from 'react'
 import Link from 'next/link'
-import { motion } from 'framer-motion'
 import { ArrowRight, Check, Copy, Play } from 'lucide-react'
 
 function InstallCommand() {
@@ -34,14 +33,14 @@ function InstallCommand() {
   )
 }
 
-const FADE_UP = {
-  initial: { opacity: 0, y: 8 },
-  animate: { opacity: 1, y: 0 },
-}
-
-const STAGGER = {
-  animate: { transition: { staggerChildren: 0.08 } },
-}
+// Entrance animation is the CSS `.fade-up` class (globals.css), not
+// framer-motion: motion's initial={opacity: 0} is server-rendered inline, so
+// the hero — including the LCP text — stayed invisible until hydration. The
+// headline and subheadline get no animation at all so LCP lands at first paint.
+const fadeUp = (step: number) => ({
+  className: 'fade-up',
+  style: { '--fade-delay': step } as React.CSSProperties,
+})
 
 export function HeroSection() {
   return (
@@ -61,118 +60,123 @@ export function HeroSection() {
       />
 
       <div className="relative mx-auto max-w-7xl px-4 sm:px-6">
-        <motion.div variants={STAGGER} initial="initial" animate="animate" className="max-w-3xl">
+        <div className="max-w-3xl">
           {/* Technical badge */}
-          <motion.div variants={FADE_UP} className="mb-6 flex items-center gap-2">
-            <span className="label-mono rounded border border-outline-variant bg-surface-container px-2.5 py-1 text-2xs text-on-surface-variant">
-              Open Source · ECL v1.0
-            </span>
-            <span className="label-mono rounded border border-outline-variant bg-surface-container px-2.5 py-1 text-2xs text-on-surface-variant">
-              WebCodecs + WebGL2
-            </span>
-          </motion.div>
+          <div {...fadeUp(0)}>
+            <div className="mb-6 flex items-center gap-2">
+              <span className="label-mono rounded border border-outline-variant bg-surface-container px-2.5 py-1 text-2xs text-on-surface-variant">
+                Open Source · ECL v1.0
+              </span>
+              <span className="label-mono rounded border border-outline-variant bg-surface-container px-2.5 py-1 text-2xs text-on-surface-variant">
+                WebCodecs + WebGL2
+              </span>
+            </div>
+          </div>
 
-          {/* Headline */}
-          <motion.h1
-            variants={FADE_UP}
+          {/* Headline — no entrance animation: this is the LCP element */}
+          <h1
             className="text-4xl font-semibold leading-tight tracking-tight text-on-surface md:text-5xl lg:text-6xl"
             style={{ fontFamily: 'var(--font-inter), system-ui, sans-serif' }}
           >
             Browser-Native
             <br />
             <span className="text-primary">Video Infrastructure</span>
-          </motion.h1>
+          </h1>
 
-          {/* Subheadline */}
-          <motion.p
-            variants={FADE_UP}
+          {/* Subheadline — static for the same reason */}
+          <p
             className="mt-5 max-w-2xl text-base leading-relaxed text-on-surface-variant md:text-lg"
             style={{ fontFamily: 'var(--font-inter), system-ui, sans-serif' }}
           >
             elah provides the timeline, rendering, and editing foundation for
             professional creative applications built entirely on the web. Engine-first,
             renderer-agnostic, scalable from prototype to production.
-          </motion.p>
+          </p>
 
           {/* Framework support */}
-          <motion.div variants={FADE_UP} className="mt-6 flex flex-wrap items-center gap-2">
-            <span className="label-mono text-2xs text-on-surface-variant opacity-60">
-              Framework-agnostic core ·
-            </span>
-            <span className="label-mono rounded border border-primary/40 bg-primary/10 px-2.5 py-1 text-2xs text-primary">
-              Next.js
-            </span>
-            <span className="label-mono rounded border border-primary/40 bg-primary/10 px-2.5 py-1 text-2xs text-primary">
-              React
-            </span>
-            <span className="label-mono rounded border border-outline-variant bg-surface-container px-2.5 py-1 text-2xs text-on-surface-variant">
-              React Native · experimental
-            </span>
-            <span className="label-mono rounded border border-dashed border-outline-variant bg-surface-container px-2.5 py-1 text-2xs text-on-surface-variant opacity-70">
-              More frameworks coming soon
-            </span>
-          </motion.div>
+          <div {...fadeUp(1)}>
+            <div className="mt-6 flex flex-wrap items-center gap-2">
+              <span className="label-mono text-2xs text-on-surface-variant opacity-90">
+                Framework-agnostic core ·
+              </span>
+              <span className="label-mono rounded border border-primary/40 bg-primary/10 px-2.5 py-1 text-2xs text-primary">
+                Next.js
+              </span>
+              <span className="label-mono rounded border border-primary/40 bg-primary/10 px-2.5 py-1 text-2xs text-primary">
+                React
+              </span>
+              <span className="label-mono rounded border border-outline-variant bg-surface-container px-2.5 py-1 text-2xs text-on-surface-variant">
+                React Native · experimental
+              </span>
+              <span className="label-mono rounded border border-dashed border-outline-variant bg-surface-container px-2.5 py-1 text-2xs text-on-surface-variant">
+                More frameworks coming soon
+              </span>
+            </div>
+          </div>
 
           {/* CTAs */}
-          <motion.div variants={FADE_UP} className="mt-8 flex flex-wrap items-center gap-3">
-            <Link
-              href="/playground/production"
-              className="inline-flex items-center gap-2 rounded bg-primary px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-primary-hover"
-            >
-              Try Now
-              <ArrowRight className="h-3.5 w-3.5" />
-            </Link>
-            <Link
-              href="/docs/getting-started"
-              className="inline-flex items-center gap-2 rounded border border-outline-variant bg-transparent px-4 py-2.5 text-sm font-medium text-on-surface transition-colors hover:bg-surface-container"
-            >
-              Get Started
-            </Link>
-            <Link
-              href="/docs"
-              className="inline-flex items-center gap-2 rounded border border-outline-variant bg-transparent px-4 py-2.5 text-sm font-medium text-on-surface transition-colors hover:bg-surface-container"
-            >
-              View Docs
-            </Link>
-            <Link
-              href="/playgrounds"
-              className="inline-flex items-center gap-2 rounded border border-outline-variant bg-transparent px-4 py-2.5 text-sm font-medium text-on-surface transition-colors hover:bg-surface-container"
-            >
-              <Play className="h-3.5 w-3.5" />
-              Open Playgrounds
-            </Link>
-          </motion.div>
+          <div {...fadeUp(2)}>
+            <div className="mt-8 flex flex-wrap items-center gap-3">
+              <Link
+                href="/playground/production"
+                className="inline-flex items-center gap-2 rounded bg-primary px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-primary-hover"
+              >
+                Try Now
+                <ArrowRight className="h-3.5 w-3.5" />
+              </Link>
+              <Link
+                href="/docs/getting-started"
+                className="inline-flex items-center gap-2 rounded border border-outline-variant bg-transparent px-4 py-2.5 text-sm font-medium text-on-surface transition-colors hover:bg-surface-container"
+              >
+                Get Started
+              </Link>
+              <Link
+                href="/docs"
+                className="inline-flex items-center gap-2 rounded border border-outline-variant bg-transparent px-4 py-2.5 text-sm font-medium text-on-surface transition-colors hover:bg-surface-container"
+              >
+                View Docs
+              </Link>
+              <Link
+                href="/playgrounds"
+                className="inline-flex items-center gap-2 rounded border border-outline-variant bg-transparent px-4 py-2.5 text-sm font-medium text-on-surface transition-colors hover:bg-surface-container"
+              >
+                <Play className="h-3.5 w-3.5" />
+                Open Playgrounds
+              </Link>
+            </div>
+          </div>
 
           {/* Install command */}
-          <motion.div variants={FADE_UP} className="mt-6">
-            <InstallCommand />
-          </motion.div>
+          <div {...fadeUp(3)}>
+            <div className="mt-6">
+              <InstallCommand />
+            </div>
+          </div>
 
           {/* Technical stats */}
-          <motion.div variants={FADE_UP} className="mt-10 flex flex-wrap gap-x-8 gap-y-3">
-            {[
-              { label: 'Time model', value: 'Integer frames' },
-              { label: 'Renderer', value: 'WebGL2 / OffscreenCanvas' },
-              { label: 'Decode', value: 'WebCodecs + mediabunny' },
-              { label: 'Audio', value: 'Web Audio API' },
-            ].map((stat) => (
-              <div key={stat.label}>
-                <div className="label-mono text-2xs text-on-surface-variant opacity-60">{stat.label}</div>
-                <div className="mt-0.5 font-mono text-xs text-on-surface">{stat.value}</div>
-              </div>
-            ))}
-          </motion.div>
-        </motion.div>
+          <div {...fadeUp(4)}>
+            <div className="mt-10 flex flex-wrap gap-x-8 gap-y-3">
+              {[
+                { label: 'Time model', value: 'Integer frames' },
+                { label: 'Renderer', value: 'WebGL2 / OffscreenCanvas' },
+                { label: 'Decode', value: 'WebCodecs + mediabunny' },
+                { label: 'Audio', value: 'Web Audio API' },
+              ].map((stat) => (
+                <div key={stat.label}>
+                  <div className="label-mono text-2xs text-on-surface-variant opacity-90">{stat.label}</div>
+                  <div className="mt-0.5 font-mono text-xs text-on-surface">{stat.value}</div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
 
         {/* Editor mockup */}
-        <motion.div
-          initial={{ opacity: 0, y: 16 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.4, duration: 0.5 }}
-          className="mt-16"
-        >
-          <EditorMockup />
-        </motion.div>
+        <div {...fadeUp(5)}>
+          <div className="mt-16">
+            <EditorMockup />
+          </div>
+        </div>
       </div>
     </section>
   )
@@ -187,7 +191,7 @@ function EditorMockup() {
         <div className="h-2.5 w-2.5 rounded-full bg-yellow-500/80" />
         <div className="h-2.5 w-2.5 rounded-full bg-green-500/80" />
         <div className="ml-3 h-5 flex-1 rounded border border-white/10 bg-white/5 px-2 flex items-center">
-          <span className="font-mono text-2xs text-white/30">elah · Full Editor</span>
+          <span className="font-mono text-2xs text-white/60">elah · Full Editor</span>
         </div>
       </div>
 
@@ -195,7 +199,7 @@ function EditorMockup() {
       <div className="flex" style={{ height: '320px' }}>
         {/* Asset panel */}
         <div className="w-44 shrink-0 border-r border-white/10 bg-[#0a0a0a] p-3">
-          <div className="label-mono mb-2 text-2xs text-white/30">MEDIA LIBRARY</div>
+          <div className="label-mono mb-2 text-2xs text-white/60">MEDIA LIBRARY</div>
           {['intro.mp4', 'bg-music.mp3', 'logo.png', 'title.txt'].map((file, i) => (
             <div
               key={file}
@@ -222,7 +226,7 @@ function EditorMockup() {
             </div>
           </div>
           {/* Timecode */}
-          <div className="absolute bottom-3 right-4 font-mono text-xs text-white/30">00:00:02:15</div>
+          <div className="absolute bottom-3 right-4 font-mono text-xs text-white/60">00:00:02:15</div>
         </div>
       </div>
 
@@ -232,7 +236,7 @@ function EditorMockup() {
         <div className="mb-2 flex items-center border-b border-white/10 pb-1">
           {Array.from({ length: 12 }).map((_, i) => (
             <div key={i} className="flex-1 border-l border-white/10 pl-1">
-              <span className="font-mono text-2xs text-white/20">{i * 5}s</span>
+              <span className="font-mono text-2xs text-white/50">{i * 5}s</span>
             </div>
           ))}
         </div>
@@ -243,7 +247,7 @@ function EditorMockup() {
           { label: 'TEXT', color: '#3a2a4a', clips: [{ start: 10, width: 15 }, { start: 50, width: 20 }] },
         ].map((track) => (
           <div key={track.label} className="mb-1 flex items-center gap-2">
-            <div className="label-mono w-10 text-right text-2xs text-white/30">{track.label}</div>
+            <div className="label-mono w-10 text-right text-2xs text-white/60">{track.label}</div>
             <div className="relative flex-1 rounded" style={{ height: '18px', background: '#111' }}>
               {track.clips.map((clip, i) => (
                 <div

--- a/apps/web/components/marketing/PlaygroundCard.tsx
+++ b/apps/web/components/marketing/PlaygroundCard.tsx
@@ -133,7 +133,7 @@ function FullEditorPreview({ color }: { color: string }) {
         <div className="w-12 border-r border-white/10 bg-black/40" />
         <div className="flex flex-1 items-center justify-center">
           <div className="h-10 w-16 rounded border border-white/10 bg-white/5 flex items-center justify-center">
-            <Play className="h-4 w-4 text-white/30 ml-0.5" />
+            <Play className="h-4 w-4 text-white/60 ml-0.5" />
           </div>
         </div>
       </div>

--- a/apps/web/components/marketing/VersionBadge.tsx
+++ b/apps/web/components/marketing/VersionBadge.tsx
@@ -29,7 +29,7 @@ export function VersionBadge({ className, block }: VersionBadgeProps) {
         <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-primary" />
       </span>
       <span className="font-mono tracking-tight">v{currentVersion}</span>
-      <span className="text-on-surface-variant opacity-60 group-hover:opacity-100">
+      <span className="text-on-surface-variant opacity-90 group-hover:opacity-100">
         What&apos;s new
       </span>
     </Link>

--- a/apps/web/components/seo/JsonLd.tsx
+++ b/apps/web/components/seo/JsonLd.tsx
@@ -1,0 +1,14 @@
+/**
+ * Renders a schema.org JSON-LD block. The `<` escape prevents a crafted string
+ * from closing the script tag early (defense-in-depth; our data is static).
+ */
+export function JsonLd({ data }: { data: Record<string, unknown> }) {
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{
+        __html: JSON.stringify(data).replace(/</g, '\\u003c'),
+      }}
+    />
+  )
+}

--- a/apps/web/config/site.ts
+++ b/apps/web/config/site.ts
@@ -3,7 +3,8 @@ export const siteConfig = {
   description:
     'Framework-agnostic, browser-native video infrastructure. The timeline, rendering, and editing foundation for professional creative applications built entirely on the web. Currently supports Next.js and React, with React Native and more frameworks coming soon.',
   url: 'https://www.elah.dev',
-  ogImage: 'https://www.elah.dev/og.png',
+  // Served by app/opengraph-image.tsx (Next file-based metadata route).
+  ogImage: 'https://www.elah.dev/opengraph-image',
   links: {
     github: 'https://github.com/elahlabs/elah',
     docs: '/docs',

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -62,7 +62,7 @@
     --color-outline-variant:     #302828; /* structural hairlines */
 
     /* Accent — Crimson (slightly more vibrant for dark bg contrast) */
-    --color-primary:             #e03050;
+    --color-primary:             #dc2f4e; /* 4.6:1 with white text (WCAG AA); #e03050 was 4.46 */
     --color-primary-hover:       #cc2846;
     --color-primary-dim:         #f08090; /* soft glow for highlights */
 
@@ -399,4 +399,25 @@
 
 ::-webkit-scrollbar-thumb:hover {
   background: var(--color-outline);
+}
+
+/* Hero entrance animation — pure CSS so the hero paints and animates before
+   hydration; framer-motion here would hold the LCP text at opacity 0 until
+   the JS bundle loads. Stagger via --fade-delay (integer step). */
+@media (prefers-reduced-motion: no-preference) {
+  .fade-up {
+    animation: fade-up 0.5s ease-out both;
+    animation-delay: calc(var(--fade-delay, 0) * 90ms);
+  }
+
+  @keyframes fade-up {
+    from {
+      opacity: 0;
+      transform: translateY(8px);
+    }
+    to {
+      opacity: 1;
+      transform: none;
+    }
+  }
 }


### PR DESCRIPTION
## What does this PR do?

Adds SEO + AI-visibility (AEO) coverage across elah.dev — structured data, canonicals, OG image, FAQ, RSS, complete sitemap/llms.txt — and fixes the landing page's Lighthouse regressions (hero LCP delay, WCAG contrast), bringing desktop to 100/100/100/100 and mobile to 93/100/100/100.

Closes #

---

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [x] Performance improvement

---

## How to test

1. `npm run build` (apps/web builds clean; new routes appear: `/opengraph-image`, `/feed.xml`, `/manifest.webmanifest`).
2. `npx next start` in `apps/web`, then verify:
   - `view-source:/` — canonical link, `og:image`/`twitter:image` tags, and four JSON-LD blocks (`Organization`, `WebSite`, `SoftwareApplication`, `FAQPage`); every docs page now has a meta description + canonical (was title-only).
   - `curl /sitemap.xml` — 25 URLs (was 13; adds `/docs/architecture`, `/docs/plugins`, `/changelog`, `/playground/*`, and all blog posts with real publish dates).
   - `curl /llms.txt` — new "Blog posts" section derived from `posts.ts`, plus changelog/pricing/showcase and all three npm packages.
   - `curl /feed.xml` — RSS 2.0 feed with all 6 posts; `curl /opengraph-image` — generated 1200×630 PNG (replaces the referenced-but-missing `og.png`).
3. Landing page: new FAQ section (native `<details>`, crawlable without JS) above the CTA; hero headline/subheadline paint immediately (entrance stagger is now pure CSS — framer-motion's `initial={{opacity:0}}` held the LCP text invisible until hydration).
4. Lighthouse (headless, local `next start`):

| Category | Mobile | Desktop |
|---|---|---|
| Performance | 85 → 93 | 99 → 100 |
| Accessibility | 96 → 100 | 96 → 100 |
| Best Practices | 100 | 100 |
| SEO | 100 | 100 |

---

## Screenshots / Recording

-

---

## Checklist

- [x] `npm test` passes — no package code touched; the 13 pre-existing core failures (`PlaybackStress`, `RenderSynchronization`) noted in #23 are unaffected
- [x] `npm run typecheck` passes for `apps/web` (via `next build`); repo-root `tsc --build` failures are pre-existing on `dev` (verified identical with this branch's changes stashed)
- [x] I've tested this in the playground — playground routes get real titles/canonicals via new nested layouts (pages are client components and can't export metadata)
- [x] No `any` types introduced without justification
