### PR TITLE
feat(editor): add AI /edit agent for natural-language video editing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,19 @@ OPENAI_API_KEY=
 ## Powers the Photos panel and image imports in the production playground.
 ## Get a free key at https://www.pexels.com/api/
 PEXEL_API_KEY=
+
+## Gemini API key — used server-side only (app/api/ai/edit-agent).
+## Powers video understanding for the AI edit agent (/edit command).
+## Get a free key at https://aistudio.google.com/apikey
+GEMINI_API_KEY=
+
+## Optional: override the Gemini model (default: gemini-3-flash-preview).
+# GEMINI_MODEL=
+
+## Groq API key — used server-side only (app/api/ai/edit-agent).
+## Powers command planning (natural language -> edit commands).
+## Get a free key at https://console.groq.com/keys
+GROQ_API_KEY=
+
+## Optional: override the Groq model (default: llama-3.3-70b-versatile).
+# GROQ_MODEL=

--- a/apps/web/app/api/ai/edit-agent/route.ts
+++ b/apps/web/app/api/ai/edit-agent/route.ts
@@ -1,0 +1,88 @@
+import { NextResponse, type NextRequest } from 'next/server'
+import { mapVideoEventsToTimeline, type TimelineEvent } from '@elah/core'
+import { geminiVideoUnderstanding } from '@/lib/ai/videoUnderstanding'
+import { groqEditPlanner, type PlannerTimelineState } from '@/lib/ai/editPlanner'
+
+/**
+ * POST /api/ai/edit-agent
+ *
+ * Orchestrates the two-stage AI edit agent:
+ *   1. (optional) Gemini video understanding — locate the requested moments.
+ *   2. Groq command planning — turn the request + events + timeline into
+ *      validated EditCommands the client runs against the engine.
+ *
+ * Body:
+ *   {
+ *     request: string,                    // natural-language edit instruction
+ *     timeline: PlannerTimelineState,     // { fps, clips: [...] }
+ *     video?: { dataBase64, mimeType, query }   // include to run understanding
+ *   }
+ *
+ * Response: { commands, events, explanation }
+ * Errors follow the api/ai/topics contract: 400 bad input, 502 upstream failure.
+ */
+export async function POST(req: NextRequest) {
+  let body: unknown
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body.' }, { status: 400 })
+  }
+
+  const b = body as {
+    request?: unknown
+    timeline?: unknown
+    video?: { dataBase64?: unknown; mimeType?: unknown; query?: unknown; clipId?: unknown; cacheKey?: unknown }
+  }
+
+  const request = typeof b?.request === 'string' ? b.request.trim() : ''
+  if (!request) {
+    return NextResponse.json({ error: 'Missing "request".' }, { status: 400 })
+  }
+
+  const timeline = b?.timeline as PlannerTimelineState | undefined
+  if (!timeline || typeof timeline.fps !== 'number' || !Array.isArray(timeline.clips)) {
+    return NextResponse.json({ error: 'Missing or invalid "timeline".' }, { status: 400 })
+  }
+
+  try {
+    let events: TimelineEvent[] | undefined
+    if (b.video && typeof b.video.dataBase64 === 'string' && typeof b.video.mimeType === 'string') {
+      const query = typeof b.video.query === 'string' && b.video.query.trim() ? b.video.query.trim() : request
+
+      // Stage 1: locate the moments in the source video (seconds).
+      const cacheKey = typeof b.video.cacheKey === 'string' ? b.video.cacheKey : undefined
+      const sourceEvents = await geminiVideoUnderstanding.analyzeVideo(
+        { dataBase64: b.video.dataBase64, mimeType: b.video.mimeType, query, cacheKey },
+        req.signal,
+      )
+
+      // Map source-seconds to timeline frames for the clip the video came from.
+      // Without a clip we can't place the events, so the planner runs text-only.
+      const clip = timeline.clips.find((c) => c.clipId === b.video?.clipId)
+      if (clip) {
+        events = mapVideoEventsToTimeline(
+          {
+            clipId: clip.clipId,
+            trackId: clip.trackId,
+            startFrame: clip.startFrame,
+            durationFrames: clip.durationFrames,
+            sourceStartFrame: clip.sourceStartFrame,
+          },
+          sourceEvents,
+          timeline.fps,
+        )
+      }
+    }
+
+    const { commands, explanation } = await groqEditPlanner.planEdits(
+      { request: request.slice(0, 500), timeline, events },
+      req.signal,
+    )
+
+    return NextResponse.json({ commands, events: events ?? [], explanation })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Edit agent failed.'
+    return NextResponse.json({ error: message }, { status: 502 })
+  }
+}

