### PR TITLE
ui: remove dead Fit/Frame buttons, hide unwired Fullscreen

### DIFF
--- a/apps/web/components/playground/production/ProductionEditor.tsx
+++ b/apps/web/components/playground/production/ProductionEditor.tsx
@@ -10,7 +10,6 @@ import {
   Square,
   Maximize2,
   ChevronDown,
-  RectangleHorizontal,
   Film,
   Image as ImageIcon,
   Music,
@@ -708,21 +707,9 @@ const TransportBar = memo(function TransportBar() {
             </button>
           </>
         ) : (
-          <>
-            <button type="button" title="Fullscreen" className={ghostIcon}>
-              <Maximize2 size={14} />
-            </button>
-            <button
-              type="button"
-              title="Fit"
-              className="inline-flex items-center gap-1 px-2 h-7 rounded border border-ed-border text-ed-text-muted text-[11px] hover:text-ed-text transition-colors cursor-pointer"
-            >
-              Fit <ChevronDown size={12} />
-            </button>
-            <button type="button" title="Frame" className={ghostIcon}>
-              <RectangleHorizontal size={15} />
-            </button>
-          </>
+          <button type="button" title="Fullscreen" className={cn(ghostIcon, 'hidden')}>
+            <Maximize2 size={14} />
+          </button>
         )}
       </div>
     </div>


### PR DESCRIPTION
## What does this PR do?

Removes the "Fit" dropdown and "Frame" (aspect ratio) icon buttons from the preview transport bar — both rendered with hover styling and tooltips but had no `onClick`/`onChange` handler wired, so they looked interactive but did nothing. The "Fullscreen" button in the same spot is also unwired; kept in the DOM but hidden (`className hidden`) rather than removed, since it's a likely near-term wire-up target and the desktop-only `Maximize2` icon slot already exists.

Closes #

---

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Performance improvement

---

## How to test

1. `npm run dev`, open `/playground/production`
2. Look at the bar directly under the preview canvas (transport bar with timecode + play/stop)
3. Before this change: right side showed a "Fit" dropdown, a "Frame" icon, and a "Fullscreen" icon — none clickable
4. After this change: right side is empty (Fullscreen hidden, Fit/Frame removed); play/stop/timecode still work

---

## Screenshots / Recording
-

---

## Checklist

- [x] `npm test` passes
- [x] `npm run typecheck` passes
- [x] I've tested this in the playground
- [x] No `any` types introduced without justification