### PR TITLE
engine: add versioned JSON project save and load

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -138,6 +138,9 @@ export { framesToTimecode, secondsToFrames, framesToSeconds, getTotalFrames, cli
 export { generateId } from './utils/id'
 export { snapFrame, buildSnapPoints, resolveOverlapEdgeSnap, DEFAULT_OVERLAP_TOLERANCE } from './utils/snap'
 
+// --- Project serialization ---
+export { serializeProject, deserializeProject } from './project/serialization'
+
 // --- Export pipeline ---
 export { exportVideo } from './export'
 export { lazyExportVideo } from './export/lazyExport'

--- a/packages/core/src/project/serialization.test.ts
+++ b/packages/core/src/project/serialization.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from 'vitest'
+import { TimelineEngine } from '../editor/TimelineEngine'
+import { deserializeProject, serializeProject } from './serialization'
+
+function buildNonTrivialEngine(): TimelineEngine {
+  const engine = new TimelineEngine({
+    fps: 30,
+    stage: { width: 1080, height: 1920 },
+    initialTracks: [{ kind: 'video', name: 'Video 1' }],
+  })
+
+  const videoTrack = engine.getProject().tracks[0]
+  const textTrack = engine.addTrack('elements', { name: 'Text 1' })
+
+  const clipA = engine.addClip({
+    trackId: videoTrack.id,
+    type: 'video',
+    src: 'blob:clip-a',
+    startFrame: 0,
+    durationFrames: 90,
+  })
+  const clipB = engine.addClip({
+    trackId: videoTrack.id,
+    type: 'video',
+    src: 'blob:clip-b',
+    startFrame: 90,
+    durationFrames: 60,
+  })
+  engine.addClip({
+    trackId: textTrack.id,
+    type: 'text',
+    startFrame: 10,
+    durationFrames: 45,
+    text: { content: 'Hello world', fontSize: 48, color: '#ff0000' },
+  })
+
+  engine.addTransition({
+    fromClipId: clipA.id,
+    toClipId: clipB.id,
+    trackId: videoTrack.id,
+    kind: 'fade',
+    durationFrames: 12,
+  })
+
+  engine.setStage(1920, 1080)
+  engine.setMasterVolume(0.5)
+
+  return engine
+}
+
+describe('serializeProject / deserializeProject', () => {
+  it('round-trips a non-trivial project into a fresh engine with identical state and deterministic JSON', () => {
+    const original = buildNonTrivialEngine()
+    const json = serializeProject(original)
+
+    const fresh = new TimelineEngine({ fps: 30 })
+    deserializeProject(fresh, json)
+
+    expect(fresh.getProject()).toEqual(original.getProject())
+
+    const jsonAgain = serializeProject(fresh)
+    expect(jsonAgain).toEqual(json)
+  })
+
+  it('round-trips into the same engine that produced the JSON', () => {
+    const engine = buildNonTrivialEngine()
+    const before = engine.getProject()
+    const json = serializeProject(engine)
+
+    deserializeProject(engine, json)
+
+    expect(engine.getProject()).toEqual(before)
+  })
+
+  it.each([2, 0, 999])(
+    'throws a clear error for unknown schema version %i',
+    (version) => {
+      const engine = new TimelineEngine({ fps: 30 })
+      const project = engine.getProject()
+      const json = JSON.stringify({ ...project, version })
+
+      expect(() => deserializeProject(engine, json)).toThrowError(
+        `Unsupported project schema version ${version} — this build of @elah/core supports version 1`,
+      )
+    },
+  )
+
+  it('throws the missing-version message when version is absent', () => {
+    const engine = new TimelineEngine({ fps: 30 })
+    const project = engine.getProject() as unknown as Record<string, unknown>
+    const { version, ...withoutVersion } = project
+    void version
+    const json = JSON.stringify(withoutVersion)
+
+    expect(() => deserializeProject(engine, json)).toThrowError(
+      'Not a valid project: missing schema version',
+    )
+  })
+
+  it('throws with a "Not valid project JSON:" prefix on malformed JSON', () => {
+    const engine = new TimelineEngine({ fps: 30 })
+
+    expect(() => deserializeProject(engine, '{nope')).toThrowError(/^Not valid project JSON:/)
+  })
+
+  it.each([
+    ['null', 'null'],
+    ['a number', '42'],
+    ['a string', '"str"'],
+  ])('throws the non-object error for %s payloads', (_label, json) => {
+    const engine = new TimelineEngine({ fps: 30 })
+
+    expect(() => deserializeProject(engine, json)).toThrowError(
+      'Not a valid project: expected a JSON object',
+    )
+  })
+
+  it('rejects an array payload with a clear error (does not silently misinterpret it as a project)', () => {
+    const engine = new TimelineEngine({ fps: 30 })
+
+    // Arrays are `typeof 'object'` in JS; the implementation explicitly guards
+    // against Array.isArray so `[]` is treated the same as any other non-object
+    // shape rather than falling through to the tracks/clips checks.
+    expect(() => deserializeProject(engine, '[]')).toThrowError(
+      'Not a valid project: expected a JSON object',
+    )
+  })
+
+  it('throws the tracks-not-an-array error', () => {
+    const engine = new TimelineEngine({ fps: 30 })
+    const project = engine.getProject()
+    const json = JSON.stringify({ ...project, tracks: {} })
+
+    expect(() => deserializeProject(engine, json)).toThrowError(
+      'Not a valid project: "tracks" must be an array',
+    )
+  })
+
+  it('throws the clips-not-an-object error', () => {
+    const engine = new TimelineEngine({ fps: 30 })
+    const project = engine.getProject()
+    const json = JSON.stringify({ ...project, clips: [] })
+
+    expect(() => deserializeProject(engine, json)).toThrowError(
+      'Not a valid project: "clips" must be an object',
+    )
+  })
+
+  it('does not mutate the engine on a failed deserialization (no partial load)', () => {
+    const engine = buildNonTrivialEngine()
+    const before = engine.getProject()
+
+    expect(() => deserializeProject(engine, '{nope')).toThrow()
+    expect(() => deserializeProject(engine, 'null')).toThrow()
+    expect(() =>
+      deserializeProject(engine, JSON.stringify({ ...before, version: 2 })),
+    ).toThrow()
+    expect(() =>
+      deserializeProject(engine, JSON.stringify({ ...before, tracks: {} })),
+    ).toThrow()
+    expect(() =>
+      deserializeProject(engine, JSON.stringify({ ...before, clips: [] })),
+    ).toThrow()
+
+    expect(engine.getProject()).toEqual(before)
+  })
+
+  it('applies loadProject side effects: history is cleared and a change event fires', () => {
+    const engine = buildNonTrivialEngine()
+    // Give the engine some undo history before deserializing.
+    engine.setMasterVolume(0.9)
+    expect(engine.canUndo()).toBe(true)
+
+    const changeEvents: unknown[] = []
+    engine.on('change', (project) => changeEvents.push(project))
+
+    const json = serializeProject(engine)
+    deserializeProject(engine, json)
+
+    expect(engine.canUndo()).toBe(false)
+    expect(changeEvents.length).toBe(1)
+  })
+})

--- a/packages/core/src/project/serialization.ts
+++ b/packages/core/src/project/serialization.ts
@@ -1,0 +1,48 @@
+import type { Project } from '../types'
+import type { TimelineEngine } from '../editor/TimelineEngine'
+
+/**
+ * Schema version this build understands. `Project.version` is the wire
+ * format itself — no separate envelope — so a future breaking change to
+ * the shape bumps this constant and `deserializeProject` gates on it.
+ */
+const PROJECT_SCHEMA_VERSION = 1
+
+/** Snapshot the engine's current project as JSON. The project's own `version` field is the schema version. */
+export function serializeProject(engine: TimelineEngine): string {
+  return JSON.stringify(engine.getProject())
+}
+
+/** Parse and load a previously serialized project into the engine, replacing its current state. */
+export function deserializeProject(engine: TimelineEngine, json: string): void {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(json)
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    throw new Error(`Not valid project JSON: ${message}`)
+  }
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new Error('Not a valid project: expected a JSON object')
+  }
+
+  const project = parsed as Record<string, unknown>
+
+  if (typeof project.version !== 'number') {
+    throw new Error('Not a valid project: missing schema version')
+  }
+  if (project.version !== PROJECT_SCHEMA_VERSION) {
+    throw new Error(
+      `Unsupported project schema version ${project.version} — this build of @elah/core supports version ${PROJECT_SCHEMA_VERSION}`,
+    )
+  }
+  if (!Array.isArray(project.tracks)) {
+    throw new Error('Not a valid project: "tracks" must be an array')
+  }
+  if (typeof project.clips !== 'object' || project.clips === null || Array.isArray(project.clips)) {
+    throw new Error('Not a valid project: "clips" must be an object')
+  }
+
+  engine.loadProject(project as unknown as Project)
+}