--- a/apps/web/components/playground/production/EditCommandBar.tsx
+++ b/apps/web/components/playground/production/EditCommandBar.tsx
@@ -1,0 +1,353 @@
+'use client'
+
+import { useCallback, useMemo, useState } from 'react'
+import { Wand2, Send, X, Check } from 'lucide-react'
+import {
+  useTimelineEngine,
+  useSelectionStore,
+  useMediaLibraryStore,
+  interpretEditCommands,
+  type EditCommand,
+} from '@elah/editor'
+
+/**
+ * `/edit` command bar — the natural-language editing surface.
+ *
+ * Serializes the current timeline, sends it plus the user's instruction to
+ * /api/ai/edit-agent, and previews the planned EditCommands. The user confirms
+ * before anything mutates; execution runs through interpretEditCommands, so the
+ * whole edit is one undo entry. Video understanding (capturing the source clip's
+ * bytes for Gemini) is wired separately — this bar already works for
+ * frame/clip-level instructions ("split the selected clip in half",
+ * "trim the first clip to 2 seconds").
+ */
+
+const FPS = 30
+
+/**
+ * Hard ceiling on the source clip we'll ship for analysis. The server routes
+ * clips ≤15MB inline and larger ones through the Gemini Files API (cached), which
+ * accepts up to 2GB — but sending 100MB+ through our own route is wasteful, so we
+ * cap here. Over the cap → clear error instead of a silent giant upload.
+ */
+const MAX_VIDEO_BYTES = 100 * 1024 * 1024
+
+/** Words that signal the request is about video CONTENT, not just frames. Only
+ *  then do we spend a Gemini call + upload the clip. */
+const CONTENT_CUES = /\b(where|when|says?|saying|said|jump|scene|moment|shows?|appears?|talk|speak|face|person|during|part)\b/i
+
+interface PlannerClip {
+  clipId: string
+  trackId: string
+  type: string
+  startFrame: number
+  durationFrames: number
+  sourceStartFrame: number
+}
+
+interface VideoPayload {
+  dataBase64: string
+  mimeType: string
+  query: string
+  clipId: string
+  /** Stable source identity so the server can cache the Files-API upload. */
+  cacheKey?: string
+}
+
+interface PlannerTrack {
+  trackId: string
+  kind: string
+}
+
+type BarState = 'idle' | 'planning' | 'reviewing'
+
+export interface EditCommandBarProps {
+  fps?: number
+  className?: string
+}
+
+export function EditCommandBar({ fps = FPS, className }: EditCommandBarProps) {
+  const engine = useTimelineEngine()
+  const [state, setState] = useState<BarState>('idle')
+  const [input, setInput] = useState('')
+  const [commands, setCommands] = useState<EditCommand[]>([])
+  const [explanation, setExplanation] = useState('')
+  const [error, setError] = useState('')
+
+  const disabled = state === 'planning'
+
+  /** Flatten the engine project into the compact shape the planner expects. */
+  const readTimeline = useCallback((): {
+    fps: number
+    clips: PlannerClip[]
+    tracks: PlannerTrack[]
+  } => {
+    const project = engine.getProject()
+    const clips: PlannerClip[] = []
+    for (const [trackId, trackClips] of Object.entries(project.clips)) {
+      for (const clip of trackClips) {
+        clips.push({
+          clipId: clip.id,
+          trackId,
+          type: clip.type,
+          startFrame: clip.startFrame,
+          durationFrames: clip.durationFrames,
+          sourceStartFrame: clip.sourceStartFrame,
+        })
+      }
+    }
+    // Include every track (even empty lanes) so `move` can target them.
+    const tracks: PlannerTrack[] = project.tracks.map((t) => ({ trackId: t.id, kind: t.kind }))
+    return { fps, clips, tracks }
+  }, [engine, fps])
+
+  /**
+   * Resolve the video clip to analyze: the selected clip if it's a video,
+   * otherwise the first video clip on the timeline. Returns null when there is
+   * no video to look at.
+   */
+  const resolveVideoClip = useCallback(() => {
+    const project = engine.getProject()
+    const selected = useSelectionStore.getState().selectedClipIds
+    for (const [, trackClips] of Object.entries(project.clips)) {
+      for (const clip of trackClips) {
+        if (clip.type === 'video' && selected.has(clip.id)) return clip
+      }
+    }
+    for (const [, trackClips] of Object.entries(project.clips)) {
+      for (const clip of trackClips) {
+        if (clip.type === 'video') return clip
+      }
+    }
+    return null
+  }, [engine])
+
+  /** Fetch the clip's source bytes and base64-encode them, size-guarded. */
+  const captureVideo = useCallback(
+    async (query: string): Promise<VideoPayload | null> => {
+      const clip = resolveVideoClip()
+      if (!clip) return null
+
+      const asset = clip.assetId
+        ? useMediaLibraryStore.getState().assets[clip.assetId]
+        : undefined
+      const srcUrl = asset?.src ?? clip.src
+      if (!srcUrl) return null
+      if (asset && asset.byteSize > MAX_VIDEO_BYTES) {
+        throw new Error(
+          `Video is too large for inline analysis (${(asset.byteSize / 1024 / 1024).toFixed(1)}MB > 12MB).`,
+        )
+      }
+
+      const blob = await fetch(srcUrl).then((r) => r.blob())
+      if (blob.size > MAX_VIDEO_BYTES) {
+        throw new Error(
+          `Video is too large for inline analysis (${(blob.size / 1024 / 1024).toFixed(1)}MB > 12MB).`,
+        )
+      }
+      const dataBase64 = await blobToBase64(blob)
+      const cacheKey = asset ? `${asset.id}:${asset.lastModified}` : undefined
+      return { dataBase64, mimeType: blob.type || 'video/mp4', query, clipId: clip.id, cacheKey }
+    },
+    [resolveVideoClip],
+  )
+
+  const submit = useCallback(async () => {
+    // Strip a leading "/edit" (or "/trim", "/split", "/cut") so the user can type
+    // it as a slash command; the planner reads plain intent.
+    const request = input.replace(/^\/\w+\s*/, '').trim()
+    if (!request || disabled) return
+
+    setError('')
+    setCommands([])
+    setExplanation('')
+    setState('planning')
+
+    try {
+      // Only spend a Gemini call + upload when the request is about video content.
+      let video: VideoPayload | null = null
+      if (CONTENT_CUES.test(request)) {
+        video = await captureVideo(request)
+      }
+
+      const res = await fetch('/api/ai/edit-agent', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ request, timeline: readTimeline(), video: video ?? undefined }),
+      })
+      const data = await res.json()
+      if (!res.ok) {
+        setError(data.error ?? `Request failed (${res.status})`)
+        setState('idle')
+        return
+      }
+      if (!Array.isArray(data.commands) || data.commands.length === 0) {
+        setError(data.explanation || 'No edits were planned for that request.')
+        setState('idle')
+        return
+      }
+      setCommands(data.commands)
+      setExplanation(typeof data.explanation === 'string' ? data.explanation : '')
+      setState('reviewing')
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Request failed.')
+      setState('idle')
+    }
+  }, [input, disabled, readTimeline, captureVideo])
+
+  const apply = useCallback(() => {
+    // interpretEditCommands runs inside engine.batch(), which rethrows if a
+    // recipe step throws — guard so an unexpected engine error surfaces as a
+    // message instead of an unhandled render crash.
+    try {
+      const results = interpretEditCommands(engine, commands, 'AI edit')
+      const failed = results.filter((r) => !r.ok)
+      if (failed.length === results.length) {
+        setError('None of the planned edits could be applied to the current timeline.')
+      } else {
+        setInput('')
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Applying the edit failed.')
+    } finally {
+      setCommands([])
+      setExplanation('')
+      setState('idle')
+    }
+  }, [engine, commands])
+
+  const cancel = useCallback(() => {
+    setCommands([])
+    setExplanation('')
+    setState('idle')
+  }, [])
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter') {
+        e.preventDefault()
+        void submit()
+      }
+    },
+    [submit],
+  )
+
+  const summary = useMemo(() => commands.map(describeCommand), [commands])
+
+  return (
+    <div
+      className={`flex flex-col gap-2 border-t border-ed-border bg-ed-bg-2 px-3 py-2 ${className ?? ''}`}
+    >
+      {state === 'reviewing' && (
+        <div className="rounded-lg border border-ed-border bg-ed-bg p-2.5">
+          <div className="flex items-center justify-between pb-1.5">
+            <span className="text-[10px] font-semibold tracking-wide text-ed-text-muted">
+              PLANNED EDITS
+            </span>
+            <button
+              type="button"
+              onClick={cancel}
+              aria-label="Discard planned edits"
+              className="inline-flex h-5 w-5 items-center justify-center rounded text-ed-text-muted hover:text-ed-text"
+            >
+              <X size={13} />
+            </button>
+          </div>
+          {explanation && (
+            <p className="pb-1.5 text-[11px] text-ed-text-muted">{explanation}</p>
+          )}
+          <ul className="flex flex-col gap-1">
+            {summary.map((line, i) => (
+              <li key={i} className="font-mono text-[11px] text-ed-text">
+                {line}
+              </li>
+            ))}
+          </ul>
+          <div className="flex justify-end gap-2 pt-2">
+            <button
+              type="button"
+              onClick={cancel}
+              className="rounded-md border border-ed-border px-2.5 py-1 text-[11px] text-ed-text-muted hover:text-ed-text"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={apply}
+              className="inline-flex items-center gap-1 rounded-md bg-ed-accent px-2.5 py-1 text-[11px] font-semibold text-black"
+            >
+              <Check size={12} /> Apply
+            </button>
+          </div>
+        </div>
+      )}
+
+      {error && <p className="text-[11px] text-ed-error">{error}</p>}
+
+      <div className="flex items-center gap-2">
+        <Wand2 size={14} className="shrink-0 text-ed-accent" />
+        <input
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={handleKeyDown}
+          disabled={disabled}
+          placeholder="/edit — describe an edit, e.g. cut where the person says Hi"
+          className="min-w-0 flex-1 rounded-md border border-ed-border bg-ed-bg px-2.5 py-1.5 text-[12px] placeholder:text-ed-text-muted focus:border-ed-accent focus:outline-none disabled:opacity-50"
+        />
+        <button
+          type="button"
+          onClick={() => void submit()}
+          disabled={disabled || !input.trim()}
+          aria-label="Plan edit"
+          className="inline-flex h-[30px] w-[30px] shrink-0 items-center justify-center rounded-md bg-ed-accent text-black disabled:opacity-40"
+        >
+          {state === 'planning' ? (
+            <span
+              className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-black/30"
+              style={{ borderTopColor: '#000' }}
+            />
+          ) : (
+            <Send size={13} />
+          )}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+/** Human-readable one-liner for a planned command, shown in the review list. */
+function describeCommand(c: EditCommand): string {
+  switch (c.kind) {
+    case 'trim':
+      return `trim ${short(c.clipId)} → start ${c.startFrame}, ${c.durationFrames}f`
+    case 'split':
+      return `split ${short(c.clipId)} @ frame ${c.atFrame}`
+    case 'delete':
+      return `delete ${short(c.clipId)}`
+    case 'move':
+      return `move ${short(c.clipId)} → frame ${c.startFrame}`
+    case 'cutRange':
+      return `cut ${short(c.clipId)} [${c.fromFrame}–${c.toFrame})`
+    default:
+      return 'unknown command'
+  }
+}
+
+function short(id: string): string {
+  return id.length > 8 ? `${id.slice(0, 6)}…` : id
+}
+
+/** Blob → bare base64 (no data: prefix). FileReader handles large blobs. */
+function blobToBase64(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onerror = () => reject(reader.error ?? new Error('Failed to read video.'))
+    reader.onload = () => {
+      const result = typeof reader.result === 'string' ? reader.result : ''
+      const comma = result.indexOf(',')
+      resolve(comma >= 0 ? result.slice(comma + 1) : result)
+    }
+    reader.readAsDataURL(blob)
+  })
+}

--- a/apps/web/components/playground/production/ProductionEditor.tsx
+++ b/apps/web/components/playground/production/ProductionEditor.tsx
@@ -31,6 +31,7 @@ import { ExportModal } from './ExportModal'
 import { PlaygroundTabs } from '../shared/PlaygroundTabs'
 import { MediaPanel, type PanelMode } from './MediaPanel'
 import { AgenticPanel } from './AgenticPanel'
+import { EditCommandBar } from './EditCommandBar'
 import { TracePanel } from './TracePanel'
 import { siteConfig } from '@/config/site'
 import { cn } from '@/lib/utils'
@@ -886,6 +887,8 @@ export default function ProductionEditor() {
               <span className="h-1 w-12 rounded-full bg-ed-text-muted group-hover:bg-ed-accent transition-colors" />
             </div>
           )}
+
+          {!isMobile && <EditCommandBar fps={FPS} />}
 
           <div className="relative flex flex-col min-h-0 shrink-0">
             <TimelineControls timelineRef={timelineRef} compact={isMobile} />

