### PR TITLE
ui: virtualize timeline track rows for large projects

### DIFF
--- a/packages/timeline/src/Timeline.tsx
+++ b/packages/timeline/src/Timeline.tsx
@@ -4,7 +4,9 @@ import {
   useCallback,
   useEffect,
   useImperativeHandle,
+  useLayoutEffect,
   useRef,
+  useState,
 } from 'react'
 import type { TimelineEngine } from '@elah/core'
 import type { PlaybackEngine } from '@elah/core'
@@ -21,6 +23,13 @@ import { TrackRow } from './TrackRow'
 import { AudioDropDialog } from './AudioDropDialog'
 import { cn } from './cn'
 import type { TimelineClassNames } from './classNames'
+import {
+  VisibleWindowContext,
+  SHOW_ALL_WINDOW,
+  computeVisibleWindow,
+  QUANTUM_PX,
+  type VisibleWindow,
+} from './visible-window'
 
 export interface TimelineRef {
   engine: TimelineEngine
@@ -115,6 +124,11 @@ export const Timeline = memo(
     const rulerWrapRef = useRef<HTMLDivElement>(null)
     const clipboardRef = useRef<Clip[]>([])
 
+    // Cached container width — the scroll handler reads this instead of
+    // clientWidth so it never forces a reflow on every scroll event.
+    const containerWidthRef = useRef(0)
+    const [visibleWindow, setVisibleWindow] = useState<VisibleWindow>(SHOW_ALL_WINDOW)
+
     // Fit the entire timeline into the visible lane width. Falls back to a
     // 10-second baseline (matching the ruler) when the timeline is empty.
     const fitToWindow = useCallback(() => {
@@ -146,6 +160,59 @@ export const Timeline = memo(
         rulerWrapRef.current.scrollLeft = scrollRef.current.scrollLeft
       }
     }, [])
+
+    // Recomputes the virtualization window from the cached width + current
+    // scrollLeft. Bails the setState when both bounds are unchanged so the
+    // VisibleWindowContext value (and its subscriber re-renders) stay quantized
+    // to QUANTUM_PX steps instead of firing every scroll frame.
+    const updateWindow = useCallback(() => {
+      const el = scrollRef.current
+      if (!el) return
+      const next = computeVisibleWindow(
+        el.scrollLeft,
+        containerWidthRef.current,
+        sidebarWidth,
+        QUANTUM_PX,
+      )
+      setVisibleWindow((prev) =>
+        prev.start === next.start && prev.end === next.end ? prev : next,
+      )
+    }, [sidebarWidth])
+
+    const handleTrackAreaScroll = useCallback(() => {
+      syncRulerScroll()
+      updateWindow()
+    }, [syncRulerScroll, updateWindow])
+
+    // Keep the cached container width current via ResizeObserver, and
+    // recompute the window whenever it changes. Seeds containerWidthRef
+    // synchronously (not just from the observer's async callback) — this is a
+    // layout effect specifically so it runs before the [zoom, updateWindow]
+    // layout effect below, guaranteeing the very first updateWindow() call
+    // (on mount) sees the real width instead of the useRef(0) default. Without
+    // this, the initial window is computed as [0,0] and stays wrong until the
+    // ResizeObserver's first callback fires — which can lag mount by seconds
+    // under load, culling clips that are actually on-screen.
+    useLayoutEffect(() => {
+      const el = scrollRef.current
+      if (!el) return
+      containerWidthRef.current = el.clientWidth
+      const observer = new ResizeObserver((entries) => {
+        const entry = entries[0]
+        if (!entry) return
+        containerWidthRef.current = entry.contentRect.width
+        updateWindow()
+      })
+      observer.observe(el)
+      return () => observer.disconnect()
+    }, [updateWindow])
+
+    // Recompute on mount and whenever zoom changes — zoom changes clip pixel
+    // positions, so the same scrollLeft maps to a different visible clip set.
+    // Layout-effect timing avoids a first-paint flash where all clips mount.
+    useLayoutEffect(() => {
+      updateWindow()
+    }, [zoom, updateWindow])
 
     // Ctrl/Cmd + scroll → zoom
     useEffect(() => {
@@ -376,7 +443,7 @@ export const Timeline = memo(
         {/* Track area — single scroll source; scrollbar sits at the bottom */}
         <div
           ref={scrollRef}
-          onScroll={syncRulerScroll}
+          onScroll={handleTrackAreaScroll}
           style={{
             flex: 1,
             overflow: 'auto',
@@ -387,29 +454,31 @@ export const Timeline = memo(
             touchAction: 'pan-x pan-y',
           }}
         >
-          {tracks.map((track) => (
-            <TrackRow
-              key={track.id}
-              track={track}
-              totalFrames={Math.max(totalFrames, fps * 10)}
-              zoom={zoom}
-              fps={fps}
-              sidebarWidth={sidebarWidth}
-              compact={compactSidebar}
-              className={classNames?.track}
-              labelClassName={classNames?.trackLabel}
-              laneClassName={classNames?.lane}
-              clipClassName={classNames?.clip}
-              clipVideo={classNames?.clipVideo}
-              clipAudio={classNames?.clipAudio}
-              clipText={classNames?.clipText}
-              clipImage={classNames?.clipImage}
-              clipVideoAccent={classNames?.clipVideoAccent}
-              clipAudioAccent={classNames?.clipAudioAccent}
-              clipTextAccent={classNames?.clipTextAccent}
-              clipImageAccent={classNames?.clipImageAccent}
-            />
-          ))}
+          <VisibleWindowContext.Provider value={visibleWindow}>
+            {tracks.map((track) => (
+              <TrackRow
+                key={track.id}
+                track={track}
+                totalFrames={Math.max(totalFrames, fps * 10)}
+                zoom={zoom}
+                fps={fps}
+                sidebarWidth={sidebarWidth}
+                compact={compactSidebar}
+                className={classNames?.track}
+                labelClassName={classNames?.trackLabel}
+                laneClassName={classNames?.lane}
+                clipClassName={classNames?.clip}
+                clipVideo={classNames?.clipVideo}
+                clipAudio={classNames?.clipAudio}
+                clipText={classNames?.clipText}
+                clipImage={classNames?.clipImage}
+                clipVideoAccent={classNames?.clipVideoAccent}
+                clipAudioAccent={classNames?.clipAudioAccent}
+                clipTextAccent={classNames?.clipTextAccent}
+                clipImageAccent={classNames?.clipImageAccent}
+              />
+            ))}
+          </VisibleWindowContext.Provider>
 
           {tracks.length === 0 && (
             <div

--- a/packages/timeline/src/TrackRow.tsx
+++ b/packages/timeline/src/TrackRow.tsx
@@ -19,6 +19,7 @@ import { TransitionChip } from './TransitionChip'
 import { useTimeline } from './engine-context'
 import { useTimelineDrop } from './useTimelineDrop'
 import { cn } from './cn'
+import { useVisibleWindow, isClipVisible, VIRTUALIZATION_BUFFER_PX } from './visible-window'
 
 /** Sidebar width — kept in sync with SIDEBAR_WIDTH in Timeline.tsx (ruler offset). */
 const SIDEBAR_WIDTH = 184
@@ -120,6 +121,8 @@ export const TrackRow = memo(function TrackRow({
   }, [clips, track.kind])
   const isActive = useSelectionStore((s) => s.activeTrackId === track.id)
   const setActiveTrack = useSelectionStore((s) => s.setActiveTrack)
+  const selectedClipIds = useSelectionStore((s) => s.selectedClipIds)
+  const visibleWindow = useVisibleWindow()
   const engine = useTimeline()
   const [laneEl, setLaneEl] = useState<HTMLDivElement | null>(null)
 
@@ -346,23 +349,36 @@ export const TrackRow = memo(function TrackRow({
                 : undefined,
         }}
       >
-        {clips.map((clip) => (
-          <ClipBlock
-            key={clip.id}
-            clip={clip}
-            zoom={zoom}
-            trackHeight={track.height}
-            className={clipClassName}
-            clipVideo={clipVideo}
-            clipAudio={clipAudio}
-            clipText={clipText}
-            clipImage={clipImage}
-            clipVideoAccent={clipVideoAccent}
-            clipAudioAccent={clipAudioAccent}
-            clipTextAccent={clipTextAccent}
-            clipImageAccent={clipImageAccent}
-          />
-        ))}
+        {clips.map((clip) => {
+          const clipStartPx = clip.startFrame * zoom
+          const clipEndPx = (clip.startFrame + clip.durationFrames) * zoom
+          // Selected clips stay mounted even off-window: a drag can auto-scroll
+          // the window while the dragged clip's committed startFrame doesn't
+          // move, and unmounting it mid-gesture would drop pointer capture.
+          if (
+            !isClipVisible(clipStartPx, clipEndPx, visibleWindow, VIRTUALIZATION_BUFFER_PX) &&
+            !selectedClipIds.has(clip.id)
+          )
+            return null
+
+          return (
+            <ClipBlock
+              key={clip.id}
+              clip={clip}
+              zoom={zoom}
+              trackHeight={track.height}
+              className={clipClassName}
+              clipVideo={clipVideo}
+              clipAudio={clipAudio}
+              clipText={clipText}
+              clipImage={clipImage}
+              clipVideoAccent={clipVideoAccent}
+              clipAudioAccent={clipAudioAccent}
+              clipTextAccent={clipTextAccent}
+              clipImageAccent={clipImageAccent}
+            />
+          )
+        })}
 
         {adjacentPairs.map(({ from, to }) => (
           <TransitionChip

--- a/packages/timeline/src/trackRowVirtualization.test.ts
+++ b/packages/timeline/src/trackRowVirtualization.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { act, createElement } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { PlaybackEngine, TimelineEngine, type Clip, type Track } from '@elah/core'
+import { EditorContext, useSelectionStore, useTracksStore } from '@elah/react'
+import { TrackRow } from './TrackRow'
+import { VisibleWindowContext, type VisibleWindow } from './visible-window'
+
+interface Rendered {
+  container: HTMLElement
+  root: Root
+}
+
+const mounted: Rendered[] = []
+const playbacks: PlaybackEngine[] = []
+
+afterEach(() => {
+  for (const { root, container } of mounted.splice(0).reverse()) {
+    act(() => root.unmount())
+    container.remove()
+  }
+  for (const playback of playbacks.splice(0)) {
+    playback.destroy()
+  }
+  document.body.replaceChildren()
+  resetStores()
+})
+
+// 50 clips laid end-to-end, 30 frames each, zoom 1 => clip i spans px
+// [i*30, i*30+30). Window [500, 600] + VIRTUALIZATION_BUFFER_PX (200) makes
+// the effective visible span (300, 800): clip i is visible iff
+// i*30+30 > 300 && i*30 < 800, i.e. i in [10, 26] inclusive => 17 clips.
+// (Expected count is hardcoded from this independent hand computation, not
+// derived by calling isClipVisible in the test.)
+const CLIP_COUNT = 50
+const CLIP_DURATION = 30
+const ZOOM = 1
+const NARROW_WINDOW: VisibleWindow = { start: 500, end: 600 }
+const EXPECTED_VISIBLE_IN_NARROW_WINDOW = 17
+
+describe('TrackRow clip virtualization', () => {
+  it('culls clips outside the visible window (+ buffer)', () => {
+    const { container } = setupTrack(CLIP_COUNT, NARROW_WINDOW)
+    expect(mountedClipCount(container)).toBe(EXPECTED_VISIBLE_IN_NARROW_WINDOW)
+  })
+
+  it('mounts all clips under the default context (SHOW_ALL_WINDOW backward-compat)', () => {
+    const { container } = setupTrack(CLIP_COUNT, undefined)
+    expect(mountedClipCount(container)).toBe(CLIP_COUNT)
+  })
+
+  it('keeps a selected clip mounted even when its pixels are far outside the window', () => {
+    const { container, clips } = setupTrack(CLIP_COUNT, NARROW_WINDOW, { selectIndex: 40 })
+    // clip 40 spans [1200, 1230) px — well outside (300, 800), so it would be
+    // culled if selection didn't exempt it.
+    const clip40 = clips[40]
+    expect(clip40.startFrame * ZOOM).toBeGreaterThanOrEqual(800)
+
+    expect(mountedClipCount(container)).toBe(EXPECTED_VISIBLE_IN_NARROW_WINDOW + 1)
+    const selectedBlock = container.querySelector('[data-clip-type][data-selected="true"]')
+    expect(selectedBlock).not.toBeNull()
+  })
+
+  it.each([5, 20, 50])(
+    'renders all %i clips under SHOW_ALL_WINDOW',
+    (count) => {
+      const { container } = setupTrack(count, undefined)
+      expect(mountedClipCount(container)).toBe(count)
+    },
+  )
+})
+
+function mountedClipCount(container: HTMLElement): number {
+  return container.querySelectorAll('[data-clip-type]').length
+}
+
+function setupTrack(
+  clipCount: number,
+  visibleWindow: VisibleWindow | undefined,
+  options: { selectIndex?: number } = {},
+) {
+  resetStores()
+  const engine = new TimelineEngine({ fps: 30 })
+  const playback = new PlaybackEngine({
+    fps: 30,
+    getTotalFrames: () => engine.getTotalFrames(),
+    now: () => 0,
+  })
+  playbacks.push(playback)
+  const track: Track = engine.addTrack('elements')
+  const clips: Clip[] = []
+  for (let i = 0; i < clipCount; i++) {
+    const clip = engine.addClip({
+      trackId: track.id,
+      type: 'text',
+      name: `Caption ${i}`,
+      text: { content: `Caption ${i}` },
+      startFrame: i * CLIP_DURATION,
+      durationFrames: CLIP_DURATION,
+    })
+    clips.push(clip)
+  }
+  syncTracks(engine)
+
+  if (options.selectIndex !== undefined) {
+    act(() => {
+      useSelectionStore.getState().selectClip(clips[options.selectIndex!].id)
+    })
+  }
+
+  const trackRow = createElement(TrackRow, {
+    track,
+    totalFrames: engine.getTotalFrames(),
+    zoom: ZOOM,
+    fps: 30,
+  })
+
+  const tree = createElement(
+    EditorContext.Provider,
+    { value: { engine, playback } },
+    visibleWindow
+      ? createElement(VisibleWindowContext.Provider, { value: visibleWindow }, trackRow)
+      : trackRow,
+  )
+
+  const { container } = render(tree)
+  return { container, clips, engine }
+}
+
+function render(element: ReturnType<typeof createElement>): Rendered {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  act(() => root.render(element))
+  const rendered = { container, root }
+  mounted.push(rendered)
+  return rendered
+}
+
+function resetStores() {
+  act(() => {
+    useTracksStore.setState({
+      tracks: [],
+      clips: {},
+      stage: { width: 1080, height: 1920 },
+      totalFrames: 0,
+      canUndo: false,
+      canRedo: false,
+    })
+    useSelectionStore.setState({
+      selectedClipIds: new Set(),
+      activeTrackId: null,
+    })
+  })
+}
+
+function syncTracks(engine: TimelineEngine) {
+  useTracksStore.getState().sync(engine.getProject(), {
+    canUndo: engine.canUndo(),
+    canRedo: engine.canRedo(),
+  })
+}

--- a/packages/timeline/src/visible-window.test.ts
+++ b/packages/timeline/src/visible-window.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest'
+import {
+  computeVisibleWindow,
+  isClipVisible,
+  QUANTUM_PX,
+  SHOW_ALL_WINDOW,
+  VIRTUALIZATION_BUFFER_PX,
+  type VisibleWindow,
+} from './visible-window'
+
+describe('isClipVisible', () => {
+  // window [1000, 2000] + buffer 200 => effective visible span (800, 2200)
+  const window: VisibleWindow = { start: 1000, end: 2000 }
+  const buffer = 200
+
+  it('is false for a clip fully left of window - buffer', () => {
+    expect(isClipVisible(500, 700, window, buffer)).toBe(false)
+  })
+
+  it('is false for a clip fully right of window + buffer', () => {
+    expect(isClipVisible(2300, 2500, window, buffer)).toBe(false)
+  })
+
+  it('is true for a clip straddling the left edge', () => {
+    expect(isClipVisible(700, 900, window, buffer)).toBe(true)
+  })
+
+  it('is true for a clip straddling the right edge', () => {
+    expect(isClipVisible(2100, 2300, window, buffer)).toBe(true)
+  })
+
+  it('is true for a clip fully inside the window', () => {
+    expect(isClipVisible(1200, 1400, window, buffer)).toBe(true)
+  })
+
+  it('is false when the clip ends exactly at window.start - buffer (strict >)', () => {
+    expect(isClipVisible(600, 800, window, buffer)).toBe(false)
+  })
+
+  it('is false when the clip starts exactly at window.end + buffer (strict <)', () => {
+    expect(isClipVisible(2200, 2400, window, buffer)).toBe(false)
+  })
+
+  it('is true just inside the left buffer edge (+1px)', () => {
+    expect(isClipVisible(600, 801, window, buffer)).toBe(true)
+  })
+
+  it('is true just inside the right buffer edge (-1px)', () => {
+    expect(isClipVisible(2199, 2400, window, buffer)).toBe(true)
+  })
+
+  it('handles the real VIRTUALIZATION_BUFFER_PX constant consistently', () => {
+    const w: VisibleWindow = { start: 0, end: 500 }
+    // Just outside the real buffer to the left.
+    expect(
+      isClipVisible(-VIRTUALIZATION_BUFFER_PX - 10, -VIRTUALIZATION_BUFFER_PX - 5, w, VIRTUALIZATION_BUFFER_PX),
+    ).toBe(false)
+    // Just inside the real buffer to the left.
+    expect(
+      isClipVisible(-VIRTUALIZATION_BUFFER_PX - 10, -VIRTUALIZATION_BUFFER_PX + 1, w, VIRTUALIZATION_BUFFER_PX),
+    ).toBe(true)
+  })
+})
+
+describe('isClipVisible with SHOW_ALL_WINDOW', () => {
+  it('is true for any finite clip (±Infinity math is safe)', () => {
+    expect(isClipVisible(0, 100, SHOW_ALL_WINDOW, VIRTUALIZATION_BUFFER_PX)).toBe(true)
+    expect(isClipVisible(-1_000_000, -999_900, SHOW_ALL_WINDOW, VIRTUALIZATION_BUFFER_PX)).toBe(true)
+    expect(isClipVisible(1_000_000, 2_000_000, SHOW_ALL_WINDOW, VIRTUALIZATION_BUFFER_PX)).toBe(true)
+    // Even a zero-duration clip is visible: strict inequalities against ±Infinity
+    // are always true for any finite value.
+    expect(isClipVisible(0, 0, SHOW_ALL_WINDOW, VIRTUALIZATION_BUFFER_PX)).toBe(true)
+  })
+})
+
+describe('computeVisibleWindow', () => {
+  const sidebarWidth = 184
+
+  it('always returns a quantized superset of the true window', () => {
+    const cases: Array<[scrollLeft: number, containerWidth: number]> = [
+      [0, 1000],
+      [50, 1000],
+      [250, 1200],
+      [999, 500],
+      [1, 201],
+      [12345, 4321],
+    ]
+
+    for (const [scrollLeft, containerWidth] of cases) {
+      const trueStart = scrollLeft
+      const trueEnd = scrollLeft + Math.max(0, containerWidth - sidebarWidth)
+      const result = computeVisibleWindow(scrollLeft, containerWidth, sidebarWidth, QUANTUM_PX)
+
+      expect(result.start).toBeLessThanOrEqual(trueStart)
+      expect(result.end).toBeGreaterThanOrEqual(trueEnd)
+      expect(result.start % QUANTUM_PX).toBe(0)
+      expect(result.end % QUANTUM_PX).toBe(0)
+    }
+  })
+
+  it('subtracts the sidebar width from the container width for the true span', () => {
+    // quantum = 1 disables quantization rounding so the raw subtraction is visible.
+    const result = computeVisibleWindow(0, 1000, 184, 1)
+    expect(result).toEqual({ start: 0, end: 816 })
+  })
+
+  it('clamps the span to 0 when containerWidth < sidebarWidth', () => {
+    // quantum = 1 avoids masking a negative pre-quantize span.
+    const result = computeVisibleWindow(50, 100, 184, 1)
+    expect(result.start).toBe(50)
+    expect(result.end).toBe(50)
+    expect(result.end - result.start).toBe(0)
+  })
+
+  it('returns start 0 for scrollLeft 0', () => {
+    const result = computeVisibleWindow(0, 1000, 184, QUANTUM_PX)
+    expect(result.start).toBe(0)
+  })
+
+  it('gives identical windows for two scrollLefts within the same quantum step', () => {
+    const a = computeVisibleWindow(100, 1000, 184, QUANTUM_PX)
+    const b = computeVisibleWindow(150, 1000, 184, QUANTUM_PX)
+    expect(a).toEqual(b)
+    expect(a).toEqual({ start: 0, end: 1000 })
+  })
+
+  it('gives a different window once scrollLeft crosses into the next quantum step', () => {
+    const withinStep = computeVisibleWindow(100, 1000, 184, QUANTUM_PX)
+    const nextStep = computeVisibleWindow(200, 1000, 184, QUANTUM_PX)
+    expect(nextStep.start).not.toBe(withinStep.start)
+  })
+})

--- a/packages/timeline/src/visible-window.ts
+++ b/packages/timeline/src/visible-window.ts
@@ -1,0 +1,57 @@
+import { createContext, useContext } from 'react'
+
+/** Lane-local pixel range (relative to scrollLeft, not viewport coordinates). */
+export interface VisibleWindow {
+  start: number
+  end: number
+}
+
+// Pre-mounts clips just outside the viewport so they don't visibly pop in
+// during fast scrolls/drags.
+export const VIRTUALIZATION_BUFFER_PX = 200
+
+// Quantization step for computeVisibleWindow — rows re-render only every
+// QUANTUM_PX of scroll instead of every pixel (memoization safeguard).
+export const QUANTUM_PX = 200
+
+/** Default window so TrackRow used outside Timeline (or before first measure) renders everything. */
+export const SHOW_ALL_WINDOW: VisibleWindow = { start: -Infinity, end: Infinity }
+
+export const VisibleWindowContext = createContext<VisibleWindow>(SHOW_ALL_WINDOW)
+
+export function useVisibleWindow(): VisibleWindow {
+  return useContext(VisibleWindowContext)
+}
+
+/**
+ * Computes the lane-local visible window from raw scroll metrics.
+ *
+ * The sticky sidebar overlays the left `sidebarWidth` px of the viewport, so
+ * lane content only becomes visible after it — hence `containerWidth - sidebarWidth`.
+ */
+export function computeVisibleWindow(
+  scrollLeft: number,
+  containerWidth: number,
+  sidebarWidth: number,
+  quantum: number,
+): VisibleWindow {
+  const start = scrollLeft
+  const end = scrollLeft + Math.max(0, containerWidth - sidebarWidth)
+
+  // Quantize asymmetrically (floor start, ceil end) so the result is always a
+  // superset of the true window — never culls a clip that's actually visible.
+  return {
+    start: Math.floor(start / quantum) * quantum,
+    end: Math.ceil(end / quantum) * quantum,
+  }
+}
+
+/** Whether a clip's pixel span intersects the visible window, padded by `buffer`. Safe with ±Infinity. */
+export function isClipVisible(
+  clipStartPx: number,
+  clipEndPx: number,
+  window: VisibleWindow,
+  buffer: number,
+): boolean {
+  return clipEndPx > window.start - buffer && clipStartPx < window.end + buffer
+}


### PR DESCRIPTION
## What does this PR do?

Virtualizes the timeline track rows so clips outside the visible scroll area don't mount at all. Before this, every clip on a track rendered no matter where you were scrolled, which meant noticeable frame drops once a project hit 50+ clips.

Closes #10

---

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [x] Performance improvement

---

## How to test

1. `npm run dev` and open http://localhost:3001/editor
2. Add a lot of clips to a track (50+), zoom in so the timeline is much wider than the screen
3. Scroll around and count mounted clips in devtools: `document.querySelectorAll('[data-clip-type]').length` — it stays small (visible window + 200px buffer each side) while the set shifts with scroll
4. Zoom out until everything fits — all clips mount again
5. Drag, trim, select still work as usual, including dragging a clip across the edge of the visible area

Measured on a 21,000px-wide timeline in a ~1,500px viewport: 3-5 clips mounted at any scroll position out of 24 total; at 120 clips the mounted count stayed between 22-28 while scrolling a wider window.

---

## How it works

`Timeline.tsx` computes the visible window (scrollLeft + container width, minus the sticky sidebar) and shares it through a context. `TrackRow` checks each clip's pixel range against that window and skips the ones that can't be seen. The pure helpers live in `visible-window.ts` and are unit tested.

Two details worth a close look in review:

- The window is quantized to 200px steps, so rows only re-render when the set of visible clips can actually change, not on every scrolled pixel. Passing raw scrollLeft as a prop would have defeated TrackRow's memoization (this is the pitfall the issue called out).
- Selected clips are never culled. If the timeline auto-scrolls mid-drag, the dragged clip could otherwise fall outside the window and unmount while you're still holding it, which kills pointer capture.

Also fixes a ResizeObserver timing issue found while testing: the first window computation could read a container width of 0 (layout effects run before the observer's first callback fires), briefly culling clips that were actually on screen. The width is now seeded synchronously in a layout effect that runs before the window recompute.

Not touched, per the issue: ClipBlock internals, Ruler.tsx, playhead positioning. Transition chips aren't virtualized either — there are few of them and it felt out of scope.

While testing on densely packed tracks I hit an unrelated drag/drop bug in core's snap logic — filed as #48, not addressed here.

---

## Screenshots / Recording

No visual change — the timeline looks identical, clips just mount/unmount outside the viewport. The devtools counter in "How to test" is the observable difference.

---

## Checklist

- [x] `npm test` passes
- [x] `npm run typecheck` passes
- [x] I've tested this in the playground
- [x] No `any` types introduced without justification