### PR TITLE
ui: fix blog accessibility issues (contrast, focus, landmarks, skip link)

### DIFF
--- a/apps/web/app/blog/[slug]/page.tsx
+++ b/apps/web/app/blog/[slug]/page.tsx
@@ -135,7 +135,7 @@ export default async function BlogPostPage({
       <JsonLd data={articleJsonLd} />
       <Navbar />
 
-      <main className="flex-1">
+      <main id="main" className="flex-1">
         {/* Header */}
         <div className="border-b border-outline-variant bg-surface py-14">
           <div className="mx-auto max-w-3xl px-4 sm:px-6">
@@ -202,7 +202,7 @@ export default async function BlogPostPage({
 
             {/* TOC */}
             {toc.length > 0 && (
-              <nav className="hidden w-48 shrink-0 lg:block">
+              <nav aria-label="Table of contents" className="hidden w-48 shrink-0 lg:block">
                 <div className="sticky top-24">
                   <div className="label-mono mb-3 text-2xs text-on-surface-variant opacity-90">
                     On this page

--- a/apps/web/app/blog/page.tsx
+++ b/apps/web/app/blog/page.tsx
@@ -16,7 +16,7 @@ export default function BlogPage() {
     <div className="flex min-h-screen flex-col bg-surface">
       <Navbar />
 
-      <main className="flex-1">
+      <main id="main" className="flex-1">
         {/* Header */}
         <div className="border-b border-outline-variant bg-surface py-14">
           <div className="mx-auto max-w-7xl px-4 sm:px-6">
@@ -65,7 +65,7 @@ export default function BlogPage() {
                   </time>
                   <Link
                     href={`/blog/${post.slug}`}
-                    className="flex items-center gap-1 text-xs font-medium text-primary transition-colors hover:underline"
+                    className="flex items-center gap-1 text-xs font-medium text-on-surface underline underline-offset-2 transition-colors hover:text-primary"
                   >
                     Read
                     <ArrowRight className="h-3 w-3 transition-transform group-hover:translate-x-0.5" />

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -122,6 +122,12 @@ export default function RootLayout({
         className={`${inter.variable} ${jetbrainsMono.variable} bg-surface text-on-surface antialiased`}
         style={{ fontFamily: 'var(--font-inter), system-ui, sans-serif' }}
       >
+        <a
+          href="#main"
+          className="sr-only rounded bg-primary px-4 py-2 text-sm font-medium text-white focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-50"
+        >
+          Skip to content
+        </a>
         <JsonLd data={organizationJsonLd} />
         <JsonLd data={webSiteJsonLd} />
         <ThemeProvider>

--- a/apps/web/components/docs/CodeBlock.tsx
+++ b/apps/web/components/docs/CodeBlock.tsx
@@ -41,7 +41,7 @@ export function CodeBlock({
         <button
           onClick={handleCopy}
           className="flex items-center gap-1.5 rounded px-2 py-1 text-2xs text-on-surface-variant transition-colors hover:bg-surface-high hover:text-on-surface"
-          aria-label="Copy code"
+          aria-label={copied ? 'Code copied' : 'Copy code'}
         >
           {copied ? (
             <>
@@ -59,6 +59,9 @@ export function CodeBlock({
 
       {/* Code content */}
       <pre
+        tabIndex={0}
+        role="region"
+        aria-label={filename ? `Code: ${filename}` : `Code sample (${language})`}
         className={cn(
           'overflow-x-auto p-4 text-xs leading-relaxed',
           showLineNumbers && 'pl-0'

--- a/apps/web/components/marketing/Navbar.tsx
+++ b/apps/web/components/marketing/Navbar.tsx
@@ -40,7 +40,7 @@ export function Navbar() {
         </Link>
 
         {/* Desktop nav */}
-        <nav className="hidden items-center gap-1 md:flex">
+        <nav aria-label="Main" className="hidden items-center gap-1 md:flex">
           {navLinks.map((link) => (
             <Link
               key={link.href}
@@ -107,7 +107,7 @@ export function Navbar() {
             transition={{ duration: 0.15 }}
             className="border-t border-outline-variant bg-surface px-4 pb-4 pt-2 md:hidden"
           >
-            <nav className="flex flex-col gap-1">
+            <nav aria-label="Mobile" className="flex flex-col gap-1">
               {navLinks.map((link) => (
                 <Link
                   key={link.href}

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -3,6 +3,13 @@
 @tailwind utilities;
 
 @layer base {
+  /* Visible keyboard focus for all interactive elements (a11y: WCAG 2.4.7). */
+  :focus-visible {
+    outline: 2px solid var(--color-outline);
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
+
   /* ── Light theme (Precision Studio — warm neutral foundation) ─────────── */
   :root {
     --font-geist-sans: 'Geist', system-ui, sans-serif;


### PR DESCRIPTION
## What does this PR do?

Fixes the accessibility issues found by an axe-core (WCAG 2.1 A/AA) scan of the blog listing and post pages.

Closes # — no linked issue.

---

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Performance improvement

---

## How to test

1. `git checkout fix/blog-a11y && npm install && npm run dev`
2. On `/blog`: press **Tab** once → a "Skip to content" chip appears (jumps focus past the navbar to `#main`).
3. Tab through cards → each interactive element shows a visible focus ring; the "Read" link is now near-white + underlined (was low-contrast red, 3.63:1 → passes 4.5:1).
4. On a post: Tab into a code block → it's focusable and scrollable by keyboard; the table-of-contents `<nav>` and navbars now have distinct `aria-label`s; the Copy button announces "Code copied".
5. Re-scan for accessibility with Chrome DevTools → Lighthouse → Accessibility on `/blog` and a post page → the previously-reported violations are gone.

---

## Screenshots / Recording
--

Before/after (dark mode):
- **Read link contrast** — before: red `#dc2f4e` (3.63:1, fails); after: near-white + underline (passes 4.5:1).
- **Skip link** — before: Tab lands on the logo; after: "Skip to content" chip appears on first Tab.
- **Focus ring** — before: browser-default blue; after: branded `--color-outline` ring.

(Non-visual fixes — nav `aria-label`s, `<pre>` role/tabindex, Copy button label — are screen-reader/keyboard only.) PNGs available on request.

---

## Checklist

- [x] `npm test` passes
- [x] `npm run typecheck` passes
- [x] I've tested this in the playground (verified via `npm run dev` + an axe scan)
- [x] No `any` types introduced without justification