--- a/apps/web/lib/ai/editPlanner.ts
+++ b/apps/web/lib/ai/editPlanner.ts
@@ -1,0 +1,214 @@
+/**
+ * Edit planner — turns a natural-language request (+ optional video events +
+ * current timeline state) into a validated array of EditCommands.
+ *
+ * Stage 2 of the AI edit agent. Provider-agnostic; default is Groq
+ * (OpenAI-compatible chat completions, JSON mode). Because Groq's strict
+ * json_schema constrained decoding is currently limited to the gpt-oss models,
+ * we use JSON-object mode and validate the result ourselves — mirroring the
+ * sanitizeOptions pattern in lib/ai/client.ts.
+ */
+
+import type { EditCommand, EditCommandKind, TimelineEvent } from '@elah/editor'
+import { fetchWithRetry } from './retry'
+
+/** Compact view of a clip the planner is allowed to edit. */
+export interface PlannerClip {
+  clipId: string
+  trackId: string
+  type: string
+  startFrame: number
+  durationFrames: number
+  /** Trim in-point into the source — needed to map video events to timeline frames. */
+  sourceStartFrame: number
+}
+
+/** A track the planner may target (including empty ones). */
+export interface PlannerTrack {
+  trackId: string
+  kind: string
+}
+
+/** Everything the planner needs to know about the project. */
+export interface PlannerTimelineState {
+  fps: number
+  clips: PlannerClip[]
+  /** All tracks, so `move` can target an empty lane clips alone wouldn't reveal. */
+  tracks?: PlannerTrack[]
+}
+
+export interface PlanEditsInput {
+  request: string
+  timeline: PlannerTimelineState
+  /** Video-understanding hits already mapped to TIMELINE frames (see mapVideoEventsToTimeline). */
+  events?: TimelineEvent[]
+}
+
+export interface EditPlanner {
+  planEdits(input: PlanEditsInput, signal?: AbortSignal): Promise<{
+    commands: EditCommand[]
+    explanation: string
+  }>
+}
+
+const GROQ_URL = 'https://api.groq.com/openai/v1/chat/completions'
+const GROQ_MODEL = process.env.GROQ_MODEL || 'llama-3.3-70b-versatile'
+
+const VALID_KINDS: EditCommandKind[] = ['trim', 'split', 'delete', 'move', 'cutRange']
+
+const SYSTEM_PROMPT = `You are the command planner for a browser video editor.
+You translate a user's editing request into a JSON list of edit commands that run
+against the timeline. TIME IS INTEGER FRAMES. Convert any seconds you are given to
+frames using the provided fps (frame = round(seconds * fps)).
+
+You may ONLY use these commands, and only reference clipId/trackId values that
+appear in the provided timeline state:
+
+- trim:     { "kind":"trim", "clipId","trackId", "startFrame","durationFrames" }
+- split:    { "kind":"split", "clipId","trackId", "atFrame" }   // atFrame strictly inside the clip
+- delete:   { "kind":"delete", "clipId","trackId" }
+- move:     { "kind":"move", "clipId","fromTrackId","toTrackId","startFrame" }
+- cutRange: { "kind":"cutRange", "clipId","trackId", "fromFrame","toFrame" }  // removes [fromFrame,toFrame)
+
+Prefer cutRange to remove a segment the user wants gone. Keep the command list
+minimal. If the request cannot be satisfied, return an empty commands array and
+explain why.
+
+If "events" are provided, they are moments already located in the video and
+already converted to TIMELINE frames: each has { label, clipId, trackId,
+startFrame, endFrame }. Use these frames directly — do NOT re-derive them. For a
+"cut/remove where X" request, emit a cutRange on the event's clip using its
+startFrame/endFrame.
+
+Return ONLY JSON of the form:
+{ "commands": [ ... ], "explanation": "one short sentence" }`
+
+function getApiKey(): string {
+  const key = process.env.GROQ_API_KEY
+  if (!key) throw new Error('GROQ_API_KEY is not configured on the server.')
+  return key
+}
+
+function num(v: unknown): number | null {
+  return typeof v === 'number' && Number.isFinite(v) ? v : null
+}
+
+/**
+ * Validate one raw object into an EditCommand, or null if malformed. Every clip
+ * / track id is checked against the known sets so the model cannot invent
+ * targets that would fail (or worse, alias) at execution time.
+ */
+function validateCommand(
+  raw: unknown,
+  clipIds: Set<string>,
+  trackIds: Set<string>,
+): EditCommand | null {
+  if (!raw || typeof raw !== 'object') return null
+  const o = raw as Record<string, unknown>
+  const kind = o.kind as EditCommandKind
+  if (!VALID_KINDS.includes(kind)) return null
+
+  const hasClip = typeof o.clipId === 'string' && clipIds.has(o.clipId)
+
+  switch (kind) {
+    case 'trim': {
+      const startFrame = num(o.startFrame)
+      const durationFrames = num(o.durationFrames)
+      if (!hasClip || typeof o.trackId !== 'string' || !trackIds.has(o.trackId)) return null
+      if (startFrame === null || durationFrames === null || durationFrames < 1) return null
+      return { kind, clipId: o.clipId as string, trackId: o.trackId, startFrame: Math.round(startFrame), durationFrames: Math.round(durationFrames) }
+    }
+    case 'split': {
+      const atFrame = num(o.atFrame)
+      if (!hasClip || typeof o.trackId !== 'string' || !trackIds.has(o.trackId) || atFrame === null) return null
+      return { kind, clipId: o.clipId as string, trackId: o.trackId, atFrame: Math.round(atFrame) }
+    }
+    case 'delete': {
+      if (!hasClip || typeof o.trackId !== 'string' || !trackIds.has(o.trackId)) return null
+      return { kind, clipId: o.clipId as string, trackId: o.trackId }
+    }
+    case 'move': {
+      const startFrame = num(o.startFrame)
+      if (!hasClip || typeof o.fromTrackId !== 'string' || !trackIds.has(o.fromTrackId)) return null
+      if (typeof o.toTrackId !== 'string' || !trackIds.has(o.toTrackId) || startFrame === null) return null
+      return { kind, clipId: o.clipId as string, fromTrackId: o.fromTrackId, toTrackId: o.toTrackId, startFrame: Math.round(startFrame) }
+    }
+    case 'cutRange': {
+      const fromFrame = num(o.fromFrame)
+      const toFrame = num(o.toFrame)
+      if (!hasClip || typeof o.trackId !== 'string' || !trackIds.has(o.trackId)) return null
+      if (fromFrame === null || toFrame === null || toFrame <= fromFrame) return null
+      return { kind, clipId: o.clipId as string, trackId: o.trackId, fromFrame: Math.round(fromFrame), toFrame: Math.round(toFrame) }
+    }
+    default:
+      return null
+  }
+}
+
+export const groqEditPlanner: EditPlanner = {
+  async planEdits({ request, timeline, events }, signal) {
+    const clipIds = new Set(timeline.clips.map((c) => c.clipId))
+    // Prefer the explicit track list (includes empty lanes); fall back to the
+    // tracks that clips sit on when it isn't provided.
+    const trackIds = new Set(
+      timeline.tracks?.length
+        ? timeline.tracks.map((t) => t.trackId)
+        : timeline.clips.map((c) => c.trackId),
+    )
+
+    const userContent = JSON.stringify({
+      request,
+      fps: timeline.fps,
+      tracks: timeline.tracks ?? [],
+      clips: timeline.clips,
+      events: events ?? [],
+    })
+
+    const res = await fetchWithRetry(GROQ_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${getApiKey()}`,
+      },
+      signal,
+      body: JSON.stringify({
+        model: GROQ_MODEL,
+        temperature: 0.1,
+        response_format: { type: 'json_object' },
+        messages: [
+          { role: 'system', content: SYSTEM_PROMPT },
+          { role: 'user', content: userContent },
+        ],
+      }),
+    })
+
+    if (!res.ok) throw new Error(`Groq request failed with status ${res.status}`)
+
+    const data = await res.json()
+    const content: unknown = data?.choices?.[0]?.message?.content
+    if (typeof content !== 'string') throw new Error('Groq returned no content.')
+
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(content)
+    } catch {
+      throw new Error('Groq returned invalid JSON.')
+    }
+
+    const rawCommands = (parsed as { commands?: unknown })?.commands
+    const explanation =
+      typeof (parsed as { explanation?: unknown })?.explanation === 'string'
+        ? ((parsed as { explanation: string }).explanation).trim().slice(0, 200)
+        : ''
+
+    const commands: EditCommand[] = []
+    if (Array.isArray(rawCommands)) {
+      for (const raw of rawCommands) {
+        const cmd = validateCommand(raw, clipIds, trackIds)
+        if (cmd) commands.push(cmd)
+      }
+    }
+
+    return { commands, explanation }
+  },
+}

--- a/apps/web/lib/ai/retry.ts
+++ b/apps/web/lib/ai/retry.ts
@@ -1,0 +1,44 @@
+/**
+ * fetch wrapper that retries on 429 (and 503) with backoff, honoring a
+ * Retry-After header when present. Gemini's free tier is 10 RPM, so a couple of
+ * short retries smooth over bursts without hanging the request.
+ */
+export async function fetchWithRetry(
+  url: string,
+  init: RequestInit,
+  opts: { retries?: number; baseDelayMs?: number } = {},
+): Promise<Response> {
+  const retries = opts.retries ?? 2
+  const baseDelayMs = opts.baseDelayMs ?? 800
+
+  let attempt = 0
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const res = await fetch(url, init)
+    if (res.status !== 429 && res.status !== 503) return res
+    if (attempt >= retries) return res
+
+    const retryAfter = Number(res.headers.get('retry-after'))
+    const delay = Number.isFinite(retryAfter) && retryAfter > 0
+      ? retryAfter * 1000
+      : baseDelayMs * 2 ** attempt
+    // Abort promptly if the caller cancelled.
+    if (init.signal?.aborted) return res
+    await sleep(delay, init.signal)
+    attempt += 1
+  }
+}
+
+function sleep(ms: number, signal?: AbortSignal | null): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const t = setTimeout(resolve, ms)
+    signal?.addEventListener(
+      'abort',
+      () => {
+        clearTimeout(t)
+        reject(new DOMException('Aborted', 'AbortError'))
+      },
+      { once: true },
+    )
+  })
+}

--- a/apps/web/lib/ai/videoUnderstanding.ts
+++ b/apps/web/lib/ai/videoUnderstanding.ts
@@ -1,0 +1,258 @@
+/**
+ * Video understanding provider — watches a video and returns timestamped events.
+ *
+ * Stage 1 of the AI edit agent: given a video and a natural-language target
+ * ("where the person says Hi", "where they jump"), return the moments that match
+ * as { label, startSec, endSec?, confidence }. Stage 2 (editPlanner) turns those
+ * into EditCommands.
+ *
+ * The interface is provider-agnostic; the default implementation is Gemini 3
+ * Flash (free tier, native video + timestamps). Small clips (<~15MB) go inline
+ * as base64 (generateContent inlineData); larger clips are uploaded via the
+ * Files API and reused across requests through a per-asset cache — which also
+ * eases the 10 RPM free-tier limit by avoiding re-uploads.
+ */
+
+import { fetchWithRetry } from './retry'
+
+export interface VideoEvent {
+  /** What was detected, echoing the user's target, e.g. 'person says "Hi"'. */
+  label: string
+  /** Event start, seconds from the beginning of the video. */
+  startSec: number
+  /** Event end in seconds, when the event spans a range. */
+  endSec?: number
+  /** Model confidence 0..1. */
+  confidence: number
+}
+
+export interface AnalyzeVideoInput {
+  /** Base64-encoded video bytes (no data: prefix). */
+  dataBase64: string
+  /** MIME type, e.g. 'video/mp4'. */
+  mimeType: string
+  /** Natural-language description of the moments to find. */
+  query: string
+  /**
+   * Stable identity of the source (e.g. assetId + lastModified). When set, an
+   * uploaded Files-API handle is cached under this key and reused, so repeated
+   * requests on the same clip skip the upload.
+   */
+  cacheKey?: string
+}
+
+/** Above this decoded size, use the Files API instead of inline base64. */
+const INLINE_LIMIT_BYTES = 15 * 1024 * 1024
+
+export interface VideoUnderstandingProvider {
+  analyzeVideo(input: AnalyzeVideoInput, signal?: AbortSignal): Promise<VideoEvent[]>
+}
+
+const GEMINI_MODEL = process.env.GEMINI_MODEL || 'gemini-3-flash-preview'
+const GEMINI_BASE = 'https://generativelanguage.googleapis.com/v1beta'
+
+const SYSTEM_INSTRUCTION = `You analyze a video and locate the moments a user asks about.
+Return ONLY the moments that clearly match. Use timestamps in SECONDS from the
+start of the video. Be precise: startSec is when the moment begins, endSec when it
+ends. Set confidence between 0 and 1. If nothing matches, return an empty list.`
+
+const RESPONSE_SCHEMA = {
+  type: 'object',
+  properties: {
+    events: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          label: { type: 'string' },
+          startSec: { type: 'number' },
+          endSec: { type: 'number' },
+          confidence: { type: 'number' },
+        },
+        required: ['label', 'startSec', 'confidence'],
+      },
+    },
+  },
+  required: ['events'],
+}
+
+function getApiKey(): string {
+  const key = process.env.GEMINI_API_KEY
+  if (!key) throw new Error('GEMINI_API_KEY is not configured on the server.')
+  return key
+}
+
+function sanitizeEvents(raw: unknown): VideoEvent[] {
+  if (!raw || typeof raw !== 'object') return []
+  const list = (raw as { events?: unknown }).events
+  if (!Array.isArray(list)) return []
+  const out: VideoEvent[] = []
+  for (const item of list) {
+    if (!item || typeof item !== 'object') continue
+    const o = item as Record<string, unknown>
+    const label = typeof o.label === 'string' ? o.label.trim().slice(0, 120) : ''
+    const startSec = typeof o.startSec === 'number' && Number.isFinite(o.startSec) ? Math.max(0, o.startSec) : NaN
+    if (!label || Number.isNaN(startSec)) continue
+    const endSec =
+      typeof o.endSec === 'number' && Number.isFinite(o.endSec) && o.endSec > startSec ? o.endSec : undefined
+    const confidence =
+      typeof o.confidence === 'number' && Number.isFinite(o.confidence)
+        ? Math.min(1, Math.max(0, o.confidence))
+        : 0.5
+    out.push({ label, startSec, endSec, confidence })
+  }
+  return out
+}
+
+// --- Files API upload + per-asset cache -------------------------------------
+
+interface CachedFile {
+  fileUri: string
+  mimeType: string
+  /** Epoch ms after which the cache entry is considered stale. */
+  expiresAt: number
+}
+
+// Module-level cache (per server instance). Gemini stores files 48h; keep our
+// entries a little shorter so we never hand back an expired URI.
+const fileCache = new Map<string, CachedFile>()
+const FILE_TTL_MS = 46 * 60 * 60 * 1000
+
+function base64ToArrayBuffer(b64: string): ArrayBuffer {
+  const buf = Buffer.from(b64, 'base64')
+  // Copy into a fresh, exactly-sized ArrayBuffer (a Node Buffer may be a view
+  // into a larger shared pool).
+  const out = new ArrayBuffer(buf.byteLength)
+  new Uint8Array(out).set(buf)
+  return out
+}
+
+/** Resumable upload → poll ACTIVE → return the file URI. */
+async function uploadToFilesApi(
+  dataBase64: string,
+  mimeType: string,
+  signal: AbortSignal | undefined,
+): Promise<{ fileUri: string; mimeType: string }> {
+  const key = getApiKey()
+  const bytes = base64ToArrayBuffer(dataBase64)
+
+  // 1. Start a resumable session.
+  const startRes = await fetchWithRetry(`${GEMINI_BASE.replace('/v1beta', '')}/upload/v1beta/files?key=${key}`, {
+    method: 'POST',
+    signal,
+    headers: {
+      'X-Goog-Upload-Protocol': 'resumable',
+      'X-Goog-Upload-Command': 'start',
+      'X-Goog-Upload-Header-Content-Length': String(bytes.byteLength),
+      'X-Goog-Upload-Header-Content-Type': mimeType,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ file: { display_name: 'elah-edit-source' } }),
+  })
+  if (!startRes.ok) throw new Error(`Gemini upload start failed (${startRes.status}).`)
+  const uploadUrl = startRes.headers.get('x-goog-upload-url')
+  if (!uploadUrl) throw new Error('Gemini upload URL missing.')
+
+  // 2. Upload the bytes and finalize.
+  const upRes = await fetchWithRetry(uploadUrl, {
+    method: 'POST',
+    signal,
+    headers: {
+      'X-Goog-Upload-Command': 'upload, finalize',
+      'X-Goog-Upload-Offset': '0',
+      'Content-Type': mimeType,
+    },
+    body: bytes,
+  })
+  if (!upRes.ok) throw new Error(`Gemini upload failed (${upRes.status}).`)
+  const upData = await upRes.json()
+  let name: string | undefined = upData?.file?.name
+  let state: string | undefined = upData?.file?.state
+  const fileUri: string | undefined = upData?.file?.uri
+  if (!fileUri || !name) throw new Error('Gemini upload returned no file handle.')
+
+  // 3. Poll until the file is ACTIVE (video processing).
+  const deadline = Date.now() + 60_000
+  while (state !== 'ACTIVE') {
+    if (state === 'FAILED') throw new Error('Gemini failed to process the video.')
+    if (Date.now() > deadline) throw new Error('Gemini video processing timed out.')
+    await new Promise((r) => setTimeout(r, 1500))
+    const poll: Response = await fetch(`${GEMINI_BASE}/${name}?key=${key}`, { signal })
+    if (!poll.ok) throw new Error(`Gemini file poll failed (${poll.status}).`)
+    const pd: { state?: string; name?: string } = await poll.json()
+    state = pd?.state
+    name = pd?.name ?? name
+  }
+
+  return { fileUri, mimeType }
+}
+
+async function resolveFilePart(
+  input: AnalyzeVideoInput,
+  signal: AbortSignal | undefined,
+): Promise<{ fileData: { fileUri: string; mimeType: string } }> {
+  const cacheKey = input.cacheKey
+  if (cacheKey) {
+    const hit = fileCache.get(cacheKey)
+    if (hit && hit.expiresAt > Date.now()) {
+      return { fileData: { fileUri: hit.fileUri, mimeType: hit.mimeType } }
+    }
+  }
+  const uploaded = await uploadToFilesApi(input.dataBase64, input.mimeType, signal)
+  if (cacheKey) {
+    fileCache.set(cacheKey, { ...uploaded, expiresAt: Date.now() + FILE_TTL_MS })
+  }
+  return { fileData: uploaded }
+}
+
+// ---------------------------------------------------------------------------
+
+/** Gemini 3 Flash implementation. */
+export const geminiVideoUnderstanding: VideoUnderstandingProvider = {
+  async analyzeVideo(input, signal) {
+    const { dataBase64, mimeType, query } = input
+
+    // Choose transport: inline for small clips, Files API (cached) for large.
+    const approxBytes = Math.floor((dataBase64.length * 3) / 4)
+    const videoPart =
+      approxBytes <= INLINE_LIMIT_BYTES
+        ? { inlineData: { mimeType, data: dataBase64 } }
+        : await resolveFilePart(input, signal)
+
+    const url = `${GEMINI_BASE}/models/${GEMINI_MODEL}:generateContent?key=${getApiKey()}`
+    const res = await fetchWithRetry(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      signal,
+      body: JSON.stringify({
+        systemInstruction: { parts: [{ text: SYSTEM_INSTRUCTION }] },
+        contents: [
+          {
+            role: 'user',
+            parts: [videoPart, { text: `Find the moments where: ${query}` }],
+          },
+        ],
+        generationConfig: {
+          responseMimeType: 'application/json',
+          responseSchema: RESPONSE_SCHEMA,
+          temperature: 0.2,
+        },
+      }),
+    })
+
+    if (!res.ok) {
+      throw new Error(`Gemini request failed with status ${res.status}`)
+    }
+
+    const data = await res.json()
+    const text: unknown = data?.candidates?.[0]?.content?.parts?.[0]?.text
+    if (typeof text !== 'string') throw new Error('Gemini returned no content.')
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(text)
+    } catch {
+      throw new Error('Gemini returned invalid JSON.')
+    }
+    return sanitizeEvents(parsed)
+  },
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,6 +11,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@elah/core": "*",
     "@elah/editor": "*",
     "@radix-ui/react-dialog": "^1.1.6",
     "@radix-ui/react-dropdown-menu": "^2.1.6",

--- a/docs/ai-editing.md
+++ b/docs/ai-editing.md
@@ -1,0 +1,71 @@
+# AI Editing — the `/edit` agent
+
+> Natural-language editing for the Elah timeline. Type an instruction; the agent
+> plans timeline edits, you confirm, it applies them as one undo step.
+
+## What it does
+
+The `/edit` command bar (bottom of the production editor) turns instructions into
+timeline edits:
+
+- **Frame/clip edits** — "split the selected clip", "trim the first clip to 2 seconds",
+  "delete that clip". Planned directly from the timeline state; no video analysis.
+- **Content-aware edits** — "cut where the person says Hi", "remove the part where they jump".
+  The agent watches the video, locates the moment, and cuts it.
+
+Every plan is previewed before it runs. Applying is a single undo entry (Ctrl+Z reverts the whole edit).
+
+## Architecture (two stages)
+
+```
+/edit request
+   │
+   ├─ content cue? ──▶ Gemini 3 Flash (video understanding)
+   │                     → events in SOURCE seconds
+   │                     → mapVideoEventsToTimeline() → TIMELINE frames   [deterministic]
+   │
+   └─▶ Groq planner (llama-3.3-70b) : request + clips + frame-events → EditCommand[]  [JSON]
+          │
+          ▼
+   interpretEditCommands(engine, commands)  →  TimelineEngine.batch()  (one undo entry)
+```
+
+- **No FFmpeg.** Edit commands (`trim`, `split`, `delete`, `move`, `cutRange`) are a thin JSON
+  schema over the engine's existing mutation API — fully undoable.
+- **Seconds→frames is deterministic**, never left to the LLM (`packages/core/src/commands/mapVideoEvents.ts`).
+- Command validation rejects any clip/track id the model invents.
+
+## Code map
+
+| Concern | File |
+|---------|------|
+| Command schema + interpreter | `packages/core/src/commands/{editCommand,interpretEditCommands}.ts` |
+| Event → frame mapping (pure, tested) | `packages/core/src/commands/mapVideoEvents.ts` |
+| Video understanding (Gemini) | `apps/web/lib/ai/videoUnderstanding.ts` |
+| Command planner (Groq) | `apps/web/lib/ai/editPlanner.ts` |
+| 429/backoff retry | `apps/web/lib/ai/retry.ts` |
+| Server route | `apps/web/app/api/ai/edit-agent/route.ts` |
+| Command bar UI | `apps/web/components/playground/production/EditCommandBar.tsx` |
+
+## Models & keys
+
+Set in `.env.local` (server-side only):
+
+- `GEMINI_API_KEY` — video understanding. Default model `gemini-3-flash-preview` (free tier: 10 RPM,
+  1,500 req/day). Override with `GEMINI_MODEL`.
+- `GROQ_API_KEY` — command planning. Default `llama-3.3-70b-versatile`. Override with `GROQ_MODEL`.
+
+## Video transport
+
+- Clips **≤15MB** are sent inline (base64) in a single request.
+- Larger clips go through the **Gemini Files API** (up to 2GB, stored 48h) and the upload is **cached
+  per source** (`assetId:lastModified`), so repeat requests on the same clip skip re-upload — which
+  also eases the 10 RPM limit. Client cap: 100MB.
+- Video analysis only runs when the request contains a content cue ("where", "says", "jump", "scene", …),
+  so pure frame edits never spend a Gemini call.
+
+## Limits / follow-ups
+
+- Free-tier Gemini is 10 RPM — bursts are retried (backoff, Retry-After) but heavy use needs a paid key.
+- Frame precision depends on project fps; the mapper snaps to the nearest frame and clamps to clip bounds.
+- Large inline uploads pass through the app's own route — fine for short clips, Files-API path handles the rest.

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
       "name": "@elah/web",
       "version": "0.1.0",
       "dependencies": {
+        "@elah/core": "*",
         "@elah/editor": "*",
         "@radix-ui/react-dialog": "^1.1.6",
         "@radix-ui/react-dropdown-menu": "^2.1.6",

--- a/packages/core/src/commands/__tests__/interpretEditCommands.test.ts
+++ b/packages/core/src/commands/__tests__/interpretEditCommands.test.ts
@@ -1,0 +1,172 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { TimelineEngine } from '../../editor/TimelineEngine'
+import { interpretEditCommands } from '../interpretEditCommands'
+import type { EditCommand } from '../editCommand'
+
+/**
+ * Covers the AI-command interpreter: each command kind maps onto the engine
+ * mutation funnel, the whole batch is one undo entry, and unapplicable commands
+ * are reported (not thrown) without aborting siblings.
+ *
+ * Text clips are used throughout — they have no source-asset length cap, so
+ * trim/split/cut behave predictably without wiring real media.
+ */
+describe('interpretEditCommands', () => {
+  let engine: TimelineEngine
+  let trackId: string
+  let clipId: string
+
+  beforeEach(() => {
+    engine = new TimelineEngine({ fps: 30 })
+    trackId = engine.addTrack('elements').id
+    clipId = engine.addClip({
+      trackId,
+      type: 'text',
+      name: 'Text 1',
+      text: { content: 'Hello' },
+      startFrame: 0,
+      durationFrames: 120,
+    }).id
+  })
+
+  it('split divides one clip into two', () => {
+    const results = interpretEditCommands(engine, [
+      { kind: 'split', clipId, trackId, atFrame: 60 },
+    ])
+    expect(results[0].ok).toBe(true)
+    expect(engine.getClipsOnTrack(trackId)).toHaveLength(2)
+  })
+
+  it('rejects a split outside the clip bounds', () => {
+    const results = interpretEditCommands(engine, [
+      { kind: 'split', clipId, trackId, atFrame: 200 },
+    ])
+    expect(results[0]).toMatchObject({ ok: false, reason: 'split-outside-clip' })
+    expect(engine.getClipsOnTrack(trackId)).toHaveLength(1)
+  })
+
+  it('delete removes the clip', () => {
+    const results = interpretEditCommands(engine, [
+      { kind: 'delete', clipId, trackId },
+    ])
+    expect(results[0].ok).toBe(true)
+    expect(engine.findClip(clipId)).toBeNull()
+  })
+
+  it('trim shortens the clip', () => {
+    interpretEditCommands(engine, [
+      { kind: 'trim', clipId, trackId, startFrame: 0, durationFrames: 30 },
+    ])
+    expect(engine.findClip(clipId)?.clip.durationFrames).toBe(30)
+  })
+
+  it('move relocates the clip to a new start frame', () => {
+    const other = engine.addTrack('elements').id
+    const results = interpretEditCommands(engine, [
+      { kind: 'move', clipId, fromTrackId: trackId, toTrackId: other, startFrame: 300 },
+    ])
+    expect(results[0].ok).toBe(true)
+    const after = engine.findClip(clipId)
+    expect(after?.trackId).toBe(other)
+    expect(after?.clip.startFrame).toBe(300)
+  })
+
+  it('cutRange removes an interior range and leaves two clips', () => {
+    // Clip spans [0,120). Remove [40,80) → keep [0,40) and [80,120).
+    const results = interpretEditCommands(engine, [
+      { kind: 'cutRange', clipId, trackId, fromFrame: 40, toFrame: 80 },
+    ])
+    expect(results[0].ok).toBe(true)
+    const clips = [...engine.getClipsOnTrack(trackId)].sort((a, b) => a.startFrame - b.startFrame)
+    expect(clips).toHaveLength(2)
+    expect(clips[0]).toMatchObject({ startFrame: 0, durationFrames: 40 })
+    expect(clips[1].startFrame).toBe(80)
+    expect(clips[1].durationFrames).toBe(40)
+  })
+
+  it('cutRange from the clip start leaves a single trailing clip', () => {
+    interpretEditCommands(engine, [
+      { kind: 'cutRange', clipId, trackId, fromFrame: 0, toFrame: 50 },
+    ])
+    const clips = engine.getClipsOnTrack(trackId)
+    expect(clips).toHaveLength(1)
+    expect(clips[0]).toMatchObject({ startFrame: 50, durationFrames: 70 })
+  })
+
+  it('cutRange to the clip end leaves a single leading clip', () => {
+    interpretEditCommands(engine, [
+      { kind: 'cutRange', clipId, trackId, fromFrame: 90, toFrame: 120 },
+    ])
+    const clips = engine.getClipsOnTrack(trackId)
+    expect(clips).toHaveLength(1)
+    expect(clips[0]).toMatchObject({ startFrame: 0, durationFrames: 90 })
+  })
+
+  it('rejects a cutRange with from >= to', () => {
+    const results = interpretEditCommands(engine, [
+      { kind: 'cutRange', clipId, trackId, fromFrame: 80, toFrame: 40 },
+    ])
+    expect(results[0]).toMatchObject({ ok: false, reason: 'invalid-range' })
+    expect(engine.getClipsOnTrack(trackId)).toHaveLength(1)
+  })
+
+  it('reports clip-not-found for an unknown clip', () => {
+    const results = interpretEditCommands(engine, [
+      { kind: 'delete', clipId: 'nope', trackId },
+    ])
+    expect(results[0]).toMatchObject({ ok: false, reason: 'clip-not-found' })
+  })
+
+  it('reports track-mismatch when the clip is on a different track', () => {
+    const other = engine.addTrack('elements').id
+    const results = interpretEditCommands(engine, [
+      { kind: 'delete', clipId, trackId: other },
+    ])
+    expect(results[0]).toMatchObject({ ok: false, reason: 'track-mismatch' })
+    expect(engine.findClip(clipId)?.clip).toBeDefined()
+  })
+
+  it('rejects delete on a locked track', () => {
+    engine.updateTrack(trackId, { locked: true })
+    const results = interpretEditCommands(engine, [
+      { kind: 'delete', clipId, trackId },
+    ])
+    expect(results[0]).toMatchObject({ ok: false, reason: 'engine-rejected' })
+    expect(engine.findClip(clipId)?.clip).toBeDefined()
+  })
+
+  it('rejects trim on a locked track instead of reporting false success', () => {
+    engine.updateTrack(trackId, { locked: true })
+    const results = interpretEditCommands(engine, [
+      { kind: 'trim', clipId, trackId, startFrame: 0, durationFrames: 30 },
+    ])
+    expect(results[0]).toMatchObject({ ok: false, reason: 'engine-rejected' })
+    // Clip must be untouched.
+    expect(engine.findClip(clipId)?.clip.durationFrames).toBe(120)
+  })
+
+  it('collapses a multi-primitive edit into a single undo entry', () => {
+    // cutRange expands to split + split + remove — three engine mutations.
+    // If the batch collapsed correctly, exactly one undo reverts all three.
+    const commands: EditCommand[] = [
+      { kind: 'cutRange', clipId, trackId, fromFrame: 40, toFrame: 80 },
+    ]
+    interpretEditCommands(engine, commands)
+    expect(engine.getClipsOnTrack(trackId)).toHaveLength(2)
+
+    engine.undo()
+    const clips = engine.getClipsOnTrack(trackId)
+    expect(clips).toHaveLength(1)
+    expect(clips[0]).toMatchObject({ startFrame: 0, durationFrames: 120 })
+  })
+
+  it('applies siblings even when one command fails', () => {
+    const results = interpretEditCommands(engine, [
+      { kind: 'delete', clipId: 'ghost', trackId },
+      { kind: 'trim', clipId, trackId, startFrame: 0, durationFrames: 20 },
+    ])
+    expect(results[0].ok).toBe(false)
+    expect(results[1].ok).toBe(true)
+    expect(engine.findClip(clipId)?.clip.durationFrames).toBe(20)
+  })
+})

--- a/packages/core/src/commands/__tests__/mapVideoEvents.test.ts
+++ b/packages/core/src/commands/__tests__/mapVideoEvents.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import { mapVideoEventsToTimeline, type ClipGeometry } from '../mapVideoEvents'
+
+/**
+ * Covers source-seconds → timeline-frames mapping: the trim offset
+ * (sourceStartFrame), the timeline offset (startFrame), point vs range events,
+ * and clamping / dropping of events outside the clip's trimmed window.
+ */
+describe('mapVideoEventsToTimeline', () => {
+  const fps = 30
+
+  // Clip plays source frames [0, 300) at timeline frame 0. Untrimmed, unshifted.
+  const untrimmed: ClipGeometry = {
+    clipId: 'c1',
+    trackId: 't1',
+    startFrame: 0,
+    durationFrames: 300,
+    sourceStartFrame: 0,
+  }
+
+  it('maps a source-second event straight to timeline frames (no trim, no shift)', () => {
+    const [e] = mapVideoEventsToTimeline(untrimmed, [
+      { label: 'Hi', startSec: 2, endSec: 3, confidence: 0.9 },
+    ], fps)
+    expect(e).toMatchObject({ clipId: 'c1', trackId: 't1', startFrame: 60, endFrame: 90 })
+  })
+
+  it('turns a point event (no endSec) into a one-frame window', () => {
+    const [e] = mapVideoEventsToTimeline(untrimmed, [
+      { label: 'jump', startSec: 1, confidence: 0.8 },
+    ], fps)
+    expect(e.startFrame).toBe(30)
+    expect(e.endFrame).toBe(31)
+  })
+
+  it('applies the timeline offset (clip.startFrame)', () => {
+    const shifted: ClipGeometry = { ...untrimmed, startFrame: 100 }
+    const [e] = mapVideoEventsToTimeline(shifted, [
+      { label: 'Hi', startSec: 2, endSec: 3, confidence: 1 },
+    ], fps)
+    // source frame 60 → timeline 100 + 60 = 160
+    expect(e).toMatchObject({ startFrame: 160, endFrame: 190 })
+  })
+
+  it('applies the trim offset (sourceStartFrame)', () => {
+    // Clip trims off the first 1s (30 frames) of source and sits at timeline 0.
+    const trimmed: ClipGeometry = { ...untrimmed, sourceStartFrame: 30 }
+    const [e] = mapVideoEventsToTimeline(trimmed, [
+      { label: 'Hi', startSec: 2, endSec: 3, confidence: 1 },
+    ], fps)
+    // source frame 60, minus 30 trimmed = timeline 30..60
+    expect(e).toMatchObject({ startFrame: 30, endFrame: 60 })
+  })
+
+  it('drops events entirely outside the clip window', () => {
+    // Clip only holds source [0,60) → an event at 5s is past the end.
+    const shortClip: ClipGeometry = { ...untrimmed, durationFrames: 60 }
+    const events = mapVideoEventsToTimeline(shortClip, [
+      { label: 'late', startSec: 5, endSec: 6, confidence: 1 },
+    ], fps)
+    expect(events).toHaveLength(0)
+  })
+
+  it('clamps an event that partially overlaps the clip end', () => {
+    const shortClip: ClipGeometry = { ...untrimmed, durationFrames: 90 } // timeline [0,90)
+    const [e] = mapVideoEventsToTimeline(shortClip, [
+      { label: 'spans', startSec: 2.5, endSec: 4, confidence: 1 }, // 75..120
+    ], fps)
+    expect(e.startFrame).toBe(75)
+    expect(e.endFrame).toBe(90) // clamped to clip end
+  })
+})

--- a/packages/core/src/commands/editCommand.ts
+++ b/packages/core/src/commands/editCommand.ts
@@ -1,0 +1,109 @@
+/**
+ * EditCommand — the machine contract between the AI planner and the engine.
+ *
+ * The AI command-planning model emits an array of these; interpretEditCommands
+ * maps each one onto the TimelineEngine mutation funnel. This is the "FFmpeg-like
+ * command set" of the editor: a small, closed vocabulary of edits that are all
+ * expressible through existing engine methods and therefore fully undoable.
+ *
+ * TIME IS INTEGER FRAMES (engine principle P2). Every frame field here is an
+ * integer timeline frame. Conversion from the AI's seconds / MM:SS timestamps to
+ * frames happens at the web boundary where the project fps is known — the core
+ * never sees seconds, so it stays deterministic and fps-agnostic.
+ */
+
+/** Trim a clip's in/out points. Maps to engine.trimClip. */
+export interface TrimCommand {
+  kind: 'trim'
+  clipId: string
+  trackId: string
+  /** New timeline start frame of the clip. */
+  startFrame: number
+  /** New duration in frames. */
+  durationFrames: number
+}
+
+/** Split a clip in two at a timeline frame. Maps to engine.splitClip. */
+export interface SplitCommand {
+  kind: 'split'
+  clipId: string
+  trackId: string
+  /** Timeline frame at which to split; must be strictly inside the clip. */
+  atFrame: number
+}
+
+/** Remove a clip. Maps to engine.removeClip. */
+export interface DeleteCommand {
+  kind: 'delete'
+  clipId: string
+  trackId: string
+}
+
+/** Move a clip to a new start frame, optionally onto another track. Maps to engine.moveClip. */
+export interface MoveCommand {
+  kind: 'move'
+  clipId: string
+  fromTrackId: string
+  toTrackId: string
+  startFrame: number
+}
+
+/**
+ * Cut out a timeline range from a single clip: split at both boundaries and
+ * remove the middle segment. Composite — expands to split/split/remove inside
+ * one batch. This is the primitive behind "cut the part where the person
+ * says Hi".
+ */
+export interface CutRangeCommand {
+  kind: 'cutRange'
+  clipId: string
+  trackId: string
+  /** Inclusive timeline start frame of the range to remove. */
+  fromFrame: number
+  /** Exclusive timeline end frame of the range to remove. */
+  toFrame: number
+}
+
+export type EditCommand =
+  | TrimCommand
+  | SplitCommand
+  | DeleteCommand
+  | MoveCommand
+  | CutRangeCommand
+
+export type EditCommandKind = EditCommand['kind']
+
+/**
+ * JSON schema describing EditCommand[], suitable for prompting a structured-output
+ * model. Kept in sync with the discriminated union above. The planner is asked to
+ * return { "commands": EditCommand[] }.
+ */
+export const EDIT_COMMAND_JSON_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['commands'],
+  properties: {
+    commands: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['kind'],
+        properties: {
+          kind: {
+            type: 'string',
+            enum: ['trim', 'split', 'delete', 'move', 'cutRange'],
+          },
+          clipId: { type: 'string' },
+          trackId: { type: 'string' },
+          fromTrackId: { type: 'string' },
+          toTrackId: { type: 'string' },
+          startFrame: { type: 'integer', minimum: 0 },
+          durationFrames: { type: 'integer', minimum: 1 },
+          atFrame: { type: 'integer', minimum: 0 },
+          fromFrame: { type: 'integer', minimum: 0 },
+          toFrame: { type: 'integer', minimum: 0 },
+        },
+      },
+    },
+  },
+} as const

--- a/packages/core/src/commands/interpretEditCommands.ts
+++ b/packages/core/src/commands/interpretEditCommands.ts
@@ -1,0 +1,224 @@
+import type { TimelineEngine } from '../editor/TimelineEngine'
+import type { EditCommand } from './editCommand'
+
+/**
+ * Why a single command was not applied. Mirrors the tagged-failure style of
+ * actions/types.ts — the interpreter never throws on an expected rejection, it
+ * records a reason so the UI can explain what happened.
+ */
+export type EditCommandFailureReason =
+  | 'clip-not-found'
+  | 'track-mismatch'
+  | 'track-locked'
+  | 'invalid-range'
+  | 'split-outside-clip'
+  | 'engine-rejected'
+  | 'unknown-command'
+
+export type EditCommandResult =
+  | { ok: true; command: EditCommand }
+  | { ok: false; command: EditCommand; reason: EditCommandFailureReason }
+
+/**
+ * Execute AI-planned edit commands against the engine.
+ *
+ * The whole batch runs inside engine.batch(), so an entire AI edit — however
+ * many primitive commands it expands to — collapses into ONE undo entry. A
+ * command that can't be applied is reported in the returned results but does not
+ * abort the batch; sibling commands still run. (The engine's own guards — locked
+ * tracks, overlap, source bounds — remain the last line of defence.)
+ *
+ * Returns one result per input command, in order.
+ */
+export function interpretEditCommands(
+  engine: TimelineEngine,
+  commands: EditCommand[],
+  description = 'AI edit',
+): EditCommandResult[] {
+  const results: EditCommandResult[] = []
+
+  engine.batch(() => {
+    for (const command of commands) {
+      results.push(applyOne(engine, command))
+    }
+  }, description)
+
+  return results
+}
+
+function applyOne(
+  engine: TimelineEngine,
+  command: EditCommand,
+): EditCommandResult {
+  switch (command.kind) {
+    case 'trim':
+      return applyTrim(engine, command)
+    case 'split':
+      return applySplit(engine, command)
+    case 'delete':
+      return applyDelete(engine, command)
+    case 'move':
+      return applyMove(engine, command)
+    case 'cutRange':
+      return applyCutRange(engine, command)
+    default:
+      return { ok: false, command, reason: 'unknown-command' }
+  }
+}
+
+/** Confirm the clip exists on the stated track. */
+function locate(
+  engine: TimelineEngine,
+  clipId: string,
+  trackId: string,
+): { startFrame: number; durationFrames: number } | null {
+  const found = engine.findClip(clipId)
+  if (!found || found.trackId !== trackId) return null
+  return {
+    startFrame: found.clip.startFrame,
+    durationFrames: found.clip.durationFrames,
+  }
+}
+
+function applyTrim(
+  engine: TimelineEngine,
+  command: Extract<EditCommand, { kind: 'trim' }>,
+): EditCommandResult {
+  const clip = locate(engine, command.clipId, command.trackId)
+  if (!clip) return fail(command, engine, command.clipId, command.trackId)
+  if (command.durationFrames < 1) return { ok: false, command, reason: 'invalid-range' }
+
+  // No-op guard: trimClip already matches the request → nothing to verify.
+  const isNoOp =
+    clip.startFrame === command.startFrame && clip.durationFrames === command.durationFrames
+
+  engine.trimClip(
+    command.clipId,
+    command.trackId,
+    command.startFrame,
+    command.durationFrames,
+  )
+
+  // trimClip silently rejects (locked track, overlap, source-bounds) — confirm
+  // the clip actually moved, otherwise report the rejection like every sibling.
+  const after = locate(engine, command.clipId, command.trackId)
+  if (!after) return { ok: false, command, reason: 'engine-rejected' }
+  if (!isNoOp && after.startFrame === clip.startFrame && after.durationFrames === clip.durationFrames) {
+    return { ok: false, command, reason: 'engine-rejected' }
+  }
+  return { ok: true, command }
+}
+
+function applySplit(
+  engine: TimelineEngine,
+  command: Extract<EditCommand, { kind: 'split' }>,
+): EditCommandResult {
+  const clip = locate(engine, command.clipId, command.trackId)
+  if (!clip) return fail(command, engine, command.clipId, command.trackId)
+
+  const end = clip.startFrame + clip.durationFrames
+  if (command.atFrame <= clip.startFrame || command.atFrame >= end) {
+    return { ok: false, command, reason: 'split-outside-clip' }
+  }
+
+  const result = engine.splitClip(command.clipId, command.trackId, command.atFrame)
+  if (!result) return { ok: false, command, reason: 'engine-rejected' }
+  return { ok: true, command }
+}
+
+function applyDelete(
+  engine: TimelineEngine,
+  command: Extract<EditCommand, { kind: 'delete' }>,
+): EditCommandResult {
+  const clip = locate(engine, command.clipId, command.trackId)
+  if (!clip) return fail(command, engine, command.clipId, command.trackId)
+
+  engine.removeClip(command.clipId, command.trackId)
+  // removeClip is a silent no-op on a locked track; verify the clip is gone.
+  if (engine.findClip(command.clipId)) {
+    return { ok: false, command, reason: 'engine-rejected' }
+  }
+  return { ok: true, command }
+}
+
+function applyMove(
+  engine: TimelineEngine,
+  command: Extract<EditCommand, { kind: 'move' }>,
+): EditCommandResult {
+  const clip = locate(engine, command.clipId, command.fromTrackId)
+  if (!clip) return fail(command, engine, command.clipId, command.fromTrackId)
+
+  engine.moveClip(
+    command.clipId,
+    command.fromTrackId,
+    command.toTrackId,
+    command.startFrame,
+  )
+  // moveClip rejects overlaps / locked tracks silently — confirm it landed.
+  const after = engine.findClip(command.clipId)
+  if (!after || after.trackId !== command.toTrackId || after.clip.startFrame !== command.startFrame) {
+    return { ok: false, command, reason: 'engine-rejected' }
+  }
+  return { ok: true, command }
+}
+
+/**
+ * Cut a timeline range out of one clip. Splits at the range boundaries and
+ * removes the middle segment. This is the workhorse behind "cut the part where…".
+ *
+ * For a clip spanning [start, end) and a removal range [from, to):
+ *   - split at `from` (if strictly inside) → the right half becomes the segment
+ *   - split that segment at `to` (if strictly inside) → its left half is the middle
+ *   - remove the middle
+ */
+function applyCutRange(
+  engine: TimelineEngine,
+  command: Extract<EditCommand, { kind: 'cutRange' }>,
+): EditCommandResult {
+  const clip = locate(engine, command.clipId, command.trackId)
+  if (!clip) return fail(command, engine, command.clipId, command.trackId)
+
+  const start = clip.startFrame
+  const end = clip.startFrame + clip.durationFrames
+  const from = Math.max(command.fromFrame, start)
+  const to = Math.min(command.toFrame, end)
+  if (from >= to) return { ok: false, command, reason: 'invalid-range' }
+
+  const { trackId } = command
+  let segmentId = command.clipId
+
+  // Split off everything left of `from`; the right half is what we keep working on.
+  if (from > start) {
+    const split = engine.splitClip(segmentId, trackId, from)
+    if (!split) return { ok: false, command, reason: 'engine-rejected' }
+    segmentId = split[1]
+  }
+
+  // The segment now spans [from, end). Its left part up to `to` is the middle.
+  let middleId = segmentId
+  if (to < end) {
+    const split = engine.splitClip(segmentId, trackId, to)
+    if (!split) return { ok: false, command, reason: 'engine-rejected' }
+    middleId = split[0]
+  }
+
+  engine.removeClip(middleId, trackId)
+  if (engine.findClip(middleId)) {
+    return { ok: false, command, reason: 'engine-rejected' }
+  }
+  return { ok: true, command }
+}
+
+/** Distinguish "no such clip anywhere" from "clip exists but on a different track". */
+function fail(
+  command: EditCommand,
+  engine: TimelineEngine,
+  clipId: string,
+  trackId: string,
+): EditCommandResult {
+  const found = engine.findClip(clipId)
+  if (found && found.trackId !== trackId) {
+    return { ok: false, command, reason: 'track-mismatch' }
+  }
+  return { ok: false, command, reason: 'clip-not-found' }
+}

--- a/packages/core/src/commands/mapVideoEvents.ts
+++ b/packages/core/src/commands/mapVideoEvents.ts
@@ -1,0 +1,95 @@
+import { toFrame } from '../utils/frames'
+
+/**
+ * Map a video-understanding event (expressed in SOURCE seconds) onto TIMELINE
+ * frames for a specific clip.
+ *
+ * A clip plays a trimmed window of its source: source frames
+ * [sourceStartFrame, sourceStartFrame + durationFrames). An event at
+ * `startSec` in the source lands on the timeline at:
+ *
+ *   timelineFrame = clip.startFrame + (sourceFrame - clip.sourceStartFrame)
+ *
+ * where sourceFrame = round(startSec * fps). Events that fall entirely outside
+ * the clip's trimmed window are dropped; events that overlap it are clamped to
+ * the clip's timeline bounds. This is deterministic on purpose — the model
+ * locates moments, but the seconds→frames conversion must not be left to an LLM.
+ */
+
+export interface SourceVideoEvent {
+  label: string
+  /** Event start, seconds from the beginning of the SOURCE video. */
+  startSec: number
+  /** Optional event end, seconds from the beginning of the SOURCE video. */
+  endSec?: number
+  /** Model confidence 0..1. */
+  confidence: number
+}
+
+/** Just the clip geometry the mapping needs. */
+export interface ClipGeometry {
+  clipId: string
+  trackId: string
+  startFrame: number
+  durationFrames: number
+  sourceStartFrame: number
+}
+
+export interface TimelineEvent {
+  label: string
+  clipId: string
+  trackId: string
+  /** Inclusive timeline start frame, clamped to the clip. */
+  startFrame: number
+  /** Exclusive timeline end frame, clamped to the clip. Always > startFrame. */
+  endFrame: number
+  confidence: number
+}
+
+/**
+ * Convert source-time events to clip-relative timeline-frame events. Returns
+ * only events that intersect the clip's trimmed window, clamped to its bounds.
+ */
+export function mapVideoEventsToTimeline(
+  clip: ClipGeometry,
+  events: SourceVideoEvent[],
+  fps: number,
+): TimelineEvent[] {
+  const clipStart = clip.startFrame
+  const clipEnd = clip.startFrame + clip.durationFrames // exclusive
+  const out: TimelineEvent[] = []
+
+  for (const ev of events) {
+    const startSourceFrame = toFrame(ev.startSec * fps)
+    // Point events (no endSec) become a one-frame window so a range is well-formed.
+    const endSourceFrame =
+      typeof ev.endSec === 'number' && ev.endSec > ev.startSec
+        ? toFrame(ev.endSec * fps)
+        : startSourceFrame + 1
+
+    // Shift from source frames into timeline frames for this clip.
+    const offset = clipStart - clip.sourceStartFrame
+    let startFrame = startSourceFrame + offset
+    let endFrame = endSourceFrame + offset
+
+    // Drop events that don't intersect the clip's timeline span at all.
+    if (endFrame <= clipStart || startFrame >= clipEnd) continue
+
+    // Clamp to the clip bounds; guarantee endFrame > startFrame.
+    startFrame = Math.max(clipStart, startFrame)
+    endFrame = Math.min(clipEnd, endFrame)
+    if (endFrame <= startFrame) endFrame = Math.min(clipEnd, startFrame + 1)
+    if (endFrame <= startFrame) continue // clip too short to hold even one frame
+
+    out.push({
+      label: ev.label,
+      clipId: clip.clipId,
+      trackId: clip.trackId,
+      startFrame,
+      endFrame,
+      confidence: ev.confidence,
+    })
+  }
+
+  return out
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -141,6 +141,29 @@ export { splitClipAtPlayhead } from './actions/splitClipAtPlayhead'
 export type { SplitAtPlayheadData } from './actions/splitClipAtPlayhead'
 export type { ActionResult, ActionFailureReason } from './actions/types'
 
+// --- AI edit commands ---
+export { interpretEditCommands } from './commands/interpretEditCommands'
+export type {
+  EditCommandResult,
+  EditCommandFailureReason,
+} from './commands/interpretEditCommands'
+export { EDIT_COMMAND_JSON_SCHEMA } from './commands/editCommand'
+export { mapVideoEventsToTimeline } from './commands/mapVideoEvents'
+export type {
+  SourceVideoEvent,
+  ClipGeometry,
+  TimelineEvent,
+} from './commands/mapVideoEvents'
+export type {
+  EditCommand,
+  EditCommandKind,
+  TrimCommand,
+  SplitCommand,
+  DeleteCommand,
+  MoveCommand,
+  CutRangeCommand,
+} from './commands/editCommand'
+
 // --- Utilities ---
 export { framesToTimecode, secondsToFrames, framesToSeconds, getTotalFrames, clipsOverlap } from './utils/frames'
 export { generateId } from './utils/id'

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -75,6 +75,23 @@ export { splitClipAtPlayhead } from '@elah/core'
 export type { SplitAtPlayheadData } from '@elah/core'
 export type { ActionResult, ActionFailureReason } from '@elah/core'
 
+// AI edit commands
+export { interpretEditCommands, EDIT_COMMAND_JSON_SCHEMA, mapVideoEventsToTimeline } from '@elah/core'
+export type {
+  EditCommand,
+  EditCommandKind,
+  TrimCommand,
+  SplitCommand,
+  DeleteCommand,
+  MoveCommand,
+  CutRangeCommand,
+  EditCommandResult,
+  EditCommandFailureReason,
+  SourceVideoEvent,
+  ClipGeometry,
+  TimelineEvent,
+} from '@elah/core'
+
 export { framesToTimecode, secondsToFrames, framesToSeconds, getTotalFrames } from '@elah/core'
 export { generateId } from '@elah/core'
 export { transformFromCoverRect } from '@elah/core'


### PR DESCRIPTION
Two-stage agent: Gemini video understanding locates timestamped events, Groq plans them into structured EditCommands that run against the existing TimelineEngine mutation API (no FFmpeg). Edits apply as a single undo entry.

- core: EditCommand schema + interpreter + pure seconds->frames mapper (21 tests)
- web: Gemini (inline + Files API cache) and Groq providers, 429 retry, /api/ai/edit-agent route, and the /edit command bar in ProductionEditor
- seconds->frames mapping is deterministic; command targets are validated

## What does this PR do?

<!-- One sentence. "Fixes X" or "Adds Y" -->

Closes #

---

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Performance improvement

---

## How to test

<!-- Steps to verify this works. Be specific. -->

1. 
2. 
3. 

---

## Screenshots / Recording

<!-- Required for any UI change. Delete this section if not applicable. -->

---

## Checklist

- [ ] `npm test` passes
- [ ] `npm run typecheck` passes
- [ ] I've tested this in the playground
- [ ] No `any` types introduced without justification
