### PR TITLE
fix: make playground editor layout responsive

### DIFF
--- a/playground/next/app/globals.css
+++ b/playground/next/app/globals.css
@@ -137,3 +137,32 @@ body {
   background: var(--pg-bg-elevated) !important;
   border-color: var(--pg-border) !important;
 }
+
+/* Visible tooltip on hover — surfaces each button's `title` instantly and
+   styled, instead of relying only on the browser's slow native tooltip. */
+.elah-toolbar-btn,
+.elah-export-btn {
+  position: relative;
+}
+.elah-toolbar-btn[title]:hover::after,
+.elah-export-btn[title]:hover::after {
+  content: attr(title);
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 4px 8px;
+  border-radius: var(--pg-radius-sm, 4px);
+  background: var(--pg-bg-elevated);
+  color: var(--pg-text);
+  border: 1px solid var(--pg-border);
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1;
+  white-space: nowrap;
+  letter-spacing: 0.02em;
+  text-transform: none;
+  pointer-events: none;
+  z-index: 50;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+}

--- a/playground/next/components/ProductionEditor.tsx
+++ b/playground/next/components/ProductionEditor.tsx
@@ -308,6 +308,32 @@ export default function ProductionEditor() {
   const demuxerFactoryRef = useRef(createDefaultDemuxerFactory())
 
   const [showExportModal, setShowExportModal] = useState(false)
+  const [timelineHeight, setTimelineHeight] = useState(236)
+  const resizeRef = useRef<{ startY: number; startHeight: number } | null>(null)
+
+  // Drag the handle above the timeline to resize its height. Clamped so the
+  // timeline can neither swallow the canvas nor collapse below a usable strip.
+  const onTimelineResizeStart = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      e.preventDefault()
+      resizeRef.current = { startY: e.clientY, startHeight: timelineHeight }
+      const onMove = (ev: PointerEvent) => {
+        if (!resizeRef.current) return
+        const delta = ev.clientY - resizeRef.current.startY
+        setTimelineHeight(
+          Math.min(600, Math.max(120, resizeRef.current.startHeight - delta)),
+        )
+      }
+      const onUp = () => {
+        resizeRef.current = null
+        window.removeEventListener('pointermove', onMove)
+        window.removeEventListener('pointerup', onUp)
+      }
+      window.addEventListener('pointermove', onMove)
+      window.addEventListener('pointerup', onUp)
+    },
+    [timelineHeight],
+  )
 
   const handleExportStart = useCallback(async (opts: {
     videoBitrate: number
@@ -397,10 +423,30 @@ export default function ProductionEditor() {
 
           <TimelineControls timelineRef={timelineRef} />
 
+          <div
+            role="separator"
+            aria-orientation="horizontal"
+            title="Drag to resize timeline"
+            onPointerDown={onTimelineResizeStart}
+            style={{
+              height: 7,
+              flexShrink: 0,
+              cursor: 'ns-resize',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              background: theme.bgSecondary,
+              borderTop: `1px solid ${theme.border}`,
+              touchAction: 'none',
+            }}
+          >
+            <div style={{ width: 36, height: 3, borderRadius: 2, background: theme.border }} />
+          </div>
+
           <Timeline
             ref={timelineRef}
             fps={FPS}
-            style={{ height: 236, flexShrink: 0, minWidth: 0 }}
+            style={{ height: timelineHeight, flexShrink: 0, minWidth: 0 }}
           />
         </div>
       </div>

--- a/playground/next/components/ProductionEditor.tsx
+++ b/playground/next/components/ProductionEditor.tsx
@@ -58,11 +58,14 @@ const AppHeader = memo(function AppHeader({ onExport }: { onExport: () => void }
   return (
     <header
       style={{
-        display: 'grid',
-        gridTemplateColumns: '1fr auto 1fr',
+        display: 'flex',
         alignItems: 'center',
-        padding: '0 16px',
-        height: 46,
+        justifyContent: 'space-between',
+        flexWrap: 'wrap',
+        columnGap: 12,
+        rowGap: 6,
+        padding: '6px 16px',
+        minHeight: 46,
         background: theme.bgSecondary,
         borderBottom: `1px solid ${theme.border}`,
         flexShrink: 0,
@@ -189,11 +192,14 @@ const TimelineControls = memo(function TimelineControls({
   return (
     <div
       style={{
-        display: 'grid',
-        gridTemplateColumns: '1fr auto 1fr',
+        display: 'flex',
         alignItems: 'center',
-        height: 40,
-        padding: '0 16px',
+        justifyContent: 'space-between',
+        flexWrap: 'wrap',
+        columnGap: 12,
+        rowGap: 6,
+        minHeight: 40,
+        padding: '6px 16px',
         background: theme.bgSecondary,
         borderTop: `1px solid ${theme.border}`,
         flexShrink: 0,
@@ -269,6 +275,7 @@ const TimelineControls = memo(function TimelineControls({
             className="elah-toolbar-btn"
             style={aspectBtn(aspectActive(1920, 1080))}
             onClick={() => engine.setStage(1920, 1080)}
+            title="Landscape 16:9"
           >
             16:9
           </button>
@@ -277,6 +284,7 @@ const TimelineControls = memo(function TimelineControls({
             className="elah-toolbar-btn"
             style={aspectBtn(aspectActive(1080, 1920))}
             onClick={() => engine.setStage(1080, 1920)}
+            title="Portrait 9:16"
           >
             9:16
           </button>
@@ -285,6 +293,7 @@ const TimelineControls = memo(function TimelineControls({
             className="elah-toolbar-btn"
             style={aspectBtn(aspectActive(1080, 1080))}
             onClick={() => engine.setStage(1080, 1080)}
+            title="Square 1:1"
           >
             1:1
           </button>

--- a/playground/next/components/ProductionEditor.tsx
+++ b/playground/next/components/ProductionEditor.tsx
@@ -120,19 +120,13 @@ const AppHeader = memo(function AppHeader({ onExport }: { onExport: () => void }
   )
 })
 
-const TimelineControls = memo(function TimelineControls({
-  timelineRef,
-}: {
-  timelineRef: React.RefObject<TimelineRef | null>
-}) {
-  const engine = useTimelineEngine()
+// Play control + running time — mirrors the app-side editor by sitting directly
+// below the preview. A 1fr auto 1fr grid centers the play button; the running
+// time / total time reads on the left.
+const PreviewTransport = memo(function PreviewTransport() {
   const isPlaying = usePlaybackStore((s) => s.isPlaying)
   const togglePlayPause = usePlaybackStore((s) => s.togglePlayPause)
-  const zoom = usePlaybackStore((s) => s.zoom)
-  const setZoom = usePlaybackStore((s) => s.setZoom)
   const totalFrames = useTracksStore((s) => s.totalFrames)
-  const stage = useTracksStore((s) => s.stage)
-  const hasSelection = useSelectionStore((s) => s.selectedClipIds.size === 1)
   const timecodeRef = useRef<HTMLSpanElement>(null)
 
   useEffect(() => {
@@ -153,6 +147,72 @@ const TimelineControls = memo(function TimelineControls({
         `${framesToTimecode(frame, FPS)} / ${framesToTimecode(dur, FPS)}`
     }
   }, [totalFrames])
+
+  const playBtnStyle: React.CSSProperties = {
+    ...btnDisabled(false),
+    minWidth: 36,
+    padding: '5px 12px',
+    ...(isPlaying
+      ? {
+          background: 'rgba(34, 197, 94, 0.12)',
+          border: `1px solid ${theme.success}`,
+          color: theme.success,
+        }
+      : {}),
+  }
+
+  return (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: '1fr auto 1fr',
+        alignItems: 'center',
+        gap: 12,
+        minHeight: 40,
+        padding: '6px 16px',
+        background: theme.bgSecondary,
+        borderTop: `1px solid ${theme.border}`,
+        flexShrink: 0,
+      }}
+    >
+      <span
+        ref={timecodeRef}
+        style={{
+          fontSize: 11,
+          color: theme.textSecondary,
+          fontFamily: theme.fontMono,
+          letterSpacing: '0.02em',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        00:00:00:00 / 00:00:00:00
+      </span>
+
+      <button
+        type="button"
+        className="elah-toolbar-btn"
+        style={playBtnStyle}
+        onClick={togglePlayPause}
+        title="Play / Pause (Space)"
+      >
+        {isPlaying ? '⏸' : '▶'}
+      </button>
+
+      <span />
+    </div>
+  )
+})
+
+const TimelineControls = memo(function TimelineControls({
+  timelineRef,
+}: {
+  timelineRef: React.RefObject<TimelineRef | null>
+}) {
+  const engine = useTimelineEngine()
+  const zoom = usePlaybackStore((s) => s.zoom)
+  const setZoom = usePlaybackStore((s) => s.setZoom)
+  const stage = useTracksStore((s) => s.stage)
+  const hasSelection = useSelectionStore((s) => s.selectedClipIds.size === 1)
 
   const splitAtPlayhead = useCallback(() => {
     const result = splitClipAtPlayhead(engine)
@@ -175,19 +235,6 @@ const TimelineControls = memo(function TimelineControls({
         }
       : {}),
   })
-
-  const playBtnStyle: React.CSSProperties = {
-    ...btnDisabled(false),
-    minWidth: 36,
-    padding: '5px 12px',
-    ...(isPlaying
-      ? {
-          background: 'rgba(34, 197, 94, 0.12)',
-          border: `1px solid ${theme.success}`,
-          color: theme.success,
-        }
-      : {}),
-  }
 
   return (
     <div
@@ -216,30 +263,6 @@ const TimelineControls = memo(function TimelineControls({
         >
           ✂ Split
         </button>
-      </div>
-
-      <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-        <button
-          type="button"
-          className="elah-toolbar-btn"
-          style={playBtnStyle}
-          onClick={togglePlayPause}
-          title="Play / Pause (Space)"
-        >
-          {isPlaying ? '⏸' : '▶'}
-        </button>
-        <span
-          ref={timecodeRef}
-          style={{
-            fontSize: 11,
-            color: theme.textSecondary,
-            fontFamily: theme.fontMono,
-            minWidth: 172,
-            letterSpacing: '0.02em',
-          }}
-        >
-          00:00:00:00 / 00:00:00:00
-        </span>
       </div>
 
       <div style={{ display: 'flex', alignItems: 'center', gap: 8, justifyContent: 'flex-end' }}>
@@ -408,14 +431,18 @@ export default function ProductionEditor() {
                 flex: 1,
                 minWidth: 0,
                 minHeight: 0,
-                position: 'relative',
+                display: 'flex',
+                flexDirection: 'column',
                 background: theme.bgPrimary,
               }}
             >
-              <Preview
-                demuxerFactory={demuxerFactoryRef.current}
-                style={{ width: '100%', height: '100%' }}
-              />
+              <div style={{ flex: 1, minHeight: 0, position: 'relative' }}>
+                <Preview
+                  demuxerFactory={demuxerFactoryRef.current}
+                  style={{ width: '100%', height: '100%' }}
+                />
+              </div>
+              <PreviewTransport />
             </div>
 
             <TextClipProperties />

--- a/playground/react/src/components/ProductionEditor.tsx
+++ b/playground/react/src/components/ProductionEditor.tsx
@@ -56,11 +56,14 @@ const AppHeader = memo(function AppHeader({ onExport }: { onExport: () => void }
   return (
     <header
       style={{
-        display: 'grid',
-        gridTemplateColumns: '1fr auto 1fr',
+        display: 'flex',
         alignItems: 'center',
-        padding: '0 16px',
-        height: 46,
+        justifyContent: 'space-between',
+        flexWrap: 'wrap',
+        columnGap: 12,
+        rowGap: 6,
+        padding: '6px 16px',
+        minHeight: 46,
         background: theme.bgSecondary,
         borderBottom: `1px solid ${theme.border}`,
         flexShrink: 0,
@@ -187,11 +190,14 @@ const TimelineControls = memo(function TimelineControls({
   return (
     <div
       style={{
-        display: 'grid',
-        gridTemplateColumns: '1fr auto 1fr',
+        display: 'flex',
         alignItems: 'center',
-        height: 40,
-        padding: '0 16px',
+        justifyContent: 'space-between',
+        flexWrap: 'wrap',
+        columnGap: 12,
+        rowGap: 6,
+        minHeight: 40,
+        padding: '6px 16px',
         background: theme.bgSecondary,
         borderTop: `1px solid ${theme.border}`,
         flexShrink: 0,
@@ -267,6 +273,7 @@ const TimelineControls = memo(function TimelineControls({
             className="elah-toolbar-btn"
             style={aspectBtn(aspectActive(1920, 1080))}
             onClick={() => engine.setStage(1920, 1080)}
+            title="Landscape 16:9"
           >
             16:9
           </button>
@@ -275,6 +282,7 @@ const TimelineControls = memo(function TimelineControls({
             className="elah-toolbar-btn"
             style={aspectBtn(aspectActive(1080, 1920))}
             onClick={() => engine.setStage(1080, 1920)}
+            title="Portrait 9:16"
           >
             9:16
           </button>
@@ -283,6 +291,7 @@ const TimelineControls = memo(function TimelineControls({
             className="elah-toolbar-btn"
             style={aspectBtn(aspectActive(1080, 1080))}
             onClick={() => engine.setStage(1080, 1080)}
+            title="Square 1:1"
           >
             1:1
           </button>

--- a/playground/react/src/components/ProductionEditor.tsx
+++ b/playground/react/src/components/ProductionEditor.tsx
@@ -118,19 +118,13 @@ const AppHeader = memo(function AppHeader({ onExport }: { onExport: () => void }
   )
 })
 
-const TimelineControls = memo(function TimelineControls({
-  timelineRef,
-}: {
-  timelineRef: React.RefObject<TimelineRef | null>
-}) {
-  const engine = useTimelineEngine()
+// Play control + running time — mirrors the app-side editor by sitting directly
+// below the preview. A 1fr auto 1fr grid centers the play button; the running
+// time / total time reads on the left.
+const PreviewTransport = memo(function PreviewTransport() {
   const isPlaying = usePlaybackStore((s) => s.isPlaying)
   const togglePlayPause = usePlaybackStore((s) => s.togglePlayPause)
-  const zoom = usePlaybackStore((s) => s.zoom)
-  const setZoom = usePlaybackStore((s) => s.setZoom)
   const totalFrames = useTracksStore((s) => s.totalFrames)
-  const stage = useTracksStore((s) => s.stage)
-  const hasSelection = useSelectionStore((s) => s.selectedClipIds.size === 1)
   const timecodeRef = useRef<HTMLSpanElement>(null)
 
   useEffect(() => {
@@ -151,6 +145,72 @@ const TimelineControls = memo(function TimelineControls({
         `${framesToTimecode(frame, FPS)} / ${framesToTimecode(dur, FPS)}`
     }
   }, [totalFrames])
+
+  const playBtnStyle: React.CSSProperties = {
+    ...btnDisabled(false),
+    minWidth: 36,
+    padding: '5px 12px',
+    ...(isPlaying
+      ? {
+          background: 'rgba(34, 197, 94, 0.12)',
+          border: `1px solid ${theme.success}`,
+          color: theme.success,
+        }
+      : {}),
+  }
+
+  return (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: '1fr auto 1fr',
+        alignItems: 'center',
+        gap: 12,
+        minHeight: 40,
+        padding: '6px 16px',
+        background: theme.bgSecondary,
+        borderTop: `1px solid ${theme.border}`,
+        flexShrink: 0,
+      }}
+    >
+      <span
+        ref={timecodeRef}
+        style={{
+          fontSize: 11,
+          color: theme.textSecondary,
+          fontFamily: theme.fontMono,
+          letterSpacing: '0.02em',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        00:00:00:00 / 00:00:00:00
+      </span>
+
+      <button
+        type="button"
+        className="elah-toolbar-btn"
+        style={playBtnStyle}
+        onClick={togglePlayPause}
+        title="Play / Pause (Space)"
+      >
+        {isPlaying ? '⏸' : '▶'}
+      </button>
+
+      <span />
+    </div>
+  )
+})
+
+const TimelineControls = memo(function TimelineControls({
+  timelineRef,
+}: {
+  timelineRef: React.RefObject<TimelineRef | null>
+}) {
+  const engine = useTimelineEngine()
+  const zoom = usePlaybackStore((s) => s.zoom)
+  const setZoom = usePlaybackStore((s) => s.setZoom)
+  const stage = useTracksStore((s) => s.stage)
+  const hasSelection = useSelectionStore((s) => s.selectedClipIds.size === 1)
 
   const splitAtPlayhead = useCallback(() => {
     const result = splitClipAtPlayhead(engine)
@@ -173,19 +233,6 @@ const TimelineControls = memo(function TimelineControls({
         }
       : {}),
   })
-
-  const playBtnStyle: React.CSSProperties = {
-    ...btnDisabled(false),
-    minWidth: 36,
-    padding: '5px 12px',
-    ...(isPlaying
-      ? {
-          background: 'rgba(34, 197, 94, 0.12)',
-          border: `1px solid ${theme.success}`,
-          color: theme.success,
-        }
-      : {}),
-  }
 
   return (
     <div
@@ -214,30 +261,6 @@ const TimelineControls = memo(function TimelineControls({
         >
           ✂ Split
         </button>
-      </div>
-
-      <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-        <button
-          type="button"
-          className="elah-toolbar-btn"
-          style={playBtnStyle}
-          onClick={togglePlayPause}
-          title="Play / Pause (Space)"
-        >
-          {isPlaying ? '⏸' : '▶'}
-        </button>
-        <span
-          ref={timecodeRef}
-          style={{
-            fontSize: 11,
-            color: theme.textSecondary,
-            fontFamily: theme.fontMono,
-            minWidth: 172,
-            letterSpacing: '0.02em',
-          }}
-        >
-          00:00:00:00 / 00:00:00:00
-        </span>
       </div>
 
       <div style={{ display: 'flex', alignItems: 'center', gap: 8, justifyContent: 'flex-end' }}>
@@ -406,14 +429,18 @@ export default function ProductionEditor() {
                 flex: 1,
                 minWidth: 0,
                 minHeight: 0,
-                position: 'relative',
+                display: 'flex',
+                flexDirection: 'column',
                 background: theme.bgPrimary,
               }}
             >
-              <Preview
-                demuxerFactory={demuxerFactoryRef.current}
-                style={{ width: '100%', height: '100%' }}
-              />
+              <div style={{ flex: 1, minHeight: 0, position: 'relative' }}>
+                <Preview
+                  demuxerFactory={demuxerFactoryRef.current}
+                  style={{ width: '100%', height: '100%' }}
+                />
+              </div>
+              <PreviewTransport />
             </div>
 
             <TextClipProperties />

--- a/playground/react/src/components/ProductionEditor.tsx
+++ b/playground/react/src/components/ProductionEditor.tsx
@@ -306,6 +306,32 @@ export default function ProductionEditor() {
   const demuxerFactoryRef = useRef(createDefaultDemuxerFactory())
 
   const [showExportModal, setShowExportModal] = useState(false)
+  const [timelineHeight, setTimelineHeight] = useState(236)
+  const resizeRef = useRef<{ startY: number; startHeight: number } | null>(null)
+
+  // Drag the handle above the timeline to resize its height. Clamped so the
+  // timeline can neither swallow the canvas nor collapse below a usable strip.
+  const onTimelineResizeStart = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      e.preventDefault()
+      resizeRef.current = { startY: e.clientY, startHeight: timelineHeight }
+      const onMove = (ev: PointerEvent) => {
+        if (!resizeRef.current) return
+        const delta = ev.clientY - resizeRef.current.startY
+        setTimelineHeight(
+          Math.min(600, Math.max(120, resizeRef.current.startHeight - delta)),
+        )
+      }
+      const onUp = () => {
+        resizeRef.current = null
+        window.removeEventListener('pointermove', onMove)
+        window.removeEventListener('pointerup', onUp)
+      }
+      window.addEventListener('pointermove', onMove)
+      window.addEventListener('pointerup', onUp)
+    },
+    [timelineHeight],
+  )
 
   const handleExportStart = useCallback(async (opts: {
     videoBitrate: number
@@ -395,10 +421,30 @@ export default function ProductionEditor() {
 
           <TimelineControls timelineRef={timelineRef} />
 
+          <div
+            role="separator"
+            aria-orientation="horizontal"
+            title="Drag to resize timeline"
+            onPointerDown={onTimelineResizeStart}
+            style={{
+              height: 7,
+              flexShrink: 0,
+              cursor: 'ns-resize',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              background: theme.bgSecondary,
+              borderTop: `1px solid ${theme.border}`,
+              touchAction: 'none',
+            }}
+          >
+            <div style={{ width: 36, height: 3, borderRadius: 2, background: theme.border }} />
+          </div>
+
           <Timeline
             ref={timelineRef}
             fps={FPS}
-            style={{ height: 236, flexShrink: 0, minWidth: 0 }}
+            style={{ height: timelineHeight, flexShrink: 0, minWidth: 0 }}
           />
         </div>
       </div>

--- a/playground/react/src/index.css
+++ b/playground/react/src/index.css
@@ -127,3 +127,32 @@ body {
   background: var(--pg-bg-elevated) !important;
   border-color: var(--pg-border) !important;
 }
+
+/* Visible tooltip on hover — surfaces each button's `title` instantly and
+   styled, instead of relying only on the browser's slow native tooltip. */
+.elah-toolbar-btn,
+.elah-export-btn {
+  position: relative;
+}
+.elah-toolbar-btn[title]:hover::after,
+.elah-export-btn[title]:hover::after {
+  content: attr(title);
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 4px 8px;
+  border-radius: var(--pg-radius-sm, 4px);
+  background: var(--pg-bg-elevated);
+  color: var(--pg-text);
+  border: 1px solid var(--pg-border);
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1;
+  white-space: nowrap;
+  letter-spacing: 0.02em;
+  text-transform: none;
+  pointer-events: none;
+  z-index: 50;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+}


### PR DESCRIPTION
## What does this PR do?

Fixes the playground editor's responsive layout and tidies the transport controls: the toolbars no longer overflow on narrow viewports, the timeline is height-resizable via a drag handle, toolbar buttons get hover tooltips, and the play control + running time move into a dedicated bar below the preview.

Closes #2

---

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Performance improvement

---

## How to test

1. `cd playground/next && npm install && npm run dev` (it's outside the workspace and consumes published `@elah/editor`), open `http://localhost:4001`.
2. Resize the window to **1280 / 1024 / 768px** — the top header and bottom toolbar now **wrap** instead of overflowing or clipping.
3. **Drag the handle** just above the timeline up/down — the timeline resizes (clamped 120–600px), the canvas absorbs the rest.
4. **Hover** any toolbar button — a styled tooltip appears (native `title` kept for accessibility).
5. Note the **play button + running time** now sit centered in a bar directly below the preview; Split / Zoom / Fit / aspect stay in the bottom toolbar.

Changes are playground-only (`playground/next` + `playground/react`, applied to both mirrors) — no `@elah/editor` internals touched.

---

## Screenshots / Recording

<!-- To add an image: delete the placeholder text in a cell, put the cursor there, and drag the PNG in.
     HTML <td> cells tolerate the multi-line <img> GitHub inserts, so the table won't break. -->

<table>
  <thead>
    <tr><th>Change</th><th>Before</th><th>After</th></tr>
  </thead>
  <tbody>
    <tr>
      <td>Toolbars at 768px (overflow → wrap)</td>
      <td><img width="380" alt="1-toolbars-at-768px-before" src="https://github.com/user-attachments/assets/d509d974-5565-45aa-966f-7e161bc665ac" /></td>
      <td>
<img width="1536" height="1640" alt="1-toolbars-at-768px-after" src="https://github.com/user-attachments/assets/80e18b36-07cf-4061-bc03-43d8f29a1fec" />
</td>
    </tr>
    <tr>
      <td>Timeline resize handle</td>
      <td>
<img width="2560" height="260" alt="2-timeline-handle-before" src="https://github.com/user-attachments/assets/0f250faf-6b6c-4482-ad08-8eee6a82be33" />
</td>
      <td>
<img width="2560" height="240" alt="2-timeline-handle-after" src="https://github.com/user-attachments/assets/4a020264-baa0-4ed5-b5e5-22980f8502ec" />
</td>
    </tr>
    <tr>
      <td>Button hover tooltip</td>
      <td>
<img width="520" height="200" alt="3-button-tooltip-before" src="https://github.com/user-attachments/assets/9fb7949d-0128-4501-b8ad-3fd14cf8278a" />
</td>
      <td>
<img width="520" height="200" alt="3-button-tooltip-after" src="https://github.com/user-attachments/assets/1330c87e-0fa6-4a0c-acee-e8b391f4e0ca" />
</td>
    </tr>
    <tr>
      <td>Play + running time below preview</td>
      <td>— (new)</td>
      <td>
<img width="2560" height="120" alt="4-play-below-preview-after" src="https://github.com/user-attachments/assets/35dc1320-d39c-40a7-b0dc-63f562968a75" />
</td>
    </tr>
  </tbody>
</table>

---

## Notes on scope

Deferred from the issue's "what good looks like" (can be follow-ups): left panel icon-rail collapse below 1024px, and canvas aspect-ratio-preserved auto-fill.

---

## Checklist

- [ ] `npm test` passes
- [ ] `npm run typecheck` passes
- [x] I've tested this in the playground
- [x] No `any` types introduced without justification
