### PR TITLE
docs: strengthen blog SEO metadata and LLM-friendly content routes

### DIFF
--- a/apps/web/app/blog/[slug]/md/route.ts
+++ b/apps/web/app/blog/[slug]/md/route.ts
@@ -1,0 +1,28 @@
+import { posts, getPost } from '../../posts'
+import { postToMarkdown } from '../../serialize'
+
+// Raw markdown of a post at /blog/[slug]/md — a machine-readable full-content
+// endpoint for LLM agents and doc fetchers (advertised from /llms.txt). The
+// HTML page at /blog/[slug] stays canonical; this mirrors its body as text.
+
+export function generateStaticParams() {
+  return posts.map((post) => ({ slug: post.slug }))
+}
+
+export async function GET(_req: Request, { params }: { params: Promise<{ slug: string }> }): Promise<Response> {
+  const { slug } = await params
+  const post = getPost(slug)
+  if (!post) {
+    return new Response(`# Not found\n\nNo blog post with slug "${slug}".\n`, {
+      status: 404,
+      headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+    })
+  }
+
+  return new Response(postToMarkdown(post), {
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600, s-maxage=3600',
+    },
+  })
+}

--- a/apps/web/app/blog/[slug]/opengraph-image.tsx
+++ b/apps/web/app/blog/[slug]/opengraph-image.tsx
@@ -1,0 +1,72 @@
+import { ImageResponse } from 'next/og'
+import { posts, getPost } from '../posts'
+
+// Per-post file-based OG image: Next serves this at /blog/[slug]/opengraph-image
+// and injects og:image + twitter:image for each article, so every post gets a
+// distinct social card (title + category) instead of the shared site image.
+export const alt = 'elah engineering blog'
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+
+export function generateStaticParams() {
+  return posts.map((post) => ({ slug: post.slug }))
+}
+
+export default async function BlogOgImage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params
+  const post = getPost(slug)
+  const title = post?.title ?? 'elah blog'
+  const category = post?.category ?? 'Engineering'
+  const readingTime = post?.readingTime ?? ''
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          backgroundColor: '#111010',
+          padding: 72,
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
+          <div style={{ width: 14, height: 14, borderRadius: 3, backgroundColor: '#fcf9f8' }} />
+          <div style={{ fontSize: 26, color: '#9b9391', letterSpacing: 4 }}>
+            {`${category.toUpperCase()} · ELAH BLOG`}
+          </div>
+        </div>
+
+        <div
+          style={{
+            display: 'flex',
+            fontSize: title.length > 44 ? 64 : 80,
+            fontWeight: 700,
+            color: '#fcf9f8',
+            letterSpacing: -2,
+            lineHeight: 1.08,
+            maxWidth: 1040,
+          }}
+        >
+          {title}
+        </div>
+
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            borderTop: '1px solid #312d2d',
+            paddingTop: 32,
+          }}
+        >
+          <div style={{ fontSize: 28, color: '#9b9391' }}>elah.dev/blog</div>
+          <div style={{ fontSize: 28, color: '#9b9391' }}>{readingTime}</div>
+        </div>
+      </div>
+    ),
+    size
+  )
+}

--- a/apps/web/app/blog/[slug]/page.tsx
+++ b/apps/web/app/blog/[slug]/page.tsx
@@ -31,7 +31,10 @@ export async function generateMetadata({
       title: post.title,
       description: post.excerpt,
       publishedTime: post.date,
-      authors: ['elah'],
+      modifiedTime: post.date,
+      authors: [siteConfig.url],
+      section: post.category,
+      tags: [post.category],
     },
     twitter: { card: 'summary_large_image', title: post.title, description: post.excerpt },
   }
