### PR TITLE
Fix Timeline zoom drift (Issue #1)

### DIFF
--- a/packages/timeline/src/Timeline.tsx
+++ b/packages/timeline/src/Timeline.tsx
@@ -155,8 +155,17 @@ export const Timeline = memo(
       const handleWheel = (e: WheelEvent) => {
         if (!e.ctrlKey && !e.metaKey) return
         e.preventDefault()
+        
+        const state = usePlaybackStore.getState()
+        const oldZoom = state.zoom
+        const currentFrame = state.currentFrame
+        const playheadScreenX = (currentFrame * oldZoom) - el.scrollLeft
+
         const direction = e.deltaY > 0 ? -0.5 : 0.5
-        setZoom(usePlaybackStore.getState().zoom + direction)
+        setZoom(oldZoom + direction)
+        
+        const newZoom = usePlaybackStore.getState().zoom
+        el.scrollLeft = (currentFrame * newZoom) - playheadScreenX
       }
 
       el.addEventListener('wheel', handleWheel, { passive: false })


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where zooming in and out on the timeline caused the playhead to drift out of view instead of anchoring properly to the screen.

Closes #1

---

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Performance improvement

---

## How to test

1. Place the playhead on the timeline.
2. Hold `Ctrl` and scroll to zoom in and out.
3. Verify that the playhead stays anchored in place on the screen.

---

## Checklist

- [x] `npm test` passes
- [x] `npm run typecheck` passes
- [x] I've tested this in the playground
- [x] No `any` types introduced without justification