### PR DESCRIPTION
## What does this PR do?

Adds `serializeProject`/`deserializeProject` to `@elah/core` so a project can be saved to a JSON string and loaded back — the missing piece for embedding the editor in products that manage project files.

Closes #9

---

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Performance improvement

---

## How to test

1. `npm run test --workspace=packages/core -- src/project/serialization.test.ts` — 15 tests cover the round-trip and every error path
2. Or by hand in a node/bundler context:

```ts
import { TimelineEngine, serializeProject, deserializeProject } from '@elah/core'

const json = serializeProject(engine)          // save
deserializeProject(freshEngine, json)          // load — freshEngine now deep-equals the original
```

3. Edit the saved JSON's `"version"` to `2` and load it — you get:
   `Unsupported project schema version 2 — this build of @elah/core supports version 1`

---

## How it works

`serializeProject(engine)` snapshots `engine.getProject()` straight to a JSON string. The `Project` type already carries a `version` field (set to 1 by the engine), so that's the schema version in the file — no extra wrapper object.

`deserializeProject(engine, json)` parses, checks the payload is a real object (rejecting null, arrays, and unparseable text with clear messages), gates on the schema version, does two cheap structural checks (`tracks` is an array, `clips` is an object), then hands off to the existing `engine.loadProject()` — which is called, not modified, per the issue.

Verified beyond the unit tests: a full disk round-trip (write file, read back, load into a fresh engine) reproduces the project exactly; editing after a load (undo, redo, splitClip) behaves the same as on a live-built project; save→load→save is byte-identical; and a 500-clip project serializes and loads in under a millisecond.

Worth flagging: validation is intentionally shallow — version plus the two shape checks. A hand-edited file missing `fps` or `stage` would currently load without complaint. That matches the scope of this issue; deep schema validation would be a reasonable follow-up if we want stronger guarantees against corrupted files.

---

## Screenshots / Recording

No UI change — core-only API addition.

---

## Checklist

- [x] `npm test` passes
- [x] `npm run typecheck` passes
- [x] I've tested this in the playground
- [x] No `any` types introduced without justification