@@ -118,7 +121,9 @@ export default async function BlogPostPage({
     '@type': 'BlogPosting',
     headline: post.title,
     description: post.excerpt,
+    image: `${siteConfig.url}/blog/${post.slug}/opengraph-image`,
     datePublished: post.date,
+    dateModified: post.date,
     articleSection: post.category,
     author: { '@type': 'Organization', name: 'elah', url: siteConfig.url },
     publisher: { '@type': 'Organization', name: 'elah', url: siteConfig.url },
@@ -156,7 +161,9 @@ export default async function BlogPostPage({
               {post.title}
             </h1>
             <p className="mt-3 text-sm leading-relaxed text-on-surface-variant">{post.excerpt}</p>
-            <time className="mt-4 block text-xs text-on-surface-variant">{post.date}</time>
+            <time dateTime={post.date} className="mt-4 block text-xs text-on-surface-variant">
+              {post.date}
+            </time>
           </div>
         </div>
 

--- a/apps/web/app/blog/page.tsx
+++ b/apps/web/app/blog/page.tsx
@@ -60,7 +60,9 @@ export default function BlogPage() {
                 </p>
 
                 <div className="flex items-center justify-between">
-                  <time className="text-xs text-on-surface-variant">{post.date}</time>
+                  <time dateTime={post.date} className="text-xs text-on-surface-variant">
+                    {post.date}
+                  </time>
                   <Link
                     href={`/blog/${post.slug}`}
                     className="flex items-center gap-1 text-xs font-medium text-primary transition-colors hover:underline"

--- a/apps/web/app/blog/serialize.ts
+++ b/apps/web/app/blog/serialize.ts
@@ -1,0 +1,82 @@
+// Serializers that turn a post's structured `Block[]` body into plain markdown
+// (for agents via /blog/[slug]/md and /llms-full.txt) and into HTML (for the
+// RSS `content:encoded` full body). `posts.ts` stays pure data; rendering to
+// non-React targets lives here so all three consumers share one source of truth.
+
+import { siteConfig } from '@/config/site'
+import type { Block, Post } from './posts'
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+}
+
+// Inline `code` spans use backticks in the source text. Markdown passes them
+// through as-is; for HTML we convert paired backticks to <code> elements.
+function inlineToHtml(text: string): string {
+  return text
+    .split('`')
+    .map((segment, i) => (i % 2 === 1 ? `<code>${escapeHtml(segment)}</code>` : escapeHtml(segment)))
+    .join('')
+}
+
+function blockToMarkdown(block: Block): string {
+  switch (block.type) {
+    case 'h2':
+      return `## ${block.text}`
+    case 'p':
+      return block.text
+    case 'code':
+      return `\`\`\`${block.language ?? ''}\n${block.code}\n\`\`\``
+    case 'note':
+      return [block.title ? `> **${block.title}**` : null, `> ${block.text.replace(/\n/g, '\n> ')}`]
+        .filter(Boolean)
+        .join('\n>\n')
+    case 'quote':
+      return `> ${block.text}`
+    case 'list':
+      return block.items.map((item) => `- ${item}`).join('\n')
+  }
+}
+
+function blockToHtml(block: Block): string {
+  switch (block.type) {
+    case 'h2':
+      return `<h2 id="${block.id}">${escapeHtml(block.text)}</h2>`
+    case 'p':
+      return `<p>${inlineToHtml(block.text)}</p>`
+    case 'code':
+      return `<pre><code>${escapeHtml(block.code)}</code></pre>`
+    case 'note':
+      return `<blockquote>${block.title ? `<strong>${escapeHtml(block.title)}</strong> ` : ''}${inlineToHtml(block.text)}</blockquote>`
+    case 'quote':
+      return `<blockquote>${inlineToHtml(block.text)}</blockquote>`
+    case 'list':
+      return `<ul>${block.items.map((item) => `<li>${inlineToHtml(item)}</li>`).join('')}</ul>`
+  }
+}
+
+/** Full post as clean markdown, with a canonical-link header block for agents. */
+export function postToMarkdown(post: Post): string {
+  const url = `${siteConfig.url}/blog/${post.slug}`
+  const header = [
+    `# ${post.title}`,
+    '',
+    `> ${post.excerpt}`,
+    '',
+    `**Published:** ${post.date} · **Category:** ${post.category} · **Reading time:** ${post.readingTime}`,
+    `**Canonical:** ${url}`,
+    '',
+    '---',
+    '',
+  ].join('\n')
+  const body = post.content.map(blockToMarkdown).join('\n\n')
+  return `${header}${body}\n`
+}
+
+/** Full post body as HTML — used for RSS `content:encoded`. */
+export function postToHtml(post: Post): string {
+  return post.content.map(blockToHtml).join('\n')
+}

--- a/apps/web/app/feed.xml/route.ts
+++ b/apps/web/app/feed.xml/route.ts
@@ -1,5 +1,6 @@
 import { siteConfig } from '@/config/site'
 import { posts } from '../blog/posts'
+import { postToHtml } from '../blog/serialize'
 
 function escapeXml(value: string): string {
   return value
@@ -23,12 +24,13 @@ export function GET(): Response {
       <pubDate>${new Date(post.date).toUTCString()}</pubDate>
       <category>${escapeXml(post.category)}</category>
       <description>${escapeXml(post.excerpt)}</description>
+      <content:encoded><![CDATA[${postToHtml(post)}]]></content:encoded>
     </item>`
     })
     .join('\n')
 
   const body = `<?xml version="1.0" encoding="UTF-8"?>
-<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/">
   <channel>
     <title>${escapeXml(siteConfig.name)} blog</title>
     <link>${base}/blog</link>

--- a/apps/web/app/llms-full.txt/route.ts
+++ b/apps/web/app/llms-full.txt/route.ts
@@ -1,0 +1,32 @@
+import { siteConfig } from '@/config/site'
+import { posts } from '../blog/posts'
+import { postToMarkdown } from '../blog/serialize'
+
+/**
+ * Generates /llms-full.txt — the full-content companion to /llms.txt. Where
+ * llms.txt is a curated link index, this concatenates every blog post's
+ * complete markdown body so an agent can ingest the writing in a single fetch
+ * without crawling each HTML page. Derived from the blog source of truth, so
+ * new posts appear automatically.
+ */
+export function GET(): Response {
+  const ordered = [...posts].sort((a, b) => b.date.localeCompare(a.date))
+
+  const body = `# ${siteConfig.name} — full blog content
+
+> ${siteConfig.description}
+
+This file concatenates the full markdown of every post at ${siteConfig.url}/blog.
+The curated link index lives at ${siteConfig.url}/llms.txt. Each post is also
+available individually at ${siteConfig.url}/blog/<slug>/md.
+
+${ordered.map((post) => postToMarkdown(post)).join('\n\n---\n\n')}
+`
+
+  return new Response(body, {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600, s-maxage=3600',
+    },
+  })
+}

--- a/apps/web/app/llms.txt/route.ts
+++ b/apps/web/app/llms.txt/route.ts
@@ -40,9 +40,11 @@ const RESOURCES: DocLink[] = [
 ]
 
 // Derived from the blog source of truth so new posts appear automatically.
+// Each post links to its raw-markdown variant (/blog/<slug>/md) so agents can
+// fetch full content directly instead of scraping the HTML page.
 const POSTS: DocLink[] = posts.map((post) => ({
   title: post.title,
-  path: `/blog/${post.slug}`,
+  path: `/blog/${post.slug}/md`,
   description: post.excerpt,
 }))
 
@@ -73,6 +75,9 @@ Elah is a browser-native, frame-accurate video editing engine: a framework-agnos
 core (timeline engine, pure resolver, WebGL2 renderer, WebCodecs decode, MP4 export)
 with React bindings on top. Time is integer frames; every edit funnels through one
 engine; \`resolveTimeline(frame, project) → Scene\` is the pure bridge to any renderer.
+
+For full blog content in one fetch, see ${base}/llms-full.txt. Individual posts are
+available as raw markdown at ${base}/blog/<slug>/md.
 
 ${section('Documentation', DOCS, base)}
 


### PR DESCRIPTION
## What does this PR do?

Adds LLM-friendly full-content routes for the blog and strengthens per-post SEO metadata (per-post OG images, richer JSON-LD, machine-readable dates).

Closes # — no linked issue (follow-on hardening of the blog from the SEO/AEO work).

---

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behavior change)
- [x] Documentation
- [ ] Performance improvement

---

## How to test

1. `git checkout fix/blog-llm-seo && npm install && npm run build`
2. `npx next start` (in `apps/web`), then:
   - `curl localhost:3000/blog/webcodecs-frame-pool-exhaustion/md` → full post as `text/markdown`.
   - `curl localhost:3000/llms-full.txt` → all posts concatenated as markdown.
   - `curl -I localhost:3000/blog/webcodecs-frame-pool-exhaustion/opengraph-image` → `image/png` (unique per post).
   - `curl localhost:3000/feed.xml | grep content:encoded` → full HTML bodies present.
   - View a post's page source → `og:image` per-post, JSON-LD `image`+`dateModified`, `<time datetime>`, `article:section`.
3. `/llms.txt` now links each post's `/md` variant and advertises `/llms-full.txt`.

---

## Screenshots / Recording

New per-post OG social card (1200×630, title + category) is generated at `/blog/<slug>/opengraph-image` — open that URL to view the card image. No on-page UI change (only a non-visual `datetime` attribute + JSON-LD).
<img width="1200" height="630" alt="og-architecture" src="https://github.com/user-attachments/assets/812504c8-df83-46e8-a241-6dad9e89f643" />

<img width="1200" height="630" alt="og-implementation" src="https://github.com/user-attachments/assets/4508b8b1-5f76-4d81-91f0-1b50a54dd042" />

<img width="1200" height="630" alt="og-design" src="https://github.com/user-attachments/assets/030cef43-d3fe-48aa-bbaf-1842a9e7baa1" />



---

## Checklist

- [x] `npm test` passes (core/timeline/cli — unaffected; 505 passed, 2 e2e skipped)
- [ ] `npm run typecheck` passes — `apps/web` typecheck is clean (0 errors); the repo-root `tsc --noEmit` fails on this branch due to a PRE-EXISTING issue on `dev` (phantom `@/…` + implicit-any), fixed separately by PR #44.
- [x] I've tested this in the playground (verified all routes against a running `next start` build)
- [x] No `any` types introduced without justification