### PR TITLE
docs: add jsdoc to the public API

### DIFF
--- a/packages/core/src/elements/audio.ts
+++ b/packages/core/src/elements/audio.ts
@@ -1,6 +1,7 @@
 import type { Clip, Transform } from '../types'
 import { createClip } from './base'
 
+/** Inputs for createAudioClip; `src`/`assetId` bind to imported media and `volume` sets the clip's linear level. */
 export interface CreateAudioClipOptions {
   trackId: string
   name?: string
@@ -13,6 +14,7 @@ export interface CreateAudioClipOptions {
   transform?: Transform
 }
 
+/** Typed wrapper over createClip that pins `type: 'audio'` and supplies a default name so callers can't omit them. */
 export function createAudioClip(options: CreateAudioClipOptions): Clip {
   return createClip({ ...options, type: 'audio', name: options.name ?? 'Audio' })
 }

--- a/packages/core/src/elements/image.ts
+++ b/packages/core/src/elements/image.ts
@@ -1,6 +1,7 @@
 import type { Clip, Transform } from '../types'
 import { createClip } from './base'
 
+/** Inputs for createImageClip; `src`/`assetId` bind to imported media, `durationFrames` sets how long the still holds. */
 export interface CreateImageClipOptions {
   trackId: string
   name?: string
@@ -13,6 +14,7 @@ export interface CreateImageClipOptions {
   transform?: Transform
 }
 
+/** Typed wrapper over createClip that pins `type: 'image'` and supplies a default name so callers can't omit them. */
 export function createImageClip(options: CreateImageClipOptions): Clip {
   return createClip({ ...options, type: 'image', name: options.name ?? 'Image' })
 }

--- a/packages/core/src/elements/text.ts
+++ b/packages/core/src/elements/text.ts
@@ -1,6 +1,7 @@
 import type { Clip } from '../types'
 import { createClip, type TextClipMetadata } from './base'
 
+/** Inputs for createTextClip; `text` carries the styled content, and text clips have no source media so they trim freely. */
 export interface CreateTextClipOptions {
   trackId: string
   name?: string
@@ -11,6 +12,7 @@ export interface CreateTextClipOptions {
   opacity?: number
 }
 
+/** Typed wrapper over createClip that pins `type: 'text'` and supplies a default name so callers can't omit them. */
 export function createTextClip(options: CreateTextClipOptions): Clip {
   return createClip({
     ...options,

--- a/packages/core/src/elements/video.ts
+++ b/packages/core/src/elements/video.ts
@@ -1,6 +1,7 @@
 import type { Clip, Transform } from '../types'
 import { createClip } from './base'
 
+/** Inputs for createVideoClip; `src`/`assetId` bind to imported media, the rest are optional visual/audio overrides. */
 export interface CreateVideoClipOptions {
   trackId: string
   name?: string
@@ -13,6 +14,7 @@ export interface CreateVideoClipOptions {
   transform?: Transform
 }
 
+/** Typed wrapper over createClip that pins `type: 'video'` and supplies a default name so callers can't omit them. */
 export function createVideoClip(options: CreateVideoClipOptions): Clip {
   return createClip({ ...options, type: 'video', name: options.name ?? 'Video' })
 }

--- a/packages/core/src/playback/PlaybackEngine.ts
+++ b/packages/core/src/playback/PlaybackEngine.ts
@@ -13,6 +13,7 @@
 
 import { trace } from '../debug/trace'
 
+/** Immutable transport state pushed to subscribers; `epoch` bumps on every command so a same-frame re-seek still notifies. */
 export interface PlaybackSnapshot {
   currentFrame: number
   isPlaying: boolean
@@ -149,6 +150,7 @@ export class PlaybackEngine {
 
   // ── Commands ─────────────────────────────────────────────────────────────
 
+  /** No-op if already playing; re-anchors the clock to now so resuming never replays skipped wall-clock time. */
   play(): void {
     if (this._playing) return
     this.anchorTime = this.now()
@@ -158,6 +160,7 @@ export class PlaybackEngine {
     this.startRAF()
   }
 
+  /** No-op if already paused; freezes the integrated frame so a later play() continues from exactly here. */
   pause(): void {
     if (!this._playing) return
     this.anchorFrame = this.getFrameAt()
@@ -167,6 +170,7 @@ export class PlaybackEngine {
     this.notify()
   }
 
+  /** Jumps to a frame and always bumps the epoch — even seeking to the current frame — so one-shot effects retrigger. */
   seek(frame: number): void {
     const next = Math.max(0, Math.floor(frame))
     trace('SET_PLAYHEAD', { target: next, fromAnchor: this.anchorFrame, playing: this._playing })
@@ -208,6 +212,7 @@ export class PlaybackEngine {
 
   // ── Lifecycle ────────────────────────────────────────────────────────────
 
+  /** Must be called when the engine is discarded — cancels the RAF loop and drops listeners so the clock can't leak. */
   destroy(): void {
     if (this.rafId !== null) {
       cancelAnimationFrame(this.rafId)

--- a/packages/core/src/stores/selection.store.ts
+++ b/packages/core/src/stores/selection.store.ts
@@ -1,10 +1,12 @@
 import { createStore } from 'zustand/vanilla'
 
+/** UI-only selection (Ring 2); holds no engine truth, so ids here may name clips that have since been removed. */
 export interface SelectionState {
   selectedClipIds: Set<string>
   activeTrackId: string | null
 }
 
+/** Selection mutators; selectClip replaces the set, toggleClipSelection adds/removes within it for multi-select. */
 export interface SelectionActions {
   selectClip: (clipId: string) => void
   toggleClipSelection: (clipId: string) => void
@@ -13,6 +15,7 @@ export interface SelectionActions {
   setActiveTrack: (trackId: string | null) => void
 }
 
+/** Vanilla store so core stays React-free; @elah/react wraps it as the `useSelectionStore` hook. */
 export const selectionStore = createStore<SelectionState & SelectionActions>()(
   (set) => ({
     selectedClipIds: new Set(),

--- a/packages/editor/src/editor/AssetPanel/AssetPanel.tsx
+++ b/packages/editor/src/editor/AssetPanel/AssetPanel.tsx
@@ -26,6 +26,7 @@ import {
   type AssetActivationHandler,
 } from '../activation'
 
+/** Props for AssetPanel; passing `onAssetActivate` (or `activateOnTap`) opts into tap-to-add on top of drag-to-timeline. */
 export interface AssetPanelProps {
   style?: CSSProperties
   className?: string

--- a/packages/react/src/editor-context.ts
+++ b/packages/react/src/editor-context.ts
@@ -1,18 +1,23 @@
 import { createContext, useContext } from 'react'
 import type { TimelineEngine, PlaybackEngine } from '@elah/core'
 
+/** The engine pair every editor hook reads from — the React bridge to core's framework-agnostic classes. */
 export interface EditorContextValue {
   engine: TimelineEngine
   playback: PlaybackEngine
 }
 
+/** Nullable by default so useEditor can detect and reject use outside an EditorProvider. */
 export const EditorContext = createContext<EditorContextValue | null>(null)
 
+/** Throws instead of returning null so a misplaced hook fails loudly at render, not later with an undefined engine. */
 export function useEditor(): EditorContextValue {
   const ctx = useContext(EditorContext)
   if (!ctx) throw new Error('useEditor must be used inside <EditorProvider>')
   return ctx
 }
 
+/** Convenience accessor for the timeline engine alone, for components that never touch playback. */
 export const useTimelineEngine = (): TimelineEngine => useEditor().engine
+/** Convenience accessor for the playback engine alone, for transport controls that never mutate the timeline. */
 export const usePlaybackEngine = (): PlaybackEngine => useEditor().playback


### PR DESCRIPTION
## What does this PR do?

Adds one-line JSDoc (why-not-what, per CONTRIBUTING.md) to public API symbols that had none, so SDK consumers get hover docs in VS Code.

Closes #3

---

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [x] Documentation
- [ ] Performance improvement

---

## How to test

1. `git checkout docs/jsdoc-public-api`
2. Open any of the touched files (e.g. `packages/core/src/playback/PlaybackEngine.ts`) in VS Code.
3. Hover over `play()`, `seek()`, `createVideoClip`, `useEditor`, etc. — a description now appears where before there was none.

Comments only — no signatures, exports, or runtime behavior change. `npm run typecheck` shows the same pre-existing error count with and without this branch (149 → 149); none reference the touched files.

---

## Notes on scope vs. the issue

The issue predates the `@elah/react` package split, so two items differ from what it lists:

- **`editor-context.ts`** — the issue lists it under `packages/core/`; it now lives at `packages/react/src/editor-context.ts`. Documented there (`EditorContextValue`, `EditorContext`, `useEditor`, `useTimelineEngine`, `usePlaybackEngine`).
- **`TimelineEngine.ts`** — already fully documented on `dev`; no change needed.
- The core store exports the vanilla `selectionStore`; the issue's `useSelectionStore` hook is the `@elah/react` wrapper.

Files touched: `PlaybackEngine.ts`, `elements/{video,text,image,audio}.ts`, `stores/selection.store.ts`, `AssetPanel.tsx`, `react/src/editor-context.ts`.

---

## Checklist

- [ ] `npm test` passes
- [ ] `npm run typecheck` passes
- [x] I've tested this in the playground
- [x] No `any` types introduced without justification