### PR TITLE
Fix timeline issues: Zoom drift, Ruler tooltip, Multi-selection, and Video filmstrip

### DIFF
--- a/packages/timeline/src/ClipBlock.tsx
+++ b/packages/timeline/src/ClipBlock.tsx
@@ -10,6 +10,7 @@ import {
   DEFAULT_OVERLAP_TOLERANCE,
   resolveOverlapEdgeSnap,
   snapFrame,
+  secondsToFrames,
 } from '@elah/core'
 import { useTracksStore } from '@elah/core'
 import { useMediaLibraryStore } from '@elah/core'
@@ -51,6 +52,7 @@ interface ClipBlockProps {
   clip: Clip
   zoom: number
   trackHeight: number
+  fps: number
   /** Override class for the clip body (merged so it wins over defaults). */
   className?: string
   /**
@@ -72,6 +74,7 @@ export const ClipBlock = memo(function ClipBlock({
   clip,
   zoom,
   trackHeight,
+  fps,
   className,
   clipVideo,
   clipAudio,
@@ -86,6 +89,7 @@ export const ClipBlock = memo(function ClipBlock({
   const isSelected = useSelectionStore((s) => s.selectedClipIds.has(clip.id))
   const selectClip = useSelectionStore((s) => s.selectClip)
   const clearSelection = useSelectionStore((s) => s.clearSelection)
+  const toggleClipSelection = useSelectionStore((s) => s.toggleClipSelection)
   const snapEnabled = usePlaybackStore((s) => s.snapEnabled)
   const asset = useMediaLibraryStore((s) =>
     clip.assetId ? s.assets[clip.assetId] : undefined,
@@ -126,9 +130,52 @@ export const ClipBlock = memo(function ClipBlock({
   // Filmstrip tiles for video/image — decorative; tiles repeat/reduce with zoom.
   const stripFrames =
     asset?.thumbnailStrip ?? (asset?.thumbnailUrl ? [asset.thumbnailUrl] : [])
-  const tileAspect = asset?.width && asset?.height ? asset.width / asset.height : 16 / 9
-  const tileWidth = Math.max(12, blockHeight * tileAspect)
-  const tileCount = Math.min(40, Math.max(1, Math.ceil(width / tileWidth)))
+
+  let filmstripContent = null
+  if ((clip.type === 'video' || clip.type === 'image') && stripFrames.length > 0) {
+    const assetFrames = asset?.durationSec ? secondsToFrames(asset.durationSec, fps) : Math.max(clip.durationFrames, 1)
+    const framesPerThumb = assetFrames / stripFrames.length
+    
+    const startOffsetFrames = clip.sourceStartFrame ?? 0
+    const endOffsetFrames = startOffsetFrames + clip.durationFrames
+    
+    const startIndex = Math.floor(startOffsetFrames / framesPerThumb)
+    const endIndex = Math.min(stripFrames.length - 1, Math.ceil(endOffsetFrames / framesPerThumb))
+
+    const visibleThumbs = []
+    for (let i = startIndex; i <= endIndex; i++) {
+      const thumbStartFrame = (i * framesPerThumb) - startOffsetFrames
+      visibleThumbs.push(
+        <img
+          key={i}
+          src={stripFrames[i]}
+          style={{
+            position: 'absolute',
+            left: thumbStartFrame * zoom,
+            width: framesPerThumb * zoom,
+            height: '100%',
+            objectFit: 'cover',
+            borderRight: '1px solid var(--elah-effect-tile-separator)'
+          }}
+          alt=""
+        />
+      )
+    }
+
+    filmstripContent = (
+      <div
+        style={{
+          position: 'absolute',
+          inset: 0,
+          overflow: 'hidden',
+          pointerEvents: 'none',
+          borderRadius: 4,
+        }}
+      >
+        {visibleThumbs}
+      </div>
+    )
+  }
 
   // Real waveform bars for audio — falls back to static bars while decoding.
   const waveform = asset?.waveform
@@ -153,7 +200,11 @@ export const ClipBlock = memo(function ClipBlock({
     (e: React.PointerEvent) => {
       if (e.button !== 0) return
       e.stopPropagation()
-      selectClip(clip.id)
+      if (e.shiftKey) {
+        toggleClipSelection(clip.id)
+      } else {
+        selectClip(clip.id)
+      }
       clearActiveGesture()
       if (trackLocked) return // selectable, but not draggable
 
@@ -441,41 +492,8 @@ export const ClipBlock = memo(function ClipBlock({
         zIndex: isSelected ? 5 : 1,
       }}
     >
-      {/* Filmstrip — evenly-spaced source frames tiled across the clip. Tiles
-          repeat (or thin out) as the clip widens/narrows with zoom. */}
-      {(clip.type === 'video' || clip.type === 'image') && stripFrames.length > 0 && (
-        <div
-          style={{
-            position: 'absolute',
-            inset: 0,
-            display: 'flex',
-            overflow: 'hidden',
-            pointerEvents: 'none',
-            borderRadius: 4,
-          }}
-        >
-          {Array.from({ length: tileCount }).map((_, i) => {
-            const frameIdx = Math.min(
-              stripFrames.length - 1,
-              Math.floor((i / tileCount) * stripFrames.length),
-            )
-            return (
-              <div
-                key={i}
-                style={{
-                  flex: '1 1 0',
-                  minWidth: 0,
-                  height: '100%',
-                  backgroundImage: `url(${stripFrames[frameIdx]})`,
-                  backgroundSize: 'cover',
-                  backgroundPosition: 'center',
-                  boxShadow: `inset -1px 0 0 var(--elah-effect-tile-separator)`,
-                }}
-              />
-            )
-          })}
-        </div>
-      )}
+      {/* Filmstrip logic rendered here */}
+      {filmstripContent}
 
       {/* Left accent stripe — paints from currentColor (the clip's accent). */}
       <div

