### PR TITLE
Enable multi-clip selection with Shift+click (Issue #7)

### DIFF
--- a/packages/timeline/src/ClipBlock.tsx
+++ b/packages/timeline/src/ClipBlock.tsx
@@ -86,6 +86,7 @@ export const ClipBlock = memo(function ClipBlock({
   const isSelected = useSelectionStore((s) => s.selectedClipIds.has(clip.id))
   const selectClip = useSelectionStore((s) => s.selectClip)
   const clearSelection = useSelectionStore((s) => s.clearSelection)
+  const toggleClipSelection = useSelectionStore((s) => s.toggleClipSelection)
   const snapEnabled = usePlaybackStore((s) => s.snapEnabled)
   const asset = useMediaLibraryStore((s) =>
     clip.assetId ? s.assets[clip.assetId] : undefined,
@@ -153,7 +154,11 @@ export const ClipBlock = memo(function ClipBlock({
     (e: React.PointerEvent) => {
       if (e.button !== 0) return
       e.stopPropagation()
-      selectClip(clip.id)
+      if (e.shiftKey) {
+        toggleClipSelection(clip.id)
+      } else {
+        selectClip(clip.id)
+      }
       clearActiveGesture()
       if (trackLocked) return // selectable, but not draggable
 


### PR DESCRIPTION
## What does this PR do?

Fixes a bug in the timeline where holding `Shift` to select multiple clips was not working, allowing users to select and manipulate multiple clips at once.

Closes #7

---

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Performance improvement

---

## How to test

1. Add two clips to the timeline.
2. Click the first clip, hold `Shift`, and click the second clip.
3. Verify both are highlighted. Press `Delete` to remove both simultaneously.

---

## Checklist

- [x] `npm test` passes
- [x] `npm run typecheck` passes
- [x] I've tested this in the playground
- [x] No `any` types introduced without justification
