### PR TITLE
fix: clear type errors and fix root typecheck script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev": "npm run dev --workspace=apps/web",
     "build:packages": "npm run build --workspace=packages/core && npm run build --workspace=packages/react && npm run build --workspace=packages/timeline && npm run build --workspace=packages/editor && npm run build --workspace=packages/cli",
     "build": "npm run build --workspace=apps/web",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "npm run typecheck --workspaces --if-present",
     "lint:tokens": "node scripts/check-tokens.mjs",
     "test": "npm run test --workspace=packages/core --workspace=packages/timeline --workspace=packages/cli"
   },

--- a/packages/core/src/media/audio/__tests__/AudioPlaybackController.test.ts
+++ b/packages/core/src/media/audio/__tests__/AudioPlaybackController.test.ts
@@ -60,8 +60,6 @@ function makeMockAudioContext() {
   }
 
   function makeGain(initialValue = 1) {
-    const gains: ReturnType<typeof makeGainParam>[] = []
-
     function makeGainParam(v: number) {
       const param = {
         value: v,
@@ -69,7 +67,6 @@ function makeMockAudioContext() {
         setValueAtTime: vi.fn(),
         linearRampToValueAtTime: vi.fn((target: number) => { param.value = target }),
       }
-      gains.push(param)
       return param
     }
 
@@ -443,7 +440,7 @@ describe('AudioPlaybackController', () => {
 
     // Grab the statechange handler registered on the mock context.
     const stateChangeCall = raw.addEventListener.mock.calls.find(
-      ([event]: [string]) => event === 'statechange',
+      (call: unknown[]) => call[0] === 'statechange',
     )
     expect(stateChangeCall).toBeDefined()
     const stateChangeHandler = stateChangeCall![1] as () => void

--- a/packages/core/src/renderer/gpu/__tests__/GoldenFrameHash.test.ts
+++ b/packages/core/src/renderer/gpu/__tests__/GoldenFrameHash.test.ts
@@ -54,6 +54,8 @@ function makeScene(overrides: Partial<Scene> = {}): Scene {
     audios: [],
     texts: [],
     images: [],
+    shapes: [],
+    freehand: [],
     transitions: [],
     ...overrides,
   }

--- a/packages/core/src/renderer/gpu/__tests__/RenderGraph.test.ts
+++ b/packages/core/src/renderer/gpu/__tests__/RenderGraph.test.ts
@@ -21,6 +21,8 @@ const STUB_SCENE: Scene = {
   audios: [],
   texts: [],
   images: [],
+  shapes: [],
+  freehand: [],
   transitions: [],
 }
 


### PR DESCRIPTION
## What does this PR do?

Fixes the 5 real TypeScript errors in `packages/core` test files and repairs the root `typecheck` script so it stops emitting ~144 false `Cannot find module '@/...'` errors.

Closes # — no linked issue (housekeeping found while running `npm run typecheck`).

---

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Performance improvement

(Also a build-script fix: root `typecheck` was misconfigured.)

---

## How to test

1. `git checkout fix/typecheck-test-types && npm install`
2. `npm run typecheck` at the repo root → passes across all 6 workspaces (before this branch it reported 149 errors: 144 phantom `@/…` + 5 real).
3. `npm test` → core/timeline/cli suites pass (505 passed, 2 e2e skipped).
4. Confirm the two renderer scene stubs and the audio test compile: `npm run typecheck --workspace=packages/core`.

---

## Screenshots / Recording

N/A — no UI change (test files + root `package.json` script only).

---

## Checklist

- [x] `npm test` passes
- [x] `npm run typecheck` passes
- [ ] I've tested this in the playground — N/A (test/build-config change, no runtime surface)
- [x] No `any` types introduced without justification