--- a/packages/timeline/src/Ruler.tsx
+++ b/packages/timeline/src/Ruler.tsx
@@ -1,4 +1,5 @@
-import { memo, useCallback, useEffect, useMemo, useRef } from 'react'
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { framesToTimecode } from '@elah/core'
 import { cn } from './cn'
 
 /**
@@ -71,6 +72,7 @@ export const Ruler = memo(function Ruler({
   }, [fps, totalFrames, zoom])
 
   const activeGestureCleanup = useRef<(() => void) | null>(null)
+  const [hoverState, setHoverState] = useState<{ frame: number; x: number } | null>(null)
 
   const clearActiveGesture = useCallback(() => {
     activeGestureCleanup.current?.()
@@ -133,7 +135,40 @@ export const Ruler = memo(function Ruler({
         userSelect: 'none',
       }}
       onPointerDown={handlePointerDown}
+      onPointerMove={(e) => {
+        const rect = e.currentTarget.getBoundingClientRect()
+        const x = e.clientX - rect.left
+        const frame = Math.floor(x / zoom)
+        setHoverState({ frame, x })
+      }}
+      onPointerLeave={() => setHoverState(null)}
     >
+      {hoverState && (
+        <div
+          className="bg-ed-panel border-ed-border border-ed-border-subtle text-ed-text"
+          style={{
+            position: 'absolute',
+            left: hoverState.x,
+            bottom: height + 4,
+            transform: 'translateX(-50%)',
+            padding: '4px 8px',
+            borderRadius: 4,
+            fontSize: 11,
+            pointerEvents: 'none',
+            whiteSpace: 'nowrap',
+            zIndex: 50,
+            borderWidth: 1,
+            borderStyle: 'solid',
+            boxShadow: '0 2px 4px rgba(0,0,0,0.2)'
+          }}
+        >
+          <div>Frame {hoverState.frame}</div>
+          <div style={{ color: 'var(--elah-text-muted)', fontSize: 10 }}>
+            {framesToTimecode(hoverState.frame, fps)}
+          </div>
+        </div>
+      )}
+
       {ticks.map(({ frame, label }) => (
         <div
           key={frame}

--- a/packages/timeline/src/Timeline.tsx
+++ b/packages/timeline/src/Timeline.tsx
@@ -155,8 +155,17 @@ export const Timeline = memo(
       const handleWheel = (e: WheelEvent) => {
         if (!e.ctrlKey && !e.metaKey) return
         e.preventDefault()
+        
+        const state = usePlaybackStore.getState()
+        const oldZoom = state.zoom
+        const currentFrame = state.currentFrame
+        const playheadScreenX = (currentFrame * oldZoom) - el.scrollLeft
+
         const direction = e.deltaY > 0 ? -0.5 : 0.5
-        setZoom(usePlaybackStore.getState().zoom + direction)
+        setZoom(oldZoom + direction)
+        
+        const newZoom = usePlaybackStore.getState().zoom
+        el.scrollLeft = (currentFrame * newZoom) - playheadScreenX
       }
 
       el.addEventListener('wheel', handleWheel, { passive: false })

--- a/packages/timeline/src/TrackRow.tsx
+++ b/packages/timeline/src/TrackRow.tsx
@@ -352,6 +352,7 @@ export const TrackRow = memo(function TrackRow({
             clip={clip}
             zoom={zoom}
             trackHeight={track.height}
+            fps={fps}
             className={clipClassName}
             clipVideo={clipVideo}
             clipAudio={clipAudio}


### PR DESCRIPTION
## What does this PR do?

Fixes several bugs in the timeline playground including zoom drift, missing ruler tooltips, broken multi-clip selection, and missing video clip filmstrips.

Closes #1, Closes #4, Closes #7, Closes #8

---

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Performance improvement

---

## How to test

1. **Zoom Drift (#1)**: Place the playhead on the timeline, hold `Ctrl` and scroll to zoom. The playhead should stay anchored in place on the screen.
2. **Ruler Tooltip (#4)**: Hover your mouse over the timeline ruler at the top. A tooltip should appear showing the exact frame number and timecode.
3. **Multi-selection (#7)**: Add two clips to the timeline. Click the first clip, hold `Shift`, and click the second clip. Both should highlight. Press `Delete` to remove both simultaneously.
4. **Video Filmstrip (#8)**: Add a video clip to the timeline. It should now display a sequence of thumbnail frames across the clip instead of a solid color block.

---

## Checklist

- [x] `npm test` passes
- [x] `npm run typecheck` passes
- [x] I've tested this in the playground
- [x] No `any` types introduced without justification
