### PR TITLE
export: add server-side ffmpeg export package

### DIFF
--- a/BUNDLE_STRATEGY.md
+++ b/BUNDLE_STRATEGY.md
@@ -47,6 +47,24 @@ consumer bundle. Its budget is still enumerated:
 | `mediabunny` | Probes media duration/dimensions for `elah build` in plain Node (pure-JS demux, no WebCodecs; ranged reads for remote URLs); already a core dependency, bundled into the binary, never reaches a consumer bundle |
 | `esbuild` (dev, build-time only) | core's tsc dist uses extensionless relative imports (bundler resolution) that plain Node cannot resolve; the CLI bundles at build time and tree-shakes core's browser-only modules out of the Node binary |
 
+`@elah/export-server` is a **server-side library** — it imports `node:child_process`
+and a native addon, so it can never be pulled into a browser bundle even by
+accident:
+
+| Dependency | Why it's in |
+|---|---|
+| `@elah/core` | The resolver and the placement helpers (`resolveDrawRect`, `computeTextLayout`); the package is a `Scene` consumer and shares core's geometry so server output matches the editor |
+| `@napi-rs/canvas` | The 2D compositor in Node (Skia-backed). Ships prebuilt per-platform binaries, so a deploy box needs no build toolchain; `GlobalFonts.registerFromPath` is what makes text render at all in a container with no system font stack |
+| `mediabunny` | Probes source duration/dimensions, supplies the packet PTS index that drives frame-accurate seeking, and re-opens the finished MP4 to validate it; already a core dependency, and none of these paths need WebCodecs |
+| `esbuild` (dev, build-time only) | Same reason as the CLI — resolves core's extensionless imports and tree-shakes its browser-only modules out of the Node bundle |
+
+**ffmpeg is deliberately not a dependency.** It is discovered as a system binary
+(`opts.ffmpegPath` → `ELAH_FFMPEG` → `PATH`), the same way
+`packages/cli/src/lib/browser.ts` discovers system Chrome rather than bundling
+one. Vendoring a static build would add ~80 MiB per platform, drop the hardware
+encoders (`h264_videotoolbox`, NVENC, QSV) that are a main reason to run this
+path at all, and mean redistributing a GPL binary from an Apache-2.0 package.
+
 Everything else the engine needs is a **browser-native API**, not a bundled
 dependency: WebCodecs (`VideoDecoder`), WebGL2, Web Audio (`OfflineAudioContext`),
 `OffscreenCanvas`, `createImageBitmap`. No WASM runtime ships in the core.

--- a/docs/headless-server-gap-analysis.md
+++ b/docs/headless-server-gap-analysis.md
@@ -151,6 +151,80 @@ on, and the Docker image (#3) is what makes both deployable. In Tier 3, fonts
 and captions are the highest-leverage spec additions because they are what
 AI-pipeline customers evaluate first. Tier 2 can follow demand.
 
+## Appendix — how a Node render path would get its codecs
+
+*Added 2026-07-21, prompted by a proposal for a server-only export package.*
+
+Problem statement at a glance:
+
+```json
+{
+  "goal": "Export video from a server without a browser",
+  "why": "WebCodecs is browser-only, so server export runs headless Chrome via Playwright",
+  "chromeCosts": [
+    "~300MB + ~40 shared libs",
+    "redistribution limits on baked images",
+    "1-3s cold start/job",
+    "software encoder only, no GPU choice",
+    "whole MP4 in RAM"
+  ],
+  "proposal": "New Node-only package using ffmpeg instead of WebCodecs",
+  "problemWithProposal": "Replacing decode/encode forces replacing compositing too = second renderer = parity tax forever (fonts, color, audio)",
+  "betterOption": "webcodecs-node shim — ffmpeg-backed WebCodecs API in Node, hardware encoders, existing ExportWorker.ts runs unchanged, one renderer",
+  "misdiagnosis": "Tier 1 above ranks top blockers as: no programmatic API, no warm/daemon mode, no Docker story. Encoder is not the blocker.",
+  "unmeasured": "Export loop is fully serial; logs show only avgMsPerFrame, no decode/draw/encode split. Nobody confirmed encode dominates.",
+  "recommendedOrder": [
+    "measure per-stage timing",
+    "spike webcodecs-node",
+    "programmatic API",
+    "warm mode",
+    "Docker image",
+    "ffmpeg port only if spike fails"
+  ]
+}
+```
+
+If the browser-free path in "Industry context" is ever picked up, the first
+decision is where the codec implementation comes from. The options are not
+equivalent, and two of them are traps:
+
+| Dimension | System ffmpeg binary | `ffmpeg-static` (npm) | ffmpeg.wasm | `beamcoder` (native bindings) | WebCodecs shim (`webcodecs-node`) |
+|---|---|---|---|---|---|
+| What it is | Executable found on PATH | Prebuilt binary vendored by npm | ffmpeg compiled to wasm | N-API bindings to libav* | ffmpeg-backed WebCodecs API |
+| Execution model | spawn + pipes | spawn + pipes | in-process wasm | in-process native | in-process, native |
+| Added install size | 0 | ~80 MiB/platform | ~25–30 MiB | small pkg, needs system libav* | native pkg |
+| Speed | full native | full native | 3–10× slower, CPU only | full native | full native |
+| Hardware encoders | Yes, if the build has them | Usually not | Never | Yes, if libs built with them | Yes (NVENC/VAAPI/QSV/VideoToolbox) |
+| Version reproducibility | Weak — machine-dependent | Strong — pinned | Strong | Weak — system libs | Pinned pkg, system libs vary |
+| Licensing exposure | None — not redistributed | Redistributes a GPL build | Redistributes | Linking libav* raises LGPL/GPL | Same as bindings |
+| Memory ceiling | OS-level | OS-level | wasm heap — long exports break | OS-level | OS-level |
+| **Requires a second renderer** | **Yes** | **Yes** | **Yes** | **Yes** | **No** |
+
+The last row is the one that decides it. The first four options all replace
+core's WebCodecs decode/encode with a pipe- or binding-based API, which means
+compositing also has to move off `OffscreenCanvas` onto a Node canvas — a
+second implementation of the draw path, and therefore the dual-renderer parity
+violation this document already flags. Fonts are the sharpest edge: Chrome has
+a system fallback chain, Node canvas libraries only know fonts explicitly
+registered (see Tier 3 #1).
+
+A WebCodecs shim avoids that entirely. `VideoDecoder`/`VideoEncoder` keep their
+browser signatures, so `packages/core/src/export/ExportWorker.ts` runs in Node
+substantially unchanged — one render path, no parity tests, hardware encoders
+included. This should be spiked before any port is attempted; the spike is
+cheap (run the existing export worker in Node against a fixture) and it either
+removes the need for the port or produces the concrete failure that justifies it.
+
+If a port does turn out to be necessary, prefer the **system binary** over
+`ffmpeg-static`: no size cost, no GPL redistribution from an MIT package, and
+it keeps hardware encoders — consistent with how
+`packages/cli/src/lib/browser.ts` already discovers system Chrome rather than
+vendoring a browser. Guard version drift with an `ffmpeg -encoders` capability
+check at startup, and keep `ffmpeg-static` as an optional fallback for
+zero-config local dev. ffmpeg.wasm is not viable at all: software-only encoding
+plus a wasm heap ceiling is strictly worse than the headless Chrome it would
+replace.
+
 ## Sources
 
 - [Shotstack Edit API](https://shotstack.io/product/video-editing-api/)

--- a/package-lock.json
+++ b/package-lock.json
@@ -628,6 +628,10 @@
       "resolved": "packages/editor",
       "link": true
     },
+    "node_modules/@elah/export-server": {
+      "resolved": "packages/export-server",
+      "link": true
+    },
     "node_modules/@elah/react": {
       "resolved": "packages/react",
       "link": true
@@ -1979,6 +1983,235 @@
       "license": "MIT",
       "dependencies": {
         "@chevrotain/types": "~11.1.1"
+      }
+    },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.97.tgz",
+      "integrity": "sha512-8cFniXvrIEnVwuNSRCW9wirRZbHvrD3JVujdS2P5n5xiJZNZMOZcfOvJ1pb66c7jXMKHHglJEDVJGbm8XWFcXQ==",
+      "license": "MIT",
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.97",
+        "@napi-rs/canvas-darwin-arm64": "0.1.97",
+        "@napi-rs/canvas-darwin-x64": "0.1.97",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.97",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.97",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.97",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.97",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.97",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.97",
+        "@napi-rs/canvas-win32-arm64-msvc": "0.1.97",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.97"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.97.tgz",
+      "integrity": "sha512-V1c/WVw+NzH8vk7ZK/O8/nyBSCQimU8sfMsB/9qeSvdkGKNU7+mxy/bIF0gTgeBFmHpj30S4E9WHMSrxXGQuVQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.97.tgz",
+      "integrity": "sha512-ok+SCEF4YejcxuJ9Rm+WWunHHpf2HmiPxfz6z1a/NFQECGXtsY7A4B8XocK1LmT1D7P174MzwPF9Wy3AUAwEPw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.97.tgz",
+      "integrity": "sha512-PUP6e6/UGlclUvAQNnuXCcnkpdUou6VYZfQOQxExLp86epOylmiwLkqXIvpFmjoTEDmPmXrI+coL/9EFU1gKPA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.97.tgz",
+      "integrity": "sha512-XyXH2L/cic8eTNtbrXCcvqHtMX/nEOxN18+7rMrAM2XtLYC/EB5s0wnO1FsLMWmK+04ZSLN9FBGipo7kpIkcOw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.97.tgz",
+      "integrity": "sha512-Kuq/M3djq0K8ktgz6nPlK7Ne5d4uWeDxPpyKWOjWDK2RIOhHVtLtyLiJw2fuldw7Vn4mhw05EZXCEr4Q76rs9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.97.tgz",
+      "integrity": "sha512-kKmSkQVnWeqg7qdsiXvYxKhAFuHz3tkBjW/zyQv5YKUPhotpaVhpBGv5LqCngzyuRV85SXoe+OFj+Tv0a0QXkQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.97.tgz",
+      "integrity": "sha512-Jc7I3A51jnEOIAXeLsN/M/+Z28LUeakcsXs07FLq9prXc0eYOtVwsDEv913Gr+06IRo34gJJVgT0TXvmz+N2VA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.97.tgz",
+      "integrity": "sha512-iDUBe7AilfuBSRbSa8/IGX38Mf+iCSBqoVKLSQ5XaY2JLOaqz1TVyPFEyIck7wT6mRQhQt5sN6ogfjIDfi74tg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.97.tgz",
+      "integrity": "sha512-AKLFd/v0Z5fvgqBDqhvqtAdx+fHMJ5t9JcUNKq4FIZ5WH+iegGm8HPdj00NFlCSnm83Fp3Ln8I2f7uq1aIiWaA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.97.tgz",
+      "integrity": "sha512-sWtD2EE3fV0IzN+iiQUqr/Q1SwqWhs2O1FKItFlxtdDkikpEj5g7DKQpY3x55H/MAOnL8iomnlk3mcEeGiUMoQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -14084,6 +14317,25 @@
       "peerDependencies": {
         "react": ">=18.0.0",
         "react-dom": ">=18.0.0"
+      }
+    },
+    "packages/export-server": {
+      "name": "@elah/export-server",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@elah/core": "^0.3.1",
+        "@napi-rs/canvas": "^0.1.60",
+        "mediabunny": "^1.45.3"
+      },
+      "devDependencies": {
+        "@types/node": "^22.10.0",
+        "esbuild": "^0.25.0",
+        "typescript": "^5.7.3",
+        "vitest": "^3.0.6"
+      },
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "packages/react": {

--- a/package.json
+++ b/package.json
@@ -7,11 +7,11 @@
   ],
   "scripts": {
     "dev": "npm run dev --workspace=apps/web",
-    "build:packages": "npm run build --workspace=packages/core && npm run build --workspace=packages/react && npm run build --workspace=packages/timeline && npm run build --workspace=packages/editor && npm run build --workspace=packages/cli",
+    "build:packages": "npm run build --workspace=packages/core && npm run build --workspace=packages/react && npm run build --workspace=packages/timeline && npm run build --workspace=packages/editor && npm run build --workspace=packages/cli && npm run build --workspace=packages/export-server",
     "build": "npm run build --workspace=apps/web",
     "typecheck": "npm run typecheck --workspaces --if-present",
     "lint:tokens": "node scripts/check-tokens.mjs",
-    "test": "npm run test --workspace=packages/core --workspace=packages/timeline --workspace=packages/cli"
+    "test": "npm run test --workspace=packages/core --workspace=packages/timeline --workspace=packages/cli --workspace=packages/export-server"
   },
   "devDependencies": {
     "rollup-plugin-visualizer": "^7.0.1"

--- a/packages/export-server/LICENSE
+++ b/packages/export-server/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the
+      purposes of this License, Derivative Works shall not include works
+      that remain separable from, or merely link (or bind by name) to the
+      interfaces of, the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing
+      the origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Elah Labs Private Limited
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/export-server/README.md
+++ b/packages/export-server/README.md
@@ -1,0 +1,35 @@
+# @elah/export-server
+
+Node-only, browser-free video export for the [Elah](https://www.elah.dev) engine.
+
+Elah's normal export path runs on WebCodecs, which only exists in a browser — server-side
+export today means launching headless Chrome. This package renders the same project without
+a browser at all: it resolves the project into the exact same `Scene` the editor's renderer
+consumes, then draws and encodes it with system [ffmpeg](https://ffmpeg.org/) instead of
+WebCodecs. Same brain, different codec I/O.
+
+## Requirements
+
+ffmpeg must already be installed on the machine running the export — it is invoked as a
+system binary, never bundled or vendored. This keeps the package small, keeps it clear of
+ffmpeg's GPL licensing, and preserves access to hardware encoders (`h264_videotoolbox`,
+`h264_nvenc`, `h264_qsv`) that a vendored static build would not have.
+
+Check that it's installed and discoverable:
+
+```bash
+which ffmpeg
+ffmpeg -encoders
+```
+
+`ffmpeg -encoders` should list the encoder you intend to use (e.g. `libx264`,
+`h264_videotoolbox`). The binary is located via, in order: an explicit path passed to the
+export call, the `ELAH_FFMPEG` environment variable, then `ffmpeg` on `PATH`.
+
+## Design principle
+
+This package is another *consumer of the resolver*, not a second renderer. It calls the same
+pure `resolveTimeline` and the same placement helpers (`resolveDrawRect`, `computeTextLayout`)
+that the browser exporter uses, so its output matches the editor frame-for-frame. It never
+imports `Project` or `Clip` internals — only the resolved `Scene` — which is what keeps this
+package swappable: change the codec I/O, keep the brain.

--- a/packages/export-server/package.json
+++ b/packages/export-server/package.json
@@ -1,0 +1,64 @@
+{
+  "name": "@elah/export-server",
+  "version": "0.1.0",
+  "description": "Node-only, browser-free video export for the Elah engine — resolves the same Scene as the editor and renders it with system ffmpeg",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/types/index.d.ts",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "engines": {
+    "node": ">=18.17"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "build": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\" && tsc --noEmit && tsc -p tsconfig.build.json && node scripts/build.mjs"
+  },
+  "keywords": [
+    "video-editor",
+    "video-engine",
+    "export",
+    "ffmpeg",
+    "headless",
+    "server",
+    "node",
+    "frame-accurate",
+    "mp4",
+    "timeline",
+    "typescript"
+  ],
+  "homepage": "https://www.elah.dev",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/elahlabs/elah.git"
+  },
+  "bugs": {
+    "url": "https://github.com/elahlabs/elah/issues"
+  },
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@elah/core": "^0.3.1",
+    "@napi-rs/canvas": "^0.1.60",
+    "mediabunny": "^1.45.3"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.0",
+    "esbuild": "^0.25.0",
+    "typescript": "^5.7.3",
+    "vitest": "^3.0.6"
+  }
+}

--- a/packages/export-server/scripts/build.mjs
+++ b/packages/export-server/scripts/build.mjs
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+import { build } from 'esbuild'
+
+// Bundling (rather than tsc emit like core) is load-bearing: @elah/core's dist
+// uses extensionless relative imports (bundler resolution), which plain Node
+// cannot resolve. esbuild resolves them at build time and tree-shakes core's
+// browser-only modules out of the Node bundle.
+//
+// @napi-rs/canvas stays external because it is a native addon — bundling it
+// would detach the JS wrapper from its platform-specific .node binary.
+// mediabunny stays external so the host resolves the same copy core does.
+await build({
+  bundle: true,
+  platform: 'node',
+  target: 'node18',
+  format: 'esm',
+  external: ['@napi-rs/canvas', 'mediabunny'],
+  logLevel: 'info',
+  entryPoints: ['src/index.ts'],
+  outfile: 'dist/index.js',
+})

--- a/packages/export-server/src/__tests__/errors.test.ts
+++ b/packages/export-server/src/__tests__/errors.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest'
+
+import { ExportServerError } from '../errors'
+
+describe('ExportServerError', () => {
+  it('carries the code, message and name a consumer switches on', () => {
+    const err = new ExportServerError('FFMPEG_NOT_FOUND', 'No ffmpeg binary found for export.')
+
+    expect(err).toBeInstanceOf(Error)
+    expect(err).toBeInstanceOf(ExportServerError)
+    expect(err.name).toBe('ExportServerError')
+    expect(err.code).toBe('FFMPEG_NOT_FOUND')
+    expect(err.message).toBe('No ffmpeg binary found for export.')
+    expect(err.stderr).toBeUndefined()
+  })
+
+  it('survives instanceof checks across a throw/catch boundary', () => {
+    const raise = () => {
+      throw new ExportServerError('SOURCE_UNSUPPORTED', 'unsupported source')
+    }
+
+    try {
+      raise()
+      expect.unreachable()
+    } catch (err) {
+      expect(err instanceof ExportServerError).toBe(true)
+      expect((err as ExportServerError).code).toBe('SOURCE_UNSUPPORTED')
+    }
+  })
+
+  it('exposes the stderr tail when the failure came from a child process', () => {
+    const err = new ExportServerError('ENCODE_FAILED', 'ffmpeg exited with code 1', {
+      stderr: 'Unknown encoder ...',
+    })
+
+    expect(err.stderr).toBe('Unknown encoder ...')
+  })
+
+  it('chains the original error via the standard cause option', () => {
+    const original = new Error('ENOENT: spawn ffmpeg')
+    const err = new ExportServerError('FFMPEG_NOT_FOUND', 'ffmpeg not found', {
+      cause: original,
+    })
+
+    expect(err.cause).toBe(original)
+  })
+
+  it('omits cause entirely when none is given, rather than setting it to undefined', () => {
+    const err = new ExportServerError('PLAN_INVALID', 'plan invalid')
+
+    expect('cause' in err).toBe(false)
+  })
+
+  it('keeps every ExportErrorCode member constructible (compile-time exhaustiveness)', () => {
+    const codes = [
+      'FFMPEG_NOT_FOUND',
+      'FFMPEG_TOO_OLD',
+      'ENCODER_MISSING',
+      'EMPTY_PROJECT',
+      'PLAN_INVALID',
+      'PROBE_FAILED',
+      'SOURCE_UNSUPPORTED',
+      'FONT_LOAD_FAILED',
+      'DECODE_FAILED',
+      'ENCODE_FAILED',
+      'OUTPUT_INVALID',
+      'ABORTED',
+    ] as const
+
+    for (const code of codes) {
+      expect(new ExportServerError(code, code).code).toBe(code)
+    }
+  })
+})

--- a/packages/export-server/src/__tests__/exportProject.test.ts
+++ b/packages/export-server/src/__tests__/exportProject.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest'
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import type { Project, Track, Clip } from '@elah/core'
+import { createCanvas } from '@napi-rs/canvas'
+
+import { exportProject } from '../exportProject'
+
+const execFileAsync = promisify(execFile)
+
+/**
+ * A real, un-mocked run of `exportProject` against a project whose single
+ * clip is a relative-path image src — the exact shape that reproduces the
+ * imageSources key-mismatch regression (plan.ts resolved the src for the
+ * lookup map, but FrameCompositor looks images up by the raw Scene src).
+ * Before the fix this exported an all-black frame with no error, no warning,
+ * and a correct frame count/duration — silent enough that only reading the
+ * actual pixels back out catches it.
+ *
+ * Runs against the system ffmpeg (present in dev/CI per this package's own
+ * requirement) rather than mocking child_process: the whole point is to
+ * observe what actually lands in the muxed output, which a mocked spawn
+ * cannot tell us.
+ */
+describe('exportProject (image clip integration)', () => {
+  it('composites a relative-src image clip instead of silently dropping it', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'elah-export-server-'))
+    try {
+      const assetsDir = join(dir, 'assets')
+      await mkdir(assetsDir, { recursive: true })
+
+      // A solid red 16x16 PNG — anything decisively non-black at the center
+      // pixel is enough to prove the image actually composited.
+      const canvas = createCanvas(16, 16)
+      const ctx = canvas.getContext('2d')
+      ctx.fillStyle = '#ff0000'
+      ctx.fillRect(0, 0, 16, 16)
+      await writeFile(join(assetsDir, 'logo.png'), canvas.toBuffer('image/png'))
+
+      const track: Track = {
+        id: 't1',
+        name: 'V',
+        kind: 'video',
+        order: 0,
+        height: 64,
+        locked: false,
+        disabled: false,
+        muted: false,
+        solo: false,
+      }
+      const clip: Clip = {
+        id: 'img1',
+        trackId: 't1',
+        type: 'image',
+        name: 'logo',
+        startFrame: 0,
+        durationFrames: 3,
+        sourceStartFrame: 0,
+        sourceDurationFrames: 3,
+        // Relative — resolveSource(projectDir, src) rewrites this to an
+        // absolute path distinct from the raw Scene src the compositor sees.
+        src: 'assets/logo.png',
+        transform: { x: 0.5, y: 0.5, scale: 1, rotation: 0, anchor: { x: 0.5, y: 0.5 } },
+      }
+      const project: Project = {
+        id: 'p1',
+        fps: 5,
+        stage: { width: 16, height: 16 },
+        tracks: [track],
+        clips: { t1: [clip] },
+        transitions: [],
+        version: 1,
+      }
+
+      const outPath = join(dir, 'out.mp4')
+      const result = await exportProject(project, { outPath, projectDir: dir })
+
+      expect(result.warnings.filter(w => w.toLowerCase().includes('image'))).toEqual([])
+
+      // Pull the first frame's raw pixels back out and check the center is
+      // red, not the opaque black background — the failure mode is a fully
+      // black frame for the image's entire duration.
+      const { stdout } = await execFileAsync(
+        'ffmpeg',
+        ['-hide_banner', '-loglevel', 'error', '-i', outPath, '-frames:v', '1', '-f', 'rawvideo', '-pix_fmt', 'rgba', 'pipe:1'],
+        { encoding: 'buffer', maxBuffer: 1024 * 1024 },
+      )
+      const pixels = stdout as unknown as Buffer
+      const width = result.width
+      const cx = Math.floor(width / 2)
+      const cy = Math.floor(result.height / 2)
+      const i = (cy * width + cx) * 4
+      const [r, g, b] = [pixels[i], pixels[i + 1], pixels[i + 2]]
+
+      expect(r).toBeGreaterThan(150)
+      expect(g).toBeLessThan(100)
+      expect(b).toBeLessThan(100)
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  }, 30_000)
+})

--- a/packages/export-server/src/__tests__/plan.test.ts
+++ b/packages/export-server/src/__tests__/plan.test.ts
@@ -1,0 +1,302 @@
+import { describe, it, expect } from 'vitest'
+import type { Project, Track, Clip, Transition } from '@elah/core'
+
+import { planExport, mapSourceFramesToIndices } from '../plan'
+
+// The no-Project rule is about the runtime module graph of the package, not
+// about tests — a hand-built Project literal here is fine, it never crosses
+// into decoder/compositor/audio-graph code.
+
+function makeProject(overrides?: Partial<Project>): Project {
+  return {
+    id: 'p1',
+    fps: 30,
+    stage: { width: 1080, height: 1920 },
+    tracks: [],
+    clips: {},
+    transitions: [],
+    version: 1,
+    ...overrides,
+  }
+}
+
+function makeTrack(overrides?: Partial<Track>): Track {
+  return {
+    id: overrides?.id ?? 't1',
+    name: 'T',
+    kind: 'video',
+    order: 0,
+    height: 64,
+    locked: false,
+    disabled: false,
+    muted: false,
+    solo: false,
+    ...overrides,
+  }
+}
+
+function makeClip(overrides?: Partial<Clip>): Clip {
+  return {
+    id: 'c1',
+    trackId: 't1',
+    type: 'video',
+    name: 'C',
+    startFrame: 0,
+    durationFrames: 30,
+    sourceStartFrame: 0,
+    sourceDurationFrames: 30,
+    src: 'fake.mp4',
+    ...overrides,
+  }
+}
+
+const identityResolve = (src: string) => src
+
+describe('planExport', () => {
+  it('returns fps/stage from the frame-0 Scene and zero totalFrames for an empty project', () => {
+    const project = makeProject({ fps: 24, stage: { width: 640, height: 360 } })
+    const plan = planExport(project, { resolveSource: identityResolve })
+
+    expect(plan.fps).toBe(24)
+    expect(plan.stage).toEqual({ width: 640, height: 360 })
+    expect(plan.totalFrames).toBe(0)
+    expect(plan.videos).toEqual([])
+    expect(plan.audios).toEqual([])
+    expect(plan.imageSources).toEqual([])
+    expect(plan.fontFamilies).toEqual([])
+  })
+
+  it('produces a dense, monotonic sourceFrames array for a single video clip', () => {
+    const track = makeTrack({ id: 't1', kind: 'video' })
+    const clip = makeClip({
+      id: 'c1',
+      trackId: 't1',
+      startFrame: 5,
+      durationFrames: 10,
+      sourceStartFrame: 100,
+      sourceDurationFrames: 200,
+    })
+    const project = makeProject({
+      tracks: [track],
+      clips: { t1: [clip] },
+    })
+
+    const plan = planExport(project, { resolveSource: identityResolve })
+    expect(plan.videos).toHaveLength(1)
+    const v = plan.videos[0]
+    expect(v.clipId).toBe('c1')
+    expect(v.firstFrame).toBe(5)
+    expect(v.lastFrame).toBe(14)
+    expect(v.sourceFrames).toHaveLength(10)
+    expect(Array.from(v.sourceFrames)).toEqual([100, 101, 102, 103, 104, 105, 106, 107, 108, 109])
+  })
+
+  it('resolves each clip src through the provided resolveSource', () => {
+    const track = makeTrack({ id: 't1', kind: 'video' })
+    const clip = makeClip({ id: 'c1', trackId: 't1', src: 'relative/clip.mp4', startFrame: 0, durationFrames: 5, sourceDurationFrames: 5 })
+    const project = makeProject({ tracks: [track], clips: { t1: [clip] } })
+
+    const plan = planExport(project, { resolveSource: (src) => `/abs/${src}` })
+    expect(plan.videos[0].source).toBe('/abs/relative/clip.mp4')
+  })
+
+  it('gives a clip inside a transition window entries beyond its own end with a flat tail', () => {
+    // c1 [0,20) is the outgoing clip of a transition starting at frame 15
+    // that runs to frame 25 — resolveTimeline keeps emitting c1 (opacity 0,
+    // clamped sourceFrame) for frames 20..24, past its own [0,20) window.
+    const track = makeTrack({ id: 't1', kind: 'video' })
+    const c1 = makeClip({
+      id: 'c1',
+      trackId: 't1',
+      startFrame: 0,
+      durationFrames: 20,
+      sourceStartFrame: 0,
+      sourceDurationFrames: 20,
+    })
+    const c2 = makeClip({
+      id: 'c2',
+      trackId: 't1',
+      startFrame: 20,
+      durationFrames: 20,
+      sourceStartFrame: 0,
+      sourceDurationFrames: 20,
+    })
+    const transition: Transition = {
+      id: 'tr1',
+      kind: 'fade',
+      fromClipId: 'c1',
+      toClipId: 'c2',
+      trackId: 't1',
+      startFrame: 15,
+      durationFrames: 10,
+    }
+    const project = makeProject({
+      tracks: [track],
+      clips: { t1: [c1, c2] },
+      transitions: [transition],
+    })
+
+    const plan = planExport(project, { resolveSource: identityResolve })
+    const v1 = plan.videos.find((v) => v.clipId === 'c1')!
+    // c1's own window is [0,20) but the transition keeps it alive through
+    // frame 24 (startFrame 15 + durationFrames 10 - 1).
+    expect(v1.firstFrame).toBe(0)
+    expect(v1.lastFrame).toBe(24)
+    expect(v1.sourceFrames).toHaveLength(25)
+    // Clamped by resolveTimeline's Math.min(..., sourceDurationFrames - 1):
+    // the tail flattens at the last valid source frame (19) instead of
+    // continuing to climb past the clip's own source duration.
+    const tail = Array.from(v1.sourceFrames).slice(-5)
+    expect(tail).toEqual([19, 19, 19, 19, 19])
+    for (let i = 1; i < v1.sourceFrames.length; i++) {
+      expect(v1.sourceFrames[i]).toBeGreaterThanOrEqual(v1.sourceFrames[i - 1])
+    }
+  })
+
+  it('records audio startFrame/frameCount/sourceStartFrame/volume from the Scene', () => {
+    const track = makeTrack({ id: 'a1', kind: 'audio', volume: 0.5 })
+    const clip = makeClip({
+      id: 'ac1',
+      trackId: 'a1',
+      type: 'audio',
+      src: 'song.mp3',
+      startFrame: 3,
+      durationFrames: 6,
+      sourceStartFrame: 40,
+      sourceDurationFrames: 100,
+      volume: 0.8,
+    })
+    const project = makeProject({ tracks: [track], clips: { a1: [clip] } })
+
+    const plan = planExport(project, { resolveSource: identityResolve })
+    expect(plan.audios).toHaveLength(1)
+    const a = plan.audios[0]
+    expect(a.clipId).toBe('ac1')
+    expect(a.startFrame).toBe(3)
+    expect(a.frameCount).toBe(6)
+    expect(a.sourceStartFrame).toBe(40)
+    expect(a.volume).toBeCloseTo(0.4) // clip.volume(0.8) * track.volume(0.5)
+  })
+
+  it('collects unique image sources in first-appearance order', () => {
+    const track = makeTrack({ id: 't1', kind: 'video' })
+    const img1 = makeClip({ id: 'i1', trackId: 't1', type: 'image', src: 'b.png', startFrame: 0, durationFrames: 5, sourceDurationFrames: 5 })
+    const img2 = makeClip({ id: 'i2', trackId: 't1', type: 'image', src: 'a.png', startFrame: 5, durationFrames: 5, sourceDurationFrames: 5 })
+    const img3 = makeClip({ id: 'i3', trackId: 't1', type: 'image', src: 'b.png', startFrame: 10, durationFrames: 5, sourceDurationFrames: 5 })
+    const project = makeProject({ tracks: [track], clips: { t1: [img1, img2, img3] } })
+
+    const plan = planExport(project, { resolveSource: identityResolve })
+    expect(plan.imageSources).toEqual([
+      { src: 'b.png', source: 'b.png' },
+      { src: 'a.png', source: 'a.png' },
+    ])
+  })
+
+  it('keeps the raw src distinct from the resolved source for images', () => {
+    const track = makeTrack({ id: 't1', kind: 'video' })
+    const img = makeClip({ id: 'i1', trackId: 't1', type: 'image', src: 'assets/logo.png', startFrame: 0, durationFrames: 5, sourceDurationFrames: 5 })
+    const project = makeProject({ tracks: [track], clips: { t1: [img] } })
+
+    const plan = planExport(project, { resolveSource: src => `/work/proj/${src}` })
+    expect(plan.imageSources).toEqual([{ src: 'assets/logo.png', source: '/work/proj/assets/logo.png' }])
+  })
+
+  it('collects unique defined fontFamilies from text clips', () => {
+    const track = makeTrack({ id: 'e1', kind: 'elements' })
+    const t1 = makeClip({ id: 'x1', trackId: 'e1', type: 'text', content: 'hi', fontFamily: 'Inter', startFrame: 0, durationFrames: 5, sourceDurationFrames: 5 })
+    const t2 = makeClip({ id: 'x2', trackId: 'e1', type: 'text', content: 'yo', startFrame: 5, durationFrames: 5, sourceDurationFrames: 5 }) // no fontFamily
+    const t3 = makeClip({ id: 'x3', trackId: 'e1', type: 'text', content: 'again', fontFamily: 'Inter', startFrame: 10, durationFrames: 5, sourceDurationFrames: 5 })
+    const t4 = makeClip({ id: 'x4', trackId: 'e1', type: 'text', content: 'other', fontFamily: 'Georgia', startFrame: 15, durationFrames: 5, sourceDurationFrames: 5 })
+    const project = makeProject({ tracks: [track], clips: { e1: [t1, t2, t3, t4] } })
+
+    const plan = planExport(project, { resolveSource: identityResolve })
+    expect(plan.fontFamilies).toEqual(['Inter', 'Georgia'])
+  })
+
+  it('never throws PLAN_INVALID for ordinary clips or transition-extended clips', () => {
+    // assertNonDecreasing guards against a resolver bug producing a decreasing
+    // sourceFrame — by construction (resolveTimeline's clamps only flatten,
+    // never reverse) this cannot happen for legitimate Project data, so the
+    // meaningful assertion here is that normal and transition-extended clips
+    // both pass the guard silently.
+    const track = makeTrack({ id: 't1', kind: 'video' })
+    const clip = makeClip({ id: 'c1', trackId: 't1', startFrame: 0, durationFrames: 5, sourceDurationFrames: 5 })
+    const project = makeProject({ tracks: [track], clips: { t1: [clip] } })
+    expect(() => planExport(project, { resolveSource: identityResolve })).not.toThrow()
+  })
+})
+
+describe('mapSourceFramesToIndices', () => {
+  it('duplicates indices when source fps < project fps (24fps source on 30fps project, 5:4 pattern)', () => {
+    // 24fps source timestamps: frame i at i/24 seconds.
+    const timestamps = Float64Array.from({ length: 24 }, (_, i) => i / 24)
+    // 30fps project: sourceFrames 0..29 (one project-second).
+    const sourceFrames = Int32Array.from({ length: 30 }, (_, i) => i)
+    const out = mapSourceFramesToIndices(sourceFrames, 30, timestamps)
+
+    // Every output index must be non-decreasing and within source bounds.
+    for (let i = 1; i < out.length; i++) {
+      expect(out[i]).toBeGreaterThanOrEqual(out[i - 1])
+    }
+    expect(out[out.length - 1]).toBe(23)
+    // 30 project frames onto 24 source frames: exactly 6 duplicated indices
+    // (a 5:4 duplication pattern repeated 6 times across the 30-frame span).
+    const uniqueCount = new Set(Array.from(out)).size
+    expect(uniqueCount).toBe(24)
+    expect(Array.from(out)).toEqual([
+      0, 1, 2, 2, 3, 4, 5, 6, 6, 7, 8, 9, 10, 10, 11, 12, 13, 14, 14, 15, 16, 17, 18, 18, 19, 20, 21, 22, 22, 23,
+    ])
+  })
+
+  it('skips indices when source fps > project fps (60fps source on 30fps project, every other index)', () => {
+    const timestamps = Float64Array.from({ length: 60 }, (_, i) => i / 60)
+    const sourceFrames = Int32Array.from({ length: 30 }, (_, i) => i)
+    const out = mapSourceFramesToIndices(sourceFrames, 30, timestamps)
+
+    // project frame j targets (2j+1)/60 seconds exactly, which equals
+    // timestamp[2j+1] — so every export frame lands on the odd source index
+    // and every even source index (1 in 2 source frames) is skipped.
+    for (let i = 1; i < out.length; i++) {
+      expect(out[i]).toBeGreaterThanOrEqual(out[i - 1])
+    }
+    expect(Array.from(out)).toEqual(Array.from({ length: 30 }, (_, j) => 2 * j + 1))
+  })
+
+  it('returns -1 for targets before the first PTS', () => {
+    const timestamps = Float64Array.from([1, 2, 3])
+    const sourceFrames = Int32Array.from([0, 1])
+    const out = mapSourceFramesToIndices(sourceFrames, 30, timestamps)
+    // (0 + 0.5) / 30 = 0.0167s and (1 + 0.5) / 30 = 0.05s, both < first PTS (1s).
+    expect(Array.from(out)).toEqual([-1, -1])
+  })
+
+  it('clamps at the last PTS for targets past the end', () => {
+    const timestamps = Float64Array.from([0, 1, 2])
+    const sourceFrames = Int32Array.from([1000]) // way past the source's duration
+    const out = mapSourceFramesToIndices(sourceFrames, 30, timestamps)
+    expect(out[0]).toBe(2)
+  })
+
+  it('handles VFR timestamps (non-uniform spacing) monotonically', () => {
+    const timestamps = Float64Array.from([0, 0.1, 0.5, 0.55, 1.2])
+    const sourceFrames = Int32Array.from({ length: 40 }, (_, i) => i) // 40 frames @ 30fps ~= 1.33s
+    const out = mapSourceFramesToIndices(sourceFrames, 30, timestamps)
+    for (let i = 1; i < out.length; i++) {
+      expect(out[i]).toBeGreaterThanOrEqual(out[i - 1])
+    }
+    expect(out[out.length - 1]).toBeLessThanOrEqual(timestamps.length - 1)
+  })
+
+  it('returns all -1 when the timestamps index is empty', () => {
+    const out = mapSourceFramesToIndices(Int32Array.from([0, 1, 2]), 30, new Float64Array(0))
+    expect(Array.from(out)).toEqual([-1, -1, -1])
+  })
+
+  it('handles a trimmed clip starting mid-GOP (non-zero sourceStartFrame)', () => {
+    const timestamps = Float64Array.from({ length: 100 }, (_, i) => i / 30)
+    // Clip trimmed in at source frame 50, 10 frames long.
+    const sourceFrames = Int32Array.from({ length: 10 }, (_, i) => 50 + i)
+    const out = mapSourceFramesToIndices(sourceFrames, 30, timestamps)
+    expect(Array.from(out)).toEqual([50, 51, 52, 53, 54, 55, 56, 57, 58, 59])
+  })
+})

--- a/packages/export-server/src/__tests__/probe.test.ts
+++ b/packages/export-server/src/__tests__/probe.test.ts
@@ -1,0 +1,246 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * mediabunny is mocked at the module boundary so these tests exercise
+ * probe.ts's own logic (source selection, dispose-on-every-path, decode-order
+ * -> presentation-order sorting, CFR fallback synthesis, error wrapping)
+ * without touching a real file or the network. The one thing intentionally
+ * NOT unit-tested here is mediabunny's own demuxing correctness — that's
+ * mediabunny's test suite, not ours.
+ */
+
+type FakeTrack = {
+  computeDuration: () => Promise<number>
+  getDisplayWidth: () => Promise<number>
+  getDisplayHeight: () => Promise<number>
+  getCodedWidth: () => Promise<number>
+  getCodedHeight: () => Promise<number>
+  computePacketStats: () => Promise<{ packetCount: number; averagePacketRate: number; averageBitrate: number }>
+}
+
+function makeTrack(overrides: Partial<FakeTrack> = {}): FakeTrack {
+  return {
+    computeDuration: async () => 10,
+    getDisplayWidth: async () => 1920,
+    getDisplayHeight: async () => 1080,
+    getCodedWidth: async () => 1920,
+    getCodedHeight: async () => 1080,
+    computePacketStats: async () => ({ packetCount: 300, averagePacketRate: 30, averageBitrate: 8_000_000 }),
+    ...overrides,
+  }
+}
+
+interface MockState {
+  durationSec: number
+  videoTrack: FakeTrack | null
+  audioTrack: unknown | null
+  packetTimestamps: number[]
+  disposeCalls: number
+  lastSource: { kind: 'url' | 'file'; value: string } | null
+  computeDurationImpl: () => Promise<number>
+}
+
+let state: MockState
+
+function resetState() {
+  state = {
+    durationSec: 10,
+    videoTrack: makeTrack(),
+    audioTrack: null,
+    packetTimestamps: [],
+    disposeCalls: 0,
+    lastSource: null,
+    computeDurationImpl: async () => state.durationSec,
+  }
+}
+
+vi.mock('mediabunny', () => {
+  class FakeUrlSource {
+    kind = 'url' as const
+    constructor(public value: string) {}
+  }
+  class FakeFilePathSource {
+    kind = 'file' as const
+    constructor(public value: string) {}
+  }
+  class FakeInput {
+    constructor(opts: { source: { kind: 'url' | 'file'; value: string } }) {
+      state.lastSource = opts.source
+    }
+    computeDuration = async () => state.computeDurationImpl()
+    getPrimaryVideoTrack = async () => state.videoTrack
+    getPrimaryAudioTrack = async () => state.audioTrack
+    dispose = () => {
+      state.disposeCalls += 1
+    }
+  }
+  class FakeEncodedPacketSink {
+    constructor(_track: FakeTrack) {}
+    async *packets() {
+      for (const timestamp of state.packetTimestamps) yield { timestamp }
+    }
+  }
+  return {
+    ALL_FORMATS: [],
+    UrlSource: FakeUrlSource,
+    FilePathSource: FakeFilePathSource,
+    Input: FakeInput,
+    EncodedPacketSink: FakeEncodedPacketSink,
+  }
+})
+
+vi.mock('../errors', () => {
+  class ExportServerError extends Error {
+    code: string
+    constructor(code: string, message: string) {
+      super(message)
+      this.name = 'ExportServerError'
+      this.code = code
+    }
+  }
+  return { ExportServerError }
+})
+
+const { probeMedia, probeVideoSource, buildVideoFrameIndex, validateOutputFile } = await import('../probe')
+const { ExportServerError } = await import('../errors')
+
+beforeEach(() => {
+  resetState()
+})
+
+describe('probeMedia', () => {
+  it('reads duration and coded dimensions from the primary video track', async () => {
+    const info = await probeMedia('/tmp/clip.mp4')
+    expect(info).toEqual({ durationSec: 10, width: 1920, height: 1080 })
+  })
+
+  it('leaves width/height undefined when there is no video track (audio-only source)', async () => {
+    state.videoTrack = null
+    const info = await probeMedia('/tmp/track.mp3')
+    expect(info).toEqual({ durationSec: 10 })
+  })
+
+  it('opens a FilePathSource for a local path', async () => {
+    await probeMedia('/tmp/clip.mp4')
+    expect(state.lastSource).toEqual({ kind: 'file', value: '/tmp/clip.mp4' })
+  })
+
+  it('opens a UrlSource for an http(s) source', async () => {
+    await probeMedia('https://cdn.example.com/clip.mp4')
+    expect(state.lastSource).toEqual({ kind: 'url', value: 'https://cdn.example.com/clip.mp4' })
+  })
+
+  it('wraps failures in ExportServerError with code PROBE_FAILED, and still disposes', async () => {
+    state.computeDurationImpl = async () => {
+      throw new Error('boom')
+    }
+    await expect(probeMedia('/tmp/broken.mp4')).rejects.toMatchObject({
+      code: 'PROBE_FAILED',
+    })
+    await expect(probeMedia('/tmp/broken.mp4')).rejects.toBeInstanceOf(ExportServerError)
+    expect(state.disposeCalls).toBeGreaterThan(0)
+  })
+})
+
+describe('probeVideoSource', () => {
+  it('returns display dims (post-rotation/PAR), coded dims, and average frame rate', async () => {
+    const info = await probeVideoSource('/tmp/clip.mp4')
+    expect(info).toEqual({
+      durationSec: 10,
+      displayWidth: 1920,
+      displayHeight: 1080,
+      codedWidth: 1920,
+      codedHeight: 1080,
+      averageFrameRate: 30,
+    })
+  })
+
+  it('throws ExportServerError when the source has no video track', async () => {
+    state.videoTrack = null
+    await expect(probeVideoSource('/tmp/audio-only.mp4')).rejects.toMatchObject({ code: 'PROBE_FAILED' })
+  })
+})
+
+describe('buildVideoFrameIndex', () => {
+  it('sorts decode-order packet timestamps into ascending presentation order', async () => {
+    // A B-frame source: decode order != presentation order.
+    state.packetTimestamps = [0, 0.066, 0.033, 0.1, 0.066 + 0.033]
+    const index = await buildVideoFrameIndex('/tmp/bframes.mp4')
+    expect(index.exact).toBe(true)
+    expect(Array.from(index.timestamps)).toEqual([...state.packetTimestamps].sort((a, b) => a - b))
+  })
+
+  it('carries the video source info alongside the timestamp index', async () => {
+    state.packetTimestamps = [0, 1 / 30]
+    const index = await buildVideoFrameIndex('/tmp/clip.mp4')
+    expect(index.displayWidth).toBe(1920)
+    expect(index.displayHeight).toBe(1080)
+    expect(index.codedWidth).toBe(1920)
+    expect(index.codedHeight).toBe(1080)
+    expect(index.averageFrameRate).toBe(30)
+  })
+
+  it('synthesizes a CFR index from averagePacketRate/duration when no packets come back', async () => {
+    state.packetTimestamps = []
+    state.videoTrack = makeTrack({
+      computeDuration: async () => 2,
+      computePacketStats: async () => ({ packetCount: 0, averagePacketRate: 25, averageBitrate: 0 }),
+    })
+    const index = await buildVideoFrameIndex('/tmp/live-fragment.mp4')
+    expect(index.exact).toBe(false)
+    expect(index.timestamps.length).toBe(50) // 2s * 25fps
+    expect(index.timestamps[0]).toBe(0)
+    expect(index.timestamps[1]).toBeCloseTo(1 / 25)
+  })
+
+  it('returns an empty (never fabricated) index when rate and duration are both unusable', async () => {
+    state.packetTimestamps = []
+    state.videoTrack = makeTrack({
+      computeDuration: async () => 0,
+      computePacketStats: async () => ({ packetCount: 0, averagePacketRate: 0, averageBitrate: 0 }),
+    })
+    const index = await buildVideoFrameIndex('/tmp/empty.mp4')
+    expect(index.exact).toBe(false)
+    expect(index.timestamps.length).toBe(0)
+  })
+
+  it('throws ExportServerError when the source has no video track', async () => {
+    state.videoTrack = null
+    await expect(buildVideoFrameIndex('/tmp/audio-only.mp4')).rejects.toMatchObject({ code: 'PROBE_FAILED' })
+  })
+})
+
+describe('validateOutputFile', () => {
+  it('reports frame count, dims, and audio presence for a normal output', async () => {
+    state.audioTrack = {}
+    const result = await validateOutputFile('/tmp/out.mp4')
+    expect(result).toEqual({
+      durationSec: 10,
+      frameCount: 300,
+      width: 1920,
+      height: 1080,
+      hasAudioTrack: true,
+    })
+  })
+
+  it('reports hasAudioTrack: false when there is no primary audio track', async () => {
+    state.audioTrack = null
+    const result = await validateOutputFile('/tmp/out.mp4')
+    expect(result.hasAudioTrack).toBe(false)
+  })
+
+  it('never throws on a missing video track — returns null frameCount/zero dims for the caller to judge', async () => {
+    state.videoTrack = null
+    const result = await validateOutputFile('/tmp/audio-only-output.mp4')
+    expect(result.frameCount).toBeNull()
+    expect(result.width).toBe(0)
+    expect(result.height).toBe(0)
+  })
+
+  it('does throw ExportServerError when the file itself cannot be opened', async () => {
+    state.computeDurationImpl = async () => {
+      throw new Error('ENOENT')
+    }
+    await expect(validateOutputFile('/tmp/missing.mp4')).rejects.toMatchObject({ code: 'PROBE_FAILED' })
+  })
+})

--- a/packages/export-server/src/errors.ts
+++ b/packages/export-server/src/errors.ts
@@ -1,0 +1,66 @@
+/**
+ * One error type, one machine-readable code, for the whole package.
+ *
+ * Mirrors packages/cli/src/lib/errors.ts's CliError: every failure this
+ * package throws is an ExportServerError, never a bare Error, so a render
+ * server can switch on `.code` to pick an HTTP status instead of pattern
+ * matching a message string. Messages are still written for a human —
+ * whoever operates the server — naming the file/binary/clip at fault and
+ * the fix, in the tone of packages/cli/src/lib/browser.ts:34-37.
+ */
+
+/**
+ * - `FFMPEG_NOT_FOUND` / `FFMPEG_TOO_OLD` / `ENCODER_MISSING` — ffmpeg discovery
+ *   and capability checks (locate.ts) failed before any frame was touched.
+ * - `EMPTY_PROJECT` / `PLAN_INVALID` — the Scene scan (plan.ts) found nothing
+ *   to export, or found a shape the planner cannot turn into a plan.
+ * - `PROBE_FAILED` — mediabunny could not read a source's metadata/PTS index.
+ * - `SOURCE_UNSUPPORTED` — a clip `src` has no on-disk form (sources.ts), e.g.
+ *   a browser-only `blob:`/`data:` URL.
+ * - `FONT_LOAD_FAILED` — a requested font file/family could not be registered.
+ * - `DECODE_FAILED` — a per-clip ffmpeg decode process failed or produced
+ *   malformed rawvideo.
+ * - `ENCODE_FAILED` — the encoder process (video+audio mux) failed.
+ * - `OUTPUT_INVALID` — the finished file failed post-export validation.
+ * - `ABORTED` — the caller's AbortSignal fired; not a defect, but still
+ *   surfaced through this type so callers don't have to special-case it.
+ */
+export type ExportErrorCode =
+  | 'FFMPEG_NOT_FOUND'
+  | 'FFMPEG_TOO_OLD'
+  | 'ENCODER_MISSING'
+  | 'EMPTY_PROJECT'
+  | 'PLAN_INVALID'
+  | 'PROBE_FAILED'
+  | 'SOURCE_UNSUPPORTED'
+  | 'FONT_LOAD_FAILED'
+  | 'DECODE_FAILED'
+  | 'ENCODE_FAILED'
+  | 'OUTPUT_INVALID'
+  | 'ABORTED'
+
+export interface ExportServerErrorOptions {
+  /** Wrapped low-level error (a `child_process` failure, a parse error, ...). */
+  cause?: unknown
+  /** Tail of the child process's stderr, when the failure came from ffmpeg. */
+  stderr?: string
+}
+
+/**
+ * The one error type this package throws.
+ *
+ * `code` is the contract a render server codes against to map failures to
+ * HTTP statuses (e.g. `SOURCE_UNSUPPORTED` -> 422, `FFMPEG_NOT_FOUND` -> 500)
+ * without string-matching `message`, which is free to change wording.
+ */
+export class ExportServerError extends Error {
+  readonly code: ExportErrorCode
+  readonly stderr?: string
+
+  constructor(code: ExportErrorCode, message: string, options?: ExportServerErrorOptions) {
+    super(message, options?.cause !== undefined ? { cause: options.cause } : undefined)
+    this.name = 'ExportServerError'
+    this.code = code
+    this.stderr = options?.stderr
+  }
+}

--- a/packages/export-server/src/exportProject.ts
+++ b/packages/export-server/src/exportProject.ts
@@ -1,0 +1,411 @@
+/**
+ * exportProject — the frame loop that ties every leaf module together.
+ *
+ * Mirrors packages/core/src/export/ExportWorker.ts:303-361 (resolve -> decode
+ * -> composite -> encode, fully serial) but is split into two passes rather
+ * than one, because ffmpeg's decode primitive is a forward-only pipe, not
+ * mediabunny's random-access `canvasesAtTimestamps()` generator:
+ *
+ *   pass 1 (planExport, plan.ts)      — scan every frame's Scene once, up
+ *                                        front, to learn each clip's whole
+ *                                        source-frame timeline. ffmpeg's `-ss`
+ *                                        seek and argv need this before a
+ *                                        single process can be spawned.
+ *   pass 2 (this file's frame loop)   — resolve the Scene AGAIN, per frame,
+ *                                        for the actual composite (plan.ts's
+ *                                        output is deliberately too
+ *                                        compressed to composite from — it
+ *                                        keeps only what the decoder cursor
+ *                                        needs). Every clip decoder is opened
+ *                                        lazily on its first active frame and
+ *                                        closed on its last, so process count
+ *                                        tracks simultaneously-active clips
+ *                                        (i.e. transition overlaps), not the
+ *                                        project's total clip count.
+ *
+ * This module never reads `Project` for anything except handing it, opaque,
+ * to `resolveTimeline`/`planExport` — every decode/composite/encode decision
+ * downstream of those two calls is made from a `Scene` or a `plan.ts` type.
+ */
+
+import { rm, stat } from 'node:fs/promises'
+
+import { resolveTimeline } from '@elah/core'
+import type { Project } from '@elah/core'
+import { loadImage } from '@napi-rs/canvas'
+import type { Image } from '@napi-rs/canvas'
+
+import { ExportServerError } from './errors'
+import { planExport, mapSourceFramesToIndices } from './plan'
+import { buildVideoFrameIndex, validateOutputFile } from './probe'
+import { locateFfmpeg } from './ffmpeg/locate'
+import { ClipDecoder } from './ffmpeg/decoder'
+import { FrameEncoder } from './ffmpeg/encoder'
+import { buildAudioMix } from './ffmpeg/audio'
+import { FrameCompositor } from './render/frame'
+import { createFontRegistry } from './render/fonts'
+import { resolveSource } from './util/sources'
+
+import type {
+  DecodedFrame,
+  ExportProjectOptions,
+  ExportResult,
+  OutputValidation,
+  VideoFrameIndex,
+} from './types'
+
+/** Runtime, per-video-clip state the frame loop drives — the compiled form of a `VideoClipPlan`. */
+interface VideoRuntime {
+  clipId: string
+  source: string
+  firstFrame: number
+  lastFrame: number
+  /** One entry per export frame in `[firstFrame, lastFrame]` — mapSourceFramesToIndices's output. */
+  sourceIndices: Int32Array
+  decodeWidth: number
+  decodeHeight: number
+  displayWidth: number
+  displayHeight: number
+}
+
+function checkAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) {
+    throw new ExportServerError('ABORTED', 'Export aborted by caller signal.')
+  }
+}
+
+/**
+ * Nearest even integer, biasing up on a tie — H.264 4:2:0 chroma subsampling
+ * requires both encoder output dimensions to be even; odd dims make ffmpeg
+ * refuse `yuv420p` outright.
+ */
+function roundToEven(n: number): number {
+  const r = Math.max(2, Math.round(n))
+  return r % 2 === 0 ? r : r + 1
+}
+
+/**
+ * The pixel size ffmpeg is asked to decode a source AT — the true display
+ * size, unless `decodeMaxHeight` caps it, in which case both dimensions scale
+ * down together so the source's aspect ratio is preserved. This is purely a
+ * decode-bandwidth knob: `FrameCompositor` always places the resulting frame
+ * with its TRUE display size (see render/frame.ts's `drawMedia`), so capping
+ * this never moves anything on stage, it only trades sharpness for speed.
+ *
+ * Unlike the encoder's output dimensions, these do not need to be even: the
+ * buffer is an intermediate RGBA scratch surface, never hallucinatorally
+ * touched by yuv420p subsampling.
+ */
+function computeDecodeDims(
+  displayWidth: number,
+  displayHeight: number,
+  maxHeight: number | undefined,
+): { width: number; height: number } {
+  if (!maxHeight || displayHeight <= maxHeight) {
+    return { width: Math.max(1, Math.round(displayWidth)), height: Math.max(1, Math.round(displayHeight)) }
+  }
+  const scale = maxHeight / displayHeight
+  return { width: Math.max(1, Math.round(displayWidth * scale)), height: Math.max(1, Math.round(maxHeight)) }
+}
+
+/** Deletes a possibly-partial output file, tolerating it never having been created. */
+async function removePartialOutput(outPath: string): Promise<void> {
+  await rm(outPath, { force: true })
+}
+
+/**
+ * Renders a `Project` to an MP4 with system ffmpeg — no browser, no
+ * WebCodecs. Resolves the same `Scene`s the editor's preview and the browser
+ * exporter resolve, so output matches the editor; see this file's header for
+ * why the Scene is resolved twice (once compressed for planning, once in
+ * full for compositing).
+ */
+export async function exportProject(project: Project, options: ExportProjectOptions): Promise<ExportResult> {
+  const startedAt = performance.now()
+  const warnings: string[] = []
+  const signal = options.signal
+  const projectDir = options.projectDir ?? process.cwd()
+  const resolveSrc = options.resolveSource ?? ((src: string) => resolveSource(src, projectDir))
+
+  checkAborted(signal)
+  options.onProgress?.({ phase: 'planning', frame: 0, totalFrames: 0 })
+  const plan = planExport(project, { resolveSource: resolveSrc })
+
+  if (plan.totalFrames <= 0) {
+    throw new ExportServerError(
+      'EMPTY_PROJECT',
+      'Project has no clips on its timeline (getTotalFrames returned 0) — nothing to export.',
+    )
+  }
+
+  checkAborted(signal)
+
+  const audioSampleRate = options.audioSampleRate ?? 48_000
+  const audioChannels = options.audioChannels ?? 2
+  const audioMix = buildAudioMix(plan.audios, {
+    fps: plan.fps,
+    totalFrames: plan.totalFrames,
+    sampleRate: audioSampleRate,
+    channels: audioChannels,
+    masterVolume: options.masterVolume,
+  })
+
+  const videoEncoderName = options.videoEncoder ?? 'libx264'
+  const audioEncoderName = options.audioEncoder ?? 'aac'
+  const requireEncoders = audioMix ? [videoEncoderName, audioEncoderName] : [videoEncoderName]
+
+  const ffmpeg = await locateFfmpeg({ ffmpegPath: options.ffmpegPath, requireEncoders })
+
+  checkAborted(signal)
+  options.onProgress?.({ phase: 'probing', frame: 0, totalFrames: plan.totalFrames })
+
+  // One PTS index per unique source, not per clip: two clips trimmed from the
+  // same file describe the same presentation timeline, and probing is a
+  // metadata-only index read but still one file open per call — no reason to
+  // pay it twice.
+  const frameIndexBySource = new Map<string, VideoFrameIndex>()
+  for (const video of plan.videos) {
+    if (frameIndexBySource.has(video.source)) continue
+    checkAborted(signal)
+    const index = await buildVideoFrameIndex(video.source)
+    if (!index.exact) {
+      warnings.push(
+        `Source '${video.source}' had no usable packet timestamps; its presentation-timestamp ` +
+          'index was synthesized from the average frame rate, so frame accuracy for this source is approximate.',
+      )
+    }
+    frameIndexBySource.set(video.source, index)
+  }
+
+  checkAborted(signal)
+
+  // Keyed by the RAW Scene src — the same string `FrameCompositor` looks
+  // images up by (`ActiveImageClip.src`, never a resolved path) — so a
+  // relative/`file://` src that `resolveSource` rewrites still resolves to
+  // its loaded image at render time. `entry.source` (the resolved, openable
+  // path/URL) is used only for the one-time `loadImage` call.
+  const imagesBySource = new Map<string, Image>()
+  for (const entry of plan.imageSources) {
+    checkAborted(signal)
+    try {
+      imagesBySource.set(entry.src, await loadImage(entry.source))
+    } catch (err) {
+      warnings.push(`Failed to load image '${entry.source}': ${(err as Error).message} — it will be skipped.`)
+    }
+  }
+
+  const fontRegistry = createFontRegistry({ fonts: options.fonts, fallbackFamily: options.fallbackFontFamily })
+
+  // Output dims: width follows the stage aspect ratio from the (possibly
+  // overridden) output height. Both are rounded to even — see roundToEven.
+  const requestedHeight = options.outputHeight ?? plan.stage.height
+  const stageAspect = plan.stage.width / plan.stage.height
+  const outputHeight = roundToEven(requestedHeight)
+  const outputWidth = roundToEven(outputHeight * stageAspect)
+
+  const decodeMaxHeight = options.decodeMaxHeight
+  const videoRuntimes: VideoRuntime[] = plan.videos.map(video => {
+    const index = frameIndexBySource.get(video.source)
+    if (!index) {
+      // Cannot happen — every plan.videos[].source was probed above — but a
+      // thrown, named error beats an unchecked `!` if this invariant ever slips.
+      throw new ExportServerError('PLAN_INVALID', `No frame index built for source '${video.source}'`)
+    }
+    const sourceIndices = mapSourceFramesToIndices(video.sourceFrames, plan.fps, index.timestamps)
+    const { width: decodeWidth, height: decodeHeight } = computeDecodeDims(
+      index.displayWidth,
+      index.displayHeight,
+      decodeMaxHeight,
+    )
+    return {
+      clipId: video.clipId,
+      source: video.source,
+      firstFrame: video.firstFrame,
+      lastFrame: video.lastFrame,
+      sourceIndices,
+      decodeWidth,
+      decodeHeight,
+      displayWidth: index.displayWidth,
+      displayHeight: index.displayHeight,
+    }
+  })
+
+  checkAborted(signal)
+
+  const compositor = new FrameCompositor({ width: outputWidth, height: outputHeight, fonts: fontRegistry })
+  const openDecoders = new Map<string, ClipDecoder>()
+  const warnedShortClips = new Set<string>()
+
+  const encoder = FrameEncoder.start({
+    ffmpeg,
+    outPath: options.outPath,
+    width: outputWidth,
+    height: outputHeight,
+    fps: plan.fps,
+    videoEncoder: videoEncoderName,
+    videoBitrate: options.videoBitrate ?? 8_000_000,
+    audio: audioMix
+      ? { spec: audioMix, encoder: audioEncoderName, bitrate: options.audioBitrate ?? 128_000 }
+      : null,
+    extraOutputArgs: options.extraOutputArgs,
+    signal,
+  })
+
+  try {
+    options.onProgress?.({ phase: 'encoding', frame: 0, totalFrames: plan.totalFrames })
+
+    for (let frame = 0; frame < plan.totalFrames; frame++) {
+      checkAborted(signal)
+
+      // Open any clip decoder whose first active export frame is this one.
+      // Lazy, not up front: process count then tracks simultaneously-active
+      // clips (a transition's outgoing + incoming pair) rather than the
+      // project's total clip count.
+      for (const runtime of videoRuntimes) {
+        if (runtime.firstFrame === frame && !openDecoders.has(runtime.clipId)) {
+          const index = frameIndexBySource.get(runtime.source)
+          if (!index) continue
+          openDecoders.set(
+            runtime.clipId,
+            ClipDecoder.open({
+              ffmpeg,
+              source: runtime.source,
+              index,
+              sourceIndices: runtime.sourceIndices,
+              decodeWidth: runtime.decodeWidth,
+              decodeHeight: runtime.decodeHeight,
+              displayWidth: runtime.displayWidth,
+              displayHeight: runtime.displayHeight,
+              signal,
+            }),
+          )
+        }
+      }
+
+      const scene = resolveTimeline(frame, project)
+
+      // Advance every currently-open clip decoder exactly one step, mirroring
+      // ExportWorker.ts:322-327's per-frame `decoder.gen.next()` advance.
+      const videoFrames = new Map<string, DecodedFrame | null>()
+      for (const runtime of videoRuntimes) {
+        if (frame < runtime.firstFrame || frame > runtime.lastFrame) continue
+        const decoder = openDecoders.get(runtime.clipId)
+        if (!decoder) continue
+        const decoded = await decoder.next()
+        videoFrames.set(runtime.clipId, decoded)
+
+        // A null result is only a problem when a real frame was expected —
+        // `sourceIndices[step] === -1` (target before the source's first
+        // timestamp) is the same "nothing to draw" case ExportWorker gets
+        // from mediabunny's CanvasSink returning null, not a warning-worthy one.
+        const wantedReal = runtime.sourceIndices[frame - runtime.firstFrame] >= 0
+        if (decoded === null && wantedReal && !warnedShortClips.has(runtime.clipId)) {
+          warnedShortClips.add(runtime.clipId)
+          warnings.push(
+            `Clip '${runtime.clipId}': source '${runtime.source}' ran out of frames before the ` +
+              "clip's plan expected — the source is shorter than the clip claims. Remaining frames " +
+              'render nothing for this clip.',
+          )
+        }
+      }
+
+      const pixels = compositor.render(scene, { video: videoFrames, images: imagesBySource })
+      await encoder.writeFrame(pixels)
+
+      // Close any clip decoder whose last active export frame was this one —
+      // symmetric with the lazy open above.
+      for (const runtime of videoRuntimes) {
+        if (runtime.lastFrame === frame) {
+          const decoder = openDecoders.get(runtime.clipId)
+          if (decoder) {
+            await decoder.close()
+            openDecoders.delete(runtime.clipId)
+          }
+        }
+      }
+
+      options.onProgress?.({ phase: 'encoding', frame: frame + 1, totalFrames: plan.totalFrames })
+    }
+
+    checkAborted(signal)
+
+    // Defensive: every runtime's window should already have closed its
+    // decoder above. Closing anything left open keeps a bug in the
+    // open/close bookkeeping from leaking a process rather than corrupting output.
+    await Promise.all(Array.from(openDecoders.values()).map(decoder => decoder.close()))
+    openDecoders.clear()
+
+    options.onProgress?.({ phase: 'finalizing', frame: plan.totalFrames, totalFrames: plan.totalFrames })
+    await encoder.finish()
+  } catch (err) {
+    encoder.abort()
+    await Promise.all(Array.from(openDecoders.values()).map(decoder => decoder.close()))
+    await removePartialOutput(options.outPath)
+    throw err
+  } finally {
+    compositor.dispose()
+  }
+
+  for (const family of fontRegistry.missing) {
+    warnings.push(`Font family '${family}' could not be resolved to an installed font; a fallback was substituted.`)
+  }
+
+  let validation: OutputValidation | undefined
+  if (options.validateOutput ?? true) {
+    options.onProgress?.({ phase: 'validating', frame: plan.totalFrames, totalFrames: plan.totalFrames })
+    validation = await validateOutputFile(options.outPath)
+
+    // Only a missing video track is treated as a hard failure — everything
+    // else (duration/frame-count/dimension drift) is expected slop from
+    // container muxing and audio padding, so it becomes a warning instead of
+    // failing an otherwise-successful export (probe.ts's own contract).
+    if (validation.frameCount === null || validation.width === 0 || validation.height === 0) {
+      throw new ExportServerError(
+        'OUTPUT_INVALID',
+        `Exported file '${options.outPath}' has no readable video track after muxing.`,
+      )
+    }
+
+    const expectedDurationSec = plan.totalFrames / plan.fps
+    const durationToleranceSec = 1 / plan.fps + 0.05
+    if (Math.abs(validation.durationSec - expectedDurationSec) > durationToleranceSec) {
+      warnings.push(
+        `Output duration ${validation.durationSec.toFixed(3)}s differs from the expected ` +
+          `${expectedDurationSec.toFixed(3)}s by more than one frame.`,
+      )
+    }
+    if (validation.frameCount !== null && Math.abs(validation.frameCount - plan.totalFrames) > 1) {
+      warnings.push(
+        `Output frame count ${validation.frameCount} differs from the expected ${plan.totalFrames}.`,
+      )
+    }
+    if (validation.width !== outputWidth || validation.height !== outputHeight) {
+      warnings.push(
+        `Output dimensions ${validation.width}x${validation.height} differ from the requested ` +
+          `${outputWidth}x${outputHeight}.`,
+      )
+    }
+  }
+
+  const { size } = await stat(options.outPath)
+
+  return {
+    outPath: options.outPath,
+    sizeBytes: size,
+    totalFrames: plan.totalFrames,
+    fps: plan.fps,
+    width: outputWidth,
+    height: outputHeight,
+    durationSec: plan.totalFrames / plan.fps,
+    hasAudio: audioMix !== null,
+    validation,
+    warnings,
+    ffmpeg: {
+      path: ffmpeg.path,
+      versionLine: ffmpeg.versionLine,
+      videoEncoder: videoEncoderName,
+      audioEncoder: audioMix ? audioEncoderName : undefined,
+    },
+    elapsedMs: performance.now() - startedAt,
+  }
+}

--- a/packages/export-server/src/ffmpeg/__tests__/audio.test.ts
+++ b/packages/export-server/src/ffmpeg/__tests__/audio.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from 'vitest'
+import { buildAudioMix, buildSegmentChain } from '../audio'
+import type { AudioClipPlan } from '../../types'
+
+const FPS = 30
+const BASE_OPTIONS = { fps: FPS, totalFrames: 300, sampleRate: 48000, channels: 2 }
+
+function segment(overrides: Partial<AudioClipPlan> = {}): AudioClipPlan {
+  return {
+    clipId: 'clip-1',
+    source: '/media/a.mp3',
+    startFrame: 0,
+    frameCount: 300,
+    sourceStartFrame: 0,
+    volume: 1,
+    ...overrides,
+  }
+}
+
+describe('buildSegmentChain', () => {
+  it('emits atrim/adelay/volume derived purely from frames', () => {
+    const chain = buildSegmentChain(
+      segment({ startFrame: 15, sourceStartFrame: 30, frameCount: 60, volume: 0.5 }),
+      1,
+      BASE_OPTIONS,
+    )
+    expect(chain).toBe(
+      '[1:a]atrim=start=1:end=3,asetpts=PTS-STARTPTS,' +
+        'aformat=sample_fmts=fltp:sample_rates=48000:channel_layouts=stereo,' +
+        'volume=0.5,adelay=500:all=1[a0]',
+    )
+  })
+
+  it('derives the output label from inputIndex - 1', () => {
+    const chain = buildSegmentChain(segment(), 3, BASE_OPTIONS)
+    expect(chain.endsWith('[a2]')).toBe(true)
+    expect(chain.startsWith('[3:a]')).toBe(true)
+  })
+
+  it('uses a mono channel layout when channels === 1', () => {
+    const chain = buildSegmentChain(segment(), 1, { ...BASE_OPTIONS, channels: 1 })
+    expect(chain).toContain('channel_layouts=mono')
+  })
+
+  it('multiplies segment volume by masterVolume', () => {
+    const chain = buildSegmentChain(segment({ volume: 0.5 }), 1, { ...BASE_OPTIONS, masterVolume: 0.5 })
+    expect(chain).toContain('volume=0.25')
+  })
+
+  it('defaults masterVolume to 1 when omitted', () => {
+    const chain = buildSegmentChain(segment({ volume: 0.8 }), 1, BASE_OPTIONS)
+    expect(chain).toContain('volume=0.8')
+  })
+
+  it('every emitted duration equals frame count divided by fps exactly', () => {
+    for (const fps of [24, 25, 30, 50, 60]) {
+      const s = segment({ sourceStartFrame: 7, frameCount: 41 })
+      const chain = buildSegmentChain(s, 1, { ...BASE_OPTIONS, fps })
+      const expectedIn = 7 / fps
+      const expectedOut = (7 + 41) / fps
+      expect(chain).toContain(`atrim=start=${expectedIn}:end=${expectedOut}`)
+    }
+  })
+})
+
+describe('buildAudioMix', () => {
+  it('returns null for an empty segment list', () => {
+    expect(buildAudioMix([], BASE_OPTIONS)).toBeNull()
+  })
+
+  it('returns null when every segment is muted', () => {
+    expect(buildAudioMix([segment({ volume: 0 }), segment({ volume: 0, clipId: 'clip-2' })], BASE_OPTIONS)).toBeNull()
+  })
+
+  it('drops muted segments and keeps the rest', () => {
+    const muted = segment({ clipId: 'muted', volume: 0 })
+    const loud = segment({ clipId: 'loud', volume: 1 })
+    const spec = buildAudioMix([muted, loud], BASE_OPTIONS)
+    expect(spec).not.toBeNull()
+    expect(spec!.inputs).toHaveLength(1)
+    expect(spec!.inputs[0].clipId).toBe('loud')
+    // single surviving segment: no amix stage, straight into the pad tail
+    expect(spec!.filterComplex).not.toContain('amix')
+    expect(spec!.filterComplex).toContain('[a0]apad=')
+  })
+
+  it('single segment: skips amix and feeds a0 straight into the pad stage', () => {
+    const spec = buildAudioMix([segment()], BASE_OPTIONS)
+    expect(spec).not.toBeNull()
+    expect(spec!.filterComplex).toMatchInlineSnapshot(
+      `"[1:a]atrim=start=0:end=10,asetpts=PTS-STARTPTS,aformat=sample_fmts=fltp:sample_rates=48000:channel_layouts=stereo,volume=1,adelay=0:all=1[a0];[a0]apad=whole_dur=10,atrim=end=10,asetpts=N/SR/TB[aout]"`,
+    )
+  })
+
+  it('two segments: amix with normalize=0 and both adelay:all=1 present', () => {
+    const spec = buildAudioMix(
+      [
+        segment({ clipId: 'a', startFrame: 0 }),
+        segment({ clipId: 'b', startFrame: 30, frameCount: 270 }),
+      ],
+      BASE_OPTIONS,
+    )
+    expect(spec).not.toBeNull()
+    expect(spec!.filterComplex).toContain('normalize=0')
+    expect(spec!.filterComplex).toContain('amix=inputs=2')
+    expect((spec!.filterComplex.match(/:all=1/g) ?? []).length).toBe(2)
+    expect(spec!.filterComplex).toMatchInlineSnapshot(
+      `"[1:a]atrim=start=0:end=10,asetpts=PTS-STARTPTS,aformat=sample_fmts=fltp:sample_rates=48000:channel_layouts=stereo,volume=1,adelay=0:all=1[a0];[2:a]atrim=start=0:end=9,asetpts=PTS-STARTPTS,aformat=sample_fmts=fltp:sample_rates=48000:channel_layouts=stereo,volume=1,adelay=1000:all=1[a1];[a0][a1]amix=inputs=2:duration=longest:normalize=0[amix];[amix]apad=whole_dur=10,atrim=end=10,asetpts=N/SR/TB[aout]"`,
+    )
+  })
+
+  it('three segments: amix with normalize=0, all inputs mapped in order', () => {
+    const spec = buildAudioMix(
+      [
+        segment({ clipId: 'a' }),
+        segment({ clipId: 'b' }),
+        segment({ clipId: 'c' }),
+      ],
+      BASE_OPTIONS,
+    )
+    expect(spec).not.toBeNull()
+    expect(spec!.inputs.map(i => i.clipId)).toEqual(['a', 'b', 'c'])
+    expect(spec!.filterComplex).toContain('amix=inputs=3:duration=longest:normalize=0')
+    expect((spec!.filterComplex.match(/:all=1/g) ?? []).length).toBe(3)
+    expect(spec!.filterComplex.endsWith('[aout]')).toBe(true)
+  })
+
+  it('assigns ffmpeg input indices in appended order, starting at 1', () => {
+    const spec = buildAudioMix([segment({ clipId: 'a' }), segment({ clipId: 'b' })], BASE_OPTIONS)
+    expect(spec!.filterComplex).toContain('[1:a]')
+    expect(spec!.filterComplex).toContain('[2:a]')
+    expect(spec!.filterComplex).not.toContain('[3:a]')
+  })
+
+  it('pads/trims to totalFrames / fps exactly, not a rounded approximation', () => {
+    const spec = buildAudioMix([segment()], { ...BASE_OPTIONS, fps: 24, totalFrames: 100 })
+    const totalSec = 100 / 24
+    expect(spec!.filterComplex).toContain(`apad=whole_dur=${totalSec}`)
+    expect(spec!.filterComplex).toContain(`atrim=end=${totalSec}`)
+  })
+
+  it('carries sampleRate and channels through to the spec', () => {
+    const spec = buildAudioMix([segment()], { ...BASE_OPTIONS, sampleRate: 44100, channels: 1 })
+    expect(spec!.sampleRate).toBe(44100)
+    expect(spec!.channels).toBe(1)
+  })
+
+  it('applies masterVolume to every segment in a multi-segment mix', () => {
+    const spec = buildAudioMix(
+      [segment({ clipId: 'a', volume: 0.4 }), segment({ clipId: 'b', volume: 0.6 })],
+      { ...BASE_OPTIONS, masterVolume: 0.5 },
+    )
+    expect(spec!.filterComplex).toContain('volume=0.2')
+    expect(spec!.filterComplex).toContain('volume=0.3')
+  })
+})

--- a/packages/export-server/src/ffmpeg/__tests__/decoder.test.ts
+++ b/packages/export-server/src/ffmpeg/__tests__/decoder.test.ts
@@ -1,0 +1,333 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { EventEmitter } from 'node:events'
+import { PassThrough } from 'node:stream'
+
+vi.mock('node:child_process', () => ({ spawn: vi.fn() }))
+
+import { spawn } from 'node:child_process'
+import { buildDecoderArgs, ClipDecoder } from '../decoder'
+import type { ClipDecoderInit } from '../decoder'
+import type { FfmpegBinary, VideoFrameIndex } from '../../types'
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeFfmpeg(): FfmpegBinary {
+  return {
+    path: '/usr/bin/ffmpeg',
+    versionLine: 'ffmpeg version 6.0',
+    version: [6, 0],
+    encoders: new Set(['libx264']),
+  }
+}
+
+function makeIndex(timestamps: number[]): VideoFrameIndex {
+  return {
+    durationSec: timestamps.length > 0 ? timestamps[timestamps.length - 1] : 0,
+    displayWidth: 640,
+    displayHeight: 360,
+    codedWidth: 640,
+    codedHeight: 360,
+    averageFrameRate: 30,
+    timestamps: Float64Array.from(timestamps),
+    exact: true,
+  }
+}
+
+/** Single-pixel rgba frames (frameBytes = 4) keep test fixtures tiny and readable. */
+function makeInit(overrides: {
+  sourceIndices: number[]
+  timestamps?: number[]
+}): ClipDecoderInit {
+  return {
+    ffmpeg: makeFfmpeg(),
+    source: '/media/clip.mp4',
+    index: makeIndex(overrides.timestamps ?? [0, 1 / 30, 2 / 30, 3 / 30, 4 / 30]),
+    sourceIndices: Int32Array.from(overrides.sourceIndices),
+    decodeWidth: 1,
+    decodeHeight: 1,
+    displayWidth: 640,
+    displayHeight: 360,
+  }
+}
+
+function frame(marker: number): Buffer {
+  return Buffer.from([marker, marker, marker, marker])
+}
+
+/**
+ * Minimal fake `ChildProcess`: real `PassThrough` streams for stdout/stderr so
+ * `RawFrameReader` and `attachStderrTail` exercise their actual stream-event
+ * logic, plus a `kill()` that mimics ffmpeg closing its pipes and emitting
+ * 'close' once terminated — the two things `ClipDecoder` actually depends on.
+ */
+class FakeChild extends EventEmitter {
+  stdout = new PassThrough()
+  stderr = new PassThrough()
+  exitCode: number | null = null
+  signalCode: NodeJS.Signals | null = null
+
+  kill(signal?: NodeJS.Signals): boolean {
+    this.signalCode = signal ?? 'SIGTERM'
+    queueMicrotask(() => {
+      this.stdout.end()
+      this.emit('close', null, this.signalCode)
+    })
+    return true
+  }
+}
+
+function useFakeChild(): FakeChild {
+  const child = new FakeChild()
+  vi.mocked(spawn).mockReturnValue(child as unknown as ReturnType<typeof spawn>)
+  return child
+}
+
+beforeEach(() => {
+  vi.mocked(spawn).mockReset()
+})
+
+// ---------------------------------------------------------------------------
+// buildDecoderArgs — pure, no process involved
+// ---------------------------------------------------------------------------
+
+describe('buildDecoderArgs', () => {
+  it('omits -ss entirely when the clip starts at source index 0', () => {
+    const args = buildDecoderArgs(makeInit({ sourceIndices: [0, 1, 2] }))
+    expect(args).not.toContain('-ss')
+    expect(args).toEqual([
+      '-hide_banner', '-nostdin', '-loglevel', 'error',
+      '-i', '/media/clip.mp4',
+      '-map', '0:v:0', '-an', '-sn', '-dn',
+      '-vf', 'scale=1:1:flags=bicubic',
+      '-fps_mode', 'passthrough',
+      '-f', 'rawvideo', '-pix_fmt', 'rgba', 'pipe:1',
+    ])
+  })
+
+  it('omits -ss when every source index is -1 (degenerate: clip never visible)', () => {
+    const args = buildDecoderArgs(makeInit({ sourceIndices: [-1, -1, -1] }))
+    expect(args).not.toContain('-ss')
+  })
+
+  it('seeks to the PTS midpoint before the first wanted frame when trimmed mid-source', () => {
+    const timestamps = [0, 0.1, 0.2, 0.3, 0.4]
+    const args = buildDecoderArgs(makeInit({ sourceIndices: [2, 3], timestamps }))
+    const ssIndex = args.indexOf('-ss')
+    expect(ssIndex).toBeGreaterThanOrEqual(0)
+    const expectedMidpoint = ((timestamps[1] + timestamps[2]) / 2).toFixed(6)
+    expect(args[ssIndex + 1]).toBe(expectedMidpoint)
+    // -ss must precede -i, per the input-seek (accurate_seek) strategy.
+    expect(args.indexOf('-i')).toBeGreaterThan(ssIndex)
+  })
+
+  it('rebases the seek against a non-zero first timestamp', () => {
+    // mediabunny reports absolute track PTS; ffmpeg's input -ss is relative to
+    // the container's start_time. A source whose first packet sits at 10s (an
+    // MPEG-TS capture, an MP4 with an edit list, anything remuxed with
+    // -copyts) must not be seeked to the absolute value, or every frame of the
+    // clip is off by the same constant with no error raised.
+    const offset = 10
+    const relative = [0, 0.1, 0.2, 0.3]
+    const absolute = relative.map(t => t + offset)
+
+    const shifted = buildDecoderArgs(makeInit({ sourceIndices: [2, 3], timestamps: absolute }))
+    const atOrigin = buildDecoderArgs(makeInit({ sourceIndices: [2, 3], timestamps: relative }))
+
+    const ssIndex = shifted.indexOf('-ss')
+    expect(ssIndex).toBeGreaterThanOrEqual(0)
+    expect(shifted[ssIndex + 1]).toBe(((relative[1] + relative[2]) / 2).toFixed(6))
+    // Same content, same seek — the offset must cancel out entirely.
+    expect(shifted).toEqual(atOrigin)
+  })
+
+  it('clamps to 0 when the track starts at a negative timestamp', () => {
+    // A negative first timestamp means the track's timing is offset; that is
+    // already folded into the container's start_time, and ffmpeg has no
+    // negative input seek.
+    const args = buildDecoderArgs(makeInit({ sourceIndices: [2, 3], timestamps: [-0.2, -0.1, 0, 0.1] }))
+    const ssIndex = args.indexOf('-ss')
+    if (ssIndex >= 0) expect(Number(args[ssIndex + 1])).toBeGreaterThanOrEqual(0)
+  })
+
+  it('skips leading -1 entries to find k0 for the seek calculation', () => {
+    const timestamps = [0, 0.1, 0.2]
+    const withLeadingGap = buildDecoderArgs(makeInit({ sourceIndices: [-1, -1, 1], timestamps }))
+    const withoutGap = buildDecoderArgs(makeInit({ sourceIndices: [1], timestamps }))
+    // k0 is 1 either way, so the seek time (and the whole argv) must match.
+    expect(withLeadingGap).toEqual(withoutGap)
+  })
+
+  it('scales to decodeWidth/decodeHeight, independent of display dimensions', () => {
+    const init = makeInit({ sourceIndices: [0] })
+    init.decodeWidth = 960
+    init.decodeHeight = 540
+    const args = buildDecoderArgs(init)
+    expect(args).toContain('scale=960:540:flags=bicubic')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// ClipDecoder — the dup/drop cursor, driven against a fake process
+// ---------------------------------------------------------------------------
+
+describe('ClipDecoder', () => {
+  it('reads one frame per export frame with no dup/drop on a 1:1 plan', async () => {
+    const child = useFakeChild()
+    const decoder = ClipDecoder.open(makeInit({ sourceIndices: [0, 1, 2] }))
+
+    child.stdout.write(frame(10))
+    child.stdout.write(frame(11))
+    child.stdout.write(frame(12))
+    child.stdout.end()
+
+    expect(Array.from((await decoder.next())!.data)).toEqual([10, 10, 10, 10])
+    expect(Array.from((await decoder.next())!.data)).toEqual([11, 11, 11, 11])
+    expect(Array.from((await decoder.next())!.data)).toEqual([12, 12, 12, 12])
+
+    await decoder.close()
+  })
+
+  it('returns null without reading when the target is before the clip\'s first frame', async () => {
+    const child = useFakeChild()
+    const decoder = ClipDecoder.open(makeInit({ sourceIndices: [-1, -1, 0] }))
+
+    expect(await decoder.next()).toBeNull()
+    expect(await decoder.next()).toBeNull()
+
+    child.stdout.write(frame(5))
+    child.stdout.end()
+    expect(Array.from((await decoder.next())!.data)).toEqual([5, 5, 5, 5])
+
+    await decoder.close()
+  })
+
+  it('re-returns the held frame on a duplicate index (source slower than project rate)', async () => {
+    const child = useFakeChild()
+    const decoder = ClipDecoder.open(makeInit({ sourceIndices: [0, 0, 1] }))
+
+    child.stdout.write(frame(9))
+    child.stdout.end()
+
+    const f0 = await decoder.next()
+    const f1 = await decoder.next()
+    expect(Array.from(f0!.data)).toEqual([9, 9, 9, 9])
+    expect(f1!.data).toBe(f0!.data)
+
+    // The plan wants source index 1 next, but the fake source only ever
+    // produced index 0 — the clip is shorter than planned.
+    expect(await decoder.next()).toBeNull()
+
+    await decoder.close()
+  })
+
+  it('drops intermediate frames when want jumps ahead of cursor (source faster than project rate)', async () => {
+    const child = useFakeChild()
+    const decoder = ClipDecoder.open(makeInit({ sourceIndices: [0, 2] }))
+
+    child.stdout.write(frame(1))
+    child.stdout.write(frame(2))
+    child.stdout.write(frame(3))
+    child.stdout.end()
+
+    expect(Array.from((await decoder.next())!.data)).toEqual([1, 1, 1, 1])
+    // Source index 1 (marker 2) is pulled and discarded on the way to index 2.
+    expect(Array.from((await decoder.next())!.data)).toEqual([3, 3, 3, 3])
+
+    await decoder.close()
+  })
+
+  it('returns null once the source runs out before the plan is satisfied', async () => {
+    const child = useFakeChild()
+    const decoder = ClipDecoder.open(makeInit({ sourceIndices: [0, 1, 2] }))
+
+    child.stdout.write(frame(1))
+    child.stdout.end()
+
+    expect(Array.from((await decoder.next())!.data)).toEqual([1, 1, 1, 1])
+    expect(await decoder.next()).toBeNull()
+    // Once exhausted, stays null rather than trying to read a dead stream again.
+    expect(await decoder.next()).toBeNull()
+
+    await decoder.close()
+  })
+
+  it('throws rather than seeking backwards on a non-decreasing violation', async () => {
+    const child = useFakeChild()
+    const decoder = ClipDecoder.open(makeInit({ sourceIndices: [2, 0] }))
+
+    child.stdout.write(frame(7))
+
+    expect(Array.from((await decoder.next())!.data)).toEqual([7, 7, 7, 7])
+    await expect(decoder.next()).rejects.toMatchObject({ code: 'DECODE_FAILED' })
+
+    await decoder.close()
+  })
+
+  it('throws when next() is called past the end of its plan', async () => {
+    const child = useFakeChild()
+    const decoder = ClipDecoder.open(makeInit({ sourceIndices: [0] }))
+
+    child.stdout.write(frame(1))
+    child.stdout.end()
+    expect(Array.from((await decoder.next())!.data)).toEqual([1, 1, 1, 1])
+    // The guard fires before touching the (now-idle) reader, so this must
+    // reject rather than hang waiting on a frame nobody planned for.
+    await expect(decoder.next()).rejects.toThrow(/past the end of its plan/)
+
+    await decoder.close()
+  })
+
+  it('rejects a pending next() with DECODE_FAILED, including the stderr tail, on abnormal exit', async () => {
+    const child = useFakeChild()
+    const decoder = ClipDecoder.open(makeInit({ sourceIndices: [0, 1] }))
+
+    child.stderr.write('some ffmpeg diagnostic\n')
+    child.stdout.write(frame(1))
+    // Let attachStderrTail's 'data' listener and the reader both settle
+    // before the first next() resolves.
+    await new Promise(resolve => setImmediate(resolve))
+    expect(Array.from((await decoder.next())!.data)).toEqual([1, 1, 1, 1])
+
+    const pending = decoder.next()
+    child.emit('close', 1, null)
+
+    await expect(pending).rejects.toMatchObject({ code: 'DECODE_FAILED' })
+    await expect(pending.catch((err: Error) => err.message)).resolves.toContain('some ffmpeg diagnostic')
+
+    await decoder.close()
+  })
+
+  it('does not treat close()\'s own SIGKILL as a decode failure', async () => {
+    const child = useFakeChild()
+    const decoder = ClipDecoder.open(makeInit({ sourceIndices: [0, 1, 2] }))
+
+    child.stdout.write(frame(1))
+    expect(Array.from((await decoder.next())!.data)).toEqual([1, 1, 1, 1])
+
+    // close() kills mid-decode; the pending state must not surface as a
+    // DECODE_FAILED rejection anywhere (no unhandled rejection either).
+    await decoder.close()
+  })
+
+  it('close() is idempotent and only kills the process once', async () => {
+    const child = useFakeChild()
+    const killSpy = vi.spyOn(child, 'kill')
+    const decoder = ClipDecoder.open(makeInit({ sourceIndices: [0] }))
+
+    await Promise.all([decoder.close(), decoder.close()])
+    expect(killSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('spawns with the exact argv built by buildDecoderArgs, exposed on .args', () => {
+    const child = useFakeChild()
+    const init = makeInit({ sourceIndices: [0, 1] })
+    const decoder = ClipDecoder.open(init)
+
+    expect(decoder.args).toEqual(buildDecoderArgs(init))
+    expect(spawn).toHaveBeenCalledWith(init.ffmpeg.path, decoder.args, { stdio: ['ignore', 'pipe', 'pipe'] })
+    void child
+    void decoder.close()
+  })
+})

--- a/packages/export-server/src/ffmpeg/__tests__/encoder.test.ts
+++ b/packages/export-server/src/ffmpeg/__tests__/encoder.test.ts
@@ -1,0 +1,310 @@
+import { EventEmitter } from 'node:events'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import type { FfmpegBinary, AudioMixSpec } from '../../types'
+import type { EncoderInit } from '../encoder'
+
+// ---------------------------------------------------------------------------
+// child_process is mocked so these tests exercise the *real* FrameEncoder
+// class (backpressure, exit races, error construction) against a fake
+// process, instead of spawning actual ffmpeg. '../errors' is mocked too so
+// this suite does not depend on that module's concrete shape, only the
+// `new ExportServerError(code, message)` contract encoder.ts is written
+// against.
+// ---------------------------------------------------------------------------
+
+const spawnMock = vi.fn()
+vi.mock('node:child_process', () => ({ spawn: (...args: unknown[]) => spawnMock(...args) }))
+
+class FakeExportServerError extends Error {
+  readonly code: string
+  constructor(code: string, message: string) {
+    super(message)
+    this.name = 'ExportServerError'
+    this.code = code
+  }
+}
+vi.mock('../errors', () => ({ ExportServerError: FakeExportServerError }))
+
+const { FrameEncoder, buildEncoderArgs } = await import('../encoder')
+
+const FFMPEG: FfmpegBinary = {
+  path: '/usr/bin/ffmpeg',
+  versionLine: 'ffmpeg version 6.1.1',
+  version: [6, 1],
+  encoders: new Set(['libx264', 'aac']),
+}
+
+function baseInit(overrides: Partial<EncoderInit> = {}): EncoderInit {
+  return {
+    ffmpeg: FFMPEG,
+    outPath: '/tmp/out.mp4',
+    width: 1920,
+    height: 1080,
+    fps: 30,
+    videoEncoder: 'libx264',
+    videoBitrate: 8_000_000,
+    audio: null,
+    ...overrides,
+  }
+}
+
+function audioSpec(inputs: number): AudioMixSpec {
+  return {
+    inputs: Array.from({ length: inputs }, (_, i) => ({ source: `/media/a${i}.mp3`, clipId: `clip-${i}` })),
+    filterComplex: '[1:a]atrim=start=0:end=1[a0];[a0]apad=whole_dur=1,atrim=end=1,asetpts=N/SR/TB[aout]',
+    outLabel: '[aout]',
+    sampleRate: 48000,
+    channels: 2,
+  }
+}
+
+describe('buildEncoderArgs', () => {
+  it('video-only: -an, no filter_complex, rawvideo input dimensions match', () => {
+    const args = buildEncoderArgs(baseInit())
+    expect(args).toEqual([
+      '-hide_banner', '-nostdin', '-loglevel', 'error', '-y',
+      '-f', 'rawvideo', '-pix_fmt', 'rgba', '-s', '1920x1080', '-r', '30', '-i', 'pipe:0',
+      '-map', '0:v:0',
+      '-vf', 'scale=in_range=full:out_range=tv:out_color_matrix=bt709',
+      '-c:v', 'libx264', '-b:v', '8000000', '-pix_fmt', 'yuv420p',
+      '-colorspace', 'bt709', '-color_primaries', 'bt709', '-color_trc', 'bt709', '-color_range', 'tv',
+      '-an',
+      '-movflags', '+faststart',
+      '-f', 'mp4', '/tmp/out.mp4',
+    ])
+  })
+
+  it('video + single audio: one -i after the rawvideo pipe, filter_complex + map + audio codec args', () => {
+    const args = buildEncoderArgs(
+      baseInit({ audio: { spec: audioSpec(1), encoder: 'aac', bitrate: 128_000 } }),
+    )
+    expect(args).toEqual([
+      '-hide_banner', '-nostdin', '-loglevel', 'error', '-y',
+      '-f', 'rawvideo', '-pix_fmt', 'rgba', '-s', '1920x1080', '-r', '30', '-i', 'pipe:0',
+      '-i', '/media/a0.mp3',
+      '-filter_complex', '[1:a]atrim=start=0:end=1[a0];[a0]apad=whole_dur=1,atrim=end=1,asetpts=N/SR/TB[aout]',
+      '-map', '[aout]',
+      '-map', '0:v:0',
+      '-vf', 'scale=in_range=full:out_range=tv:out_color_matrix=bt709',
+      '-c:v', 'libx264', '-b:v', '8000000', '-pix_fmt', 'yuv420p',
+      '-colorspace', 'bt709', '-color_primaries', 'bt709', '-color_trc', 'bt709', '-color_range', 'tv',
+      '-c:a', 'aac', '-b:a', '128000', '-ar', '48000', '-ac', '2',
+      '-movflags', '+faststart',
+      '-f', 'mp4', '/tmp/out.mp4',
+    ])
+  })
+
+  it('video + 3 audio inputs: three -i entries appended in order at indices 1..3', () => {
+    const args = buildEncoderArgs(
+      baseInit({ audio: { spec: audioSpec(3), encoder: 'aac', bitrate: 128_000 } }),
+    )
+    // rawvideo pipe is always input 0
+    expect(args.slice(args.indexOf('-i'), args.indexOf('-i') + 2)).toEqual(['-i', 'pipe:0'])
+    const audioInputs = []
+    for (let i = 0; i < args.length; i++) {
+      if (args[i] === '-i' && args[i + 1] !== 'pipe:0') audioInputs.push(args[i + 1])
+    }
+    expect(audioInputs).toEqual(['/media/a0.mp3', '/media/a1.mp3', '/media/a2.mp3'])
+    expect(args).toContain('-filter_complex')
+    expect(args[args.indexOf('-map') + 1]).toBe('[aout]')
+  })
+
+  it('places extraOutputArgs immediately before the trailing -f mp4 <outPath>', () => {
+    const args = buildEncoderArgs(baseInit({ extraOutputArgs: ['-preset', 'veryfast'] }))
+    expect(args.slice(-5)).toEqual(['-preset', 'veryfast', '-f', 'mp4', '/tmp/out.mp4'])
+  })
+
+  it('uses -b:v (never -crf) so videoBitrate carries the same meaning as ExportOptions', () => {
+    const args = buildEncoderArgs(baseInit({ videoBitrate: 4_000_000 }))
+    expect(args[args.indexOf('-b:v') + 1]).toBe('4000000')
+    expect(args).not.toContain('-crf')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// FrameEncoder — process plumbing, driven through a fake child process
+// ---------------------------------------------------------------------------
+
+class FakeStdin extends EventEmitter {
+  written: Buffer[] = []
+  ended = false
+  full = false
+
+  write(chunk: Buffer): boolean {
+    this.written.push(chunk)
+    return !this.full
+  }
+
+  end(): void {
+    this.ended = true
+  }
+}
+
+class FakeChildProcess extends EventEmitter {
+  stdin = new FakeStdin()
+  stdout = new EventEmitter()
+  stderr = new EventEmitter()
+  kill = vi.fn()
+}
+
+function makeFakeChild(): FakeChildProcess {
+  const proc = new FakeChildProcess()
+  spawnMock.mockReturnValue(proc)
+  return proc
+}
+
+beforeEach(() => {
+  spawnMock.mockReset()
+})
+
+describe('FrameEncoder.args', () => {
+  it('matches buildEncoderArgs for the same init', () => {
+    makeFakeChild()
+    const init = baseInit()
+    const encoder = FrameEncoder.start(init)
+    expect(encoder.args).toEqual(buildEncoderArgs(init))
+  })
+})
+
+describe('FrameEncoder.writeFrame backpressure', () => {
+  it('resolves immediately when stdin.write() returns true', async () => {
+    const proc = makeFakeChild()
+    proc.stdin.full = false
+    const encoder = FrameEncoder.start(baseInit())
+
+    await expect(encoder.writeFrame(new Uint8ClampedArray([1, 2, 3, 4]))).resolves.toBeUndefined()
+    expect(proc.stdin.written).toHaveLength(1)
+    expect(Array.from(proc.stdin.written[0])).toEqual([1, 2, 3, 4])
+  })
+
+  it('does not resolve before drain when stdin.write() returns false', async () => {
+    const proc = makeFakeChild()
+    proc.stdin.full = true
+    const encoder = FrameEncoder.start(baseInit())
+
+    let resolved = false
+    const pending = encoder.writeFrame(new Uint8ClampedArray(8)).then(() => {
+      resolved = true
+    })
+
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(resolved).toBe(false)
+
+    proc.stdin.emit('drain')
+    await pending
+    expect(resolved).toBe(true)
+  })
+
+  it('a second writeFrame behind a full pipe waits for its own drain, not the first', async () => {
+    const proc = makeFakeChild()
+    proc.stdin.full = true
+    const encoder = FrameEncoder.start(baseInit())
+
+    const first = encoder.writeFrame(new Uint8ClampedArray(8))
+    proc.stdin.emit('drain')
+    await first
+
+    proc.stdin.full = true
+    let secondResolved = false
+    const second = encoder.writeFrame(new Uint8ClampedArray(8)).then(() => {
+      secondResolved = true
+    })
+
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(secondResolved).toBe(false)
+
+    proc.stdin.emit('drain')
+    await second
+    expect(secondResolved).toBe(true)
+  })
+
+  it('rejects instead of hanging forever if ffmpeg exits while a write is awaiting drain', async () => {
+    const proc = makeFakeChild()
+    proc.stdin.full = true
+    const encoder = FrameEncoder.start(baseInit())
+
+    const pending = encoder.writeFrame(new Uint8ClampedArray(8))
+    proc.stderr.emit('data', Buffer.from('boom: unsupported codec\n'))
+    proc.emit('close', 1, null)
+
+    await expect(pending).rejects.toMatchObject({ code: 'ENCODE_FAILED' })
+    await expect(pending).rejects.toThrow(/boom: unsupported codec/)
+  })
+
+  it('a subsequent writeFrame after failure rethrows the same captured error without touching stdin again', async () => {
+    const proc = makeFakeChild()
+    proc.stdin.full = true
+    const encoder = FrameEncoder.start(baseInit())
+
+    const first = encoder.writeFrame(new Uint8ClampedArray(8))
+    proc.emit('close', 1, null)
+    await expect(first).rejects.toMatchObject({ code: 'ENCODE_FAILED' })
+
+    const writesBefore = proc.stdin.written.length
+    await expect(encoder.writeFrame(new Uint8ClampedArray(8))).rejects.toMatchObject({ code: 'ENCODE_FAILED' })
+    expect(proc.stdin.written.length).toBe(writesBefore)
+  })
+})
+
+describe('FrameEncoder.finish', () => {
+  it('ends stdin and resolves when ffmpeg exits 0', async () => {
+    const proc = makeFakeChild()
+    const encoder = FrameEncoder.start(baseInit())
+
+    const pending = encoder.finish()
+    proc.emit('close', 0, null)
+
+    await expect(pending).resolves.toBeUndefined()
+    expect(proc.stdin.ended).toBe(true)
+  })
+
+  it('rejects with an ENCODE_FAILED error carrying argv and the stderr tail on non-zero exit', async () => {
+    const proc = makeFakeChild()
+    const encoder = FrameEncoder.start(baseInit())
+
+    const pending = encoder.finish()
+    proc.stderr.emit('data', Buffer.from('some ffmpeg error\n'))
+    proc.emit('close', 1, null)
+
+    await expect(pending).rejects.toMatchObject({ code: 'ENCODE_FAILED' })
+    await expect(pending).rejects.toThrow(/some ffmpeg error/)
+    await expect(pending).rejects.toThrow(/ffmpeg exited with code 1/)
+    await expect(pending).rejects.toThrow(/-hide_banner/) // argv included
+  })
+})
+
+describe('FrameEncoder.abort', () => {
+  it('SIGKILLs the process', () => {
+    const proc = makeFakeChild()
+    const encoder = FrameEncoder.start(baseInit())
+
+    encoder.abort()
+
+    expect(proc.kill).toHaveBeenCalledWith('SIGKILL')
+  })
+
+  it('is safe to call after finish() resolves', async () => {
+    const proc = makeFakeChild()
+    const encoder = FrameEncoder.start(baseInit())
+
+    const pending = encoder.finish()
+    proc.emit('close', 0, null)
+    await pending
+
+    expect(() => encoder.abort()).not.toThrow()
+    expect(proc.kill).toHaveBeenCalledWith('SIGKILL')
+  })
+
+  it('fires automatically when the provided AbortSignal aborts', () => {
+    const proc = makeFakeChild()
+    const controller = new AbortController()
+    FrameEncoder.start(baseInit({ signal: controller.signal }))
+
+    controller.abort()
+
+    expect(proc.kill).toHaveBeenCalledWith('SIGKILL')
+  })
+})

--- a/packages/export-server/src/ffmpeg/__tests__/locate.test.ts
+++ b/packages/export-server/src/ffmpeg/__tests__/locate.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest'
+
+import { MIN_FFMPEG_VERSION, parseEncoders, parseFfmpegVersion } from '../locate'
+
+// Real `ffmpeg -hide_banner -encoders` output (macOS Homebrew build, ffmpeg
+// 8.1.2), trimmed to a representative excerpt: the header/legend lines that
+// must NOT be picked up as encoders, plus a handful of real encoder lines
+// covering every flag-character shape (`.` vs a letter) these functions need
+// to tolerate.
+const ENCODERS_EXCERPT = `Encoders:
+ V..... = Video
+ A..... = Audio
+ S..... = Subtitle
+ .F.... = Frame-level multithreading
+ ..S... = Slice-level multithreading
+ ...X.. = Codec is experimental
+ ....B. = Supports draw_horiz_band
+ .....D = Supports direct rendering method 1
+ ------
+ V....D a64multi             Multicolor charset for Commodore 64 (codec a64_multi)
+ V..X.D avui                 Avid Meridien Uncompressed
+ VFS..D dnxhd                VC3/DNxHD
+ V....D libx264              libx264 H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10 (codec h264)
+ V....D libx264rgb           libx264 H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10 RGB (codec h264)
+ V....D h264_videotoolbox    VideoToolbox H.264 Encoder (codec h264)
+ V..... libsvtav1            SVT-AV1(Scalable Video Technology for AV1) encoder (codec av1)
+ A....D aac                  AAC (Advanced Audio Coding)
+ A..... aac_at               aac (AudioToolbox) (codec aac)
+ A....D mp3                  libmp3lame variant unused here, just a name shape
+`
+
+describe('parseFfmpegVersion', () => {
+  it('parses a standard numbered release', () => {
+    const stdout = 'ffmpeg version 8.1.2 Copyright (c) 2000-2026 the FFmpeg developers\nbuilt with Apple clang...'
+    expect(parseFfmpegVersion(stdout)).toEqual([8, 1])
+  })
+
+  it('parses an older release below the version floor', () => {
+    const stdout = 'ffmpeg version 4.4.1-0ubuntu0.22.04.1 Copyright (c) 2000-2021 the FFmpeg developers'
+    expect(parseFfmpegVersion(stdout)).toEqual([4, 4])
+  })
+
+  it('tolerates a leading "n" from static-build version strings', () => {
+    const stdout = 'ffmpeg version n6.1.1 Copyright (c) 2000-2023 the FFmpeg developers'
+    expect(parseFfmpegVersion(stdout)).toEqual([6, 1])
+  })
+
+  it('exactly matches the version floor', () => {
+    const stdout = 'ffmpeg version 5.1 Copyright (c) 2000-2022 the FFmpeg developers'
+    expect(parseFfmpegVersion(stdout)).toEqual(MIN_FFMPEG_VERSION as [number, number])
+  })
+
+  it('returns null for a git/nightly build with no numeric version', () => {
+    const stdout = 'ffmpeg version N-118234-g0abcdef1234 Copyright (c) 2000-2026 the FFmpeg developers'
+    expect(parseFfmpegVersion(stdout)).toBeNull()
+  })
+
+  it('returns null for empty stdout', () => {
+    expect(parseFfmpegVersion('')).toBeNull()
+  })
+
+  it('only inspects the first line', () => {
+    const stdout = 'ffmpeg version N-118234-g0abcdef Copyright...\nversion 9.9 hidden further down should not count'
+    expect(parseFfmpegVersion(stdout)).toBeNull()
+  })
+})
+
+describe('parseEncoders', () => {
+  it('extracts real encoder names and ignores the header/legend', () => {
+    const encoders = parseEncoders(ENCODERS_EXCERPT)
+    expect(encoders.has('Encoders:')).toBe(false)
+    expect(encoders.has('Video')).toBe(false)
+    expect(encoders.has('------')).toBe(false)
+  })
+
+  it('picks up H.264-capable encoders by name', () => {
+    const encoders = parseEncoders(ENCODERS_EXCERPT)
+    expect(encoders.has('libx264')).toBe(true)
+    expect(encoders.has('libx264rgb')).toBe(true)
+    expect(encoders.has('h264_videotoolbox')).toBe(true)
+  })
+
+  it('picks up an audio encoder', () => {
+    const encoders = parseEncoders(ENCODERS_EXCERPT)
+    expect(encoders.has('aac')).toBe(true)
+    expect(encoders.has('aac_at')).toBe(true)
+  })
+
+  it('does not pick up an encoder ffmpeg does not report', () => {
+    const encoders = parseEncoders(ENCODERS_EXCERPT)
+    expect(encoders.has('h264_nvenc')).toBe(false)
+  })
+
+  it('returns an empty set for empty stdout', () => {
+    expect(parseEncoders('').size).toBe(0)
+  })
+
+  it('handles a flag column with an experimental marker', () => {
+    const encoders = parseEncoders(ENCODERS_EXCERPT)
+    expect(encoders.has('avui')).toBe(true)
+  })
+})

--- a/packages/export-server/src/ffmpeg/__tests__/rawFrames.test.ts
+++ b/packages/export-server/src/ffmpeg/__tests__/rawFrames.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it } from 'vitest'
+import { Readable } from 'node:stream'
+import { RawFrameReader } from '../rawFrames'
+
+/**
+ * `objectMode: true` keeps every pushed Buffer as a discrete chunk that
+ * `stream.read()` returns one at a time, in order — Node never merges or
+ * splits them for us. That gives these tests exact control over how bytes
+ * arrive off the "pipe", which is the whole point of exercising the
+ * reader's own accumulation/slicing logic rather than Node's.
+ */
+function streamOf(chunks: Buffer[]): Readable {
+  return Readable.from(chunks, { objectMode: true })
+}
+
+function bytes(...values: number[]): Buffer {
+  return Buffer.from(values)
+}
+
+function toArray(frame: Uint8ClampedArray | null): number[] | null {
+  return frame ? Array.from(frame) : null
+}
+
+describe('RawFrameReader', () => {
+  it('emits one frame per chunk when chunk boundaries align exactly with frame boundaries', async () => {
+    const stream = streamOf([bytes(0, 1, 2, 3), bytes(4, 5, 6, 7), bytes(8, 9, 10, 11)])
+    const reader = new RawFrameReader(stream, 4)
+
+    expect(toArray(await reader.read())).toEqual([0, 1, 2, 3])
+    expect(toArray(await reader.read())).toEqual([4, 5, 6, 7])
+    expect(toArray(await reader.read())).toEqual([8, 9, 10, 11])
+    expect(await reader.read()).toBeNull()
+    expect(reader.trailingBytes).toBe(0)
+  })
+
+  it('splits three frames out of a single oversized chunk', async () => {
+    const stream = streamOf([bytes(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)])
+    const reader = new RawFrameReader(stream, 4)
+
+    expect(toArray(await reader.read())).toEqual([0, 1, 2, 3])
+    expect(toArray(await reader.read())).toEqual([4, 5, 6, 7])
+    expect(toArray(await reader.read())).toEqual([8, 9, 10, 11])
+    expect(await reader.read()).toBeNull()
+    expect(reader.trailingBytes).toBe(0)
+  })
+
+  it('assembles frames that arrive one byte at a time', async () => {
+    const values = Array.from({ length: 12 }, (_, i) => i)
+    const stream = streamOf(values.map(v => bytes(v)))
+    const reader = new RawFrameReader(stream, 4)
+
+    expect(toArray(await reader.read())).toEqual([0, 1, 2, 3])
+    expect(toArray(await reader.read())).toEqual([4, 5, 6, 7])
+    expect(toArray(await reader.read())).toEqual([8, 9, 10, 11])
+    expect(await reader.read()).toBeNull()
+    expect(reader.trailingBytes).toBe(0)
+  })
+
+  it('reassembles a single frame split across five chunks', async () => {
+    const stream = streamOf([bytes(0, 1), bytes(2, 3), bytes(4, 5), bytes(6, 7), bytes(8, 9)])
+    const reader = new RawFrameReader(stream, 10)
+
+    expect(toArray(await reader.read())).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+    expect(await reader.read()).toBeNull()
+    expect(reader.trailingBytes).toBe(0)
+  })
+
+  it('drops a truncated trailing frame and reports its byte count', async () => {
+    const stream = streamOf([bytes(0, 1, 2, 3), bytes(4, 5)])
+    const reader = new RawFrameReader(stream, 4)
+
+    expect(toArray(await reader.read())).toEqual([0, 1, 2, 3])
+    expect(await reader.read()).toBeNull()
+    expect(reader.trailingBytes).toBe(2)
+  })
+
+  it('reports trailingBytes of 0 on a stream that ends with no data at all', async () => {
+    const stream = streamOf([])
+    const reader = new RawFrameReader(stream, 4)
+
+    expect(await reader.read()).toBeNull()
+    expect(reader.trailingBytes).toBe(0)
+  })
+
+  it('returns a live view: data mutated in place is reflected until the next read()', async () => {
+    const chunk = bytes(0, 1, 2, 3)
+    const stream = streamOf([chunk])
+    const reader = new RawFrameReader(stream, 4)
+
+    const frame = await reader.read()
+    expect(frame).not.toBeNull()
+    expect(frame!.length).toBe(4)
+    // Documented contract: it is a view, not a copy — callers who need to
+    // retain it (transition snapshots) must slice() it themselves.
+    expect(frame!.buffer).not.toBe(undefined)
+  })
+
+  it('rejects a pending read on stream error', async () => {
+    const stream = new Readable({ read() {} })
+    const reader = new RawFrameReader(stream, 4)
+
+    const pending = reader.read()
+    stream.emit('error', new Error('boom'))
+
+    await expect(pending).rejects.toThrow('boom')
+  })
+
+  it('rejects any subsequent read() once the stream has errored', async () => {
+    const stream = new Readable({ read() {} })
+    const reader = new RawFrameReader(stream, 4)
+
+    stream.emit('error', new Error('pipe broke'))
+
+    await expect(reader.read()).rejects.toThrow('pipe broke')
+    await expect(reader.read()).rejects.toThrow('pipe broke')
+  })
+
+  it('throws synchronously on a second concurrent read()', async () => {
+    const stream = new Readable({ read() {} })
+    const reader = new RawFrameReader(stream, 4)
+
+    const first = reader.read()
+    expect(() => reader.read()).toThrow(/still pending/)
+
+    // Clean up: finish the stream so the first read() settles.
+    stream.push(null)
+    await first
+  })
+
+  it('destroy() resolves a pending read with null and is idempotent', async () => {
+    const stream = new Readable({ read() {} })
+    const reader = new RawFrameReader(stream, 4)
+
+    const pending = reader.read()
+    reader.destroy()
+    reader.destroy()
+
+    expect(await pending).toBeNull()
+  })
+
+  it('destroy() stops the reader from reacting to further stream activity', async () => {
+    const stream = new Readable({ read() {} })
+    const reader = new RawFrameReader(stream, 4)
+    reader.destroy()
+
+    // Pushing data after destroy() must not throw or resurrect the reader.
+    expect(() => stream.push(bytes(1, 2, 3, 4))).not.toThrow()
+  })
+
+  it('handles a stream that ends exactly on a frame boundary across many small pushes', async () => {
+    const stream = streamOf([bytes(1), bytes(2), bytes(3), bytes(4), bytes(5), bytes(6), bytes(7), bytes(8)])
+    const reader = new RawFrameReader(stream, 8)
+
+    expect(toArray(await reader.read())).toEqual([1, 2, 3, 4, 5, 6, 7, 8])
+    expect(await reader.read()).toBeNull()
+    expect(reader.trailingBytes).toBe(0)
+  })
+
+  it('does not buffer a fast producer ahead of the consumer when no read() is issued', async () => {
+    // A well-behaved Readable that keeps producing forever — like a real OS
+    // pipe carrying ffmpeg's stdout, `_read()` is only invoked again once
+    // Node's own internal buffer drains below its highWaterMark, so this
+    // simulates genuine upstream backpressure rather than an unbounded firehose.
+    const chunkSize = 256
+    const producerHighWaterMark = 4096
+    let pushed = 0
+    const stream = new Readable({
+      highWaterMark: producerHighWaterMark,
+      read() {
+        pushed += chunkSize
+        this.push(Buffer.alloc(chunkSize))
+      },
+    })
+
+    // frameBytes larger than one producer refill burst, so a single pump()
+    // drain can't accidentally satisfy it in one shot.
+    const frameBytes = producerHighWaterMark * 2
+    const reader = new RawFrameReader(stream, frameBytes)
+
+    // Nobody ever calls reader.read(). Give the producer many ticks to keep
+    // pushing — before the fix, pump()'s unconditional drain-to-null loop ran
+    // on every 'readable' event and pulled every one of these pushes into
+    // `pending` regardless of demand, so `pendingBytes` would keep climbing
+    // with `pushed`. After the fix it must stop growing once one frame's
+    // worth has accumulated.
+    for (let i = 0; i < 50; i++) {
+      await new Promise(resolve => setImmediate(resolve))
+    }
+
+    // The reader never hoarded more than one frame's worth ahead of demand...
+    expect(reader.pendingBytes).toBeLessThanOrEqual(frameBytes)
+    // ...and because it stopped pulling, the producer itself was throttled.
+    // This is the discriminating assertion: with pump()'s old drain-to-null
+    // loop, every push was consumed on the 'readable' event, `_read()` was
+    // called again immediately, and `pushed` climbed without bound across
+    // these 50 ticks. Bounded `pushed` is what proves OS pipe backpressure
+    // would actually reach ffmpeg.
+    expect(pushed).toBeLessThanOrEqual(frameBytes * 3)
+
+    // Liveness: stopping the pull must not have deadlocked the reader. A
+    // consumer that asks for a frame still gets one.
+    const frame = await reader.read()
+    expect(frame?.length).toBe(frameBytes)
+
+    reader.destroy()
+    stream.destroy()
+  })
+})

--- a/packages/export-server/src/ffmpeg/audio.ts
+++ b/packages/export-server/src/ffmpeg/audio.ts
@@ -1,0 +1,112 @@
+/**
+ * Pure ffmpeg `-filter_complex` builder for the audio mix.
+ *
+ * The browser exporter mixes audio with `OfflineAudioContext` on the main
+ * thread (see `packages/core/src/export/exportVideo.ts` `renderAudioMix`) and
+ * hands the worker pre-mixed PCM — Web Audio does not exist in Node. This
+ * module rebuilds the same schedule as an ffmpeg filter graph instead: one
+ * `atrim` + `asetpts` + `aformat` + `volume` + `adelay` chain per segment,
+ * summed with `amix`, then padded/trimmed to the export's exact duration.
+ * Nothing here spawns a process or touches a filesystem — it is a function
+ * from `AudioClipPlan[]` to a string, so the whole module is snapshot-testable
+ * without ffmpeg installed.
+ *
+ * Deliberate divergence from the browser mix: `AudioClipPlan.volume` comes
+ * from `Scene.audios[].volume`, which `resolveTimeline` already folds track
+ * gain and mute into (`baseVolume * trackGain`). The browser's
+ * `renderAudioMix` uses the raw `clip.volume` and only filters muted tracks,
+ * so it silently ignores `track.volume`. The Scene value is the more correct
+ * one and is what this module uses. Similarly, `project.masterVolume` is
+ * applied only when the caller passes `options.masterVolume` explicitly —
+ * the browser exporter never applies it either, and reading it from the
+ * Project here would breach the Scene-only rule this package is built on.
+ *
+ * The `-ss` decision for audio is the opposite of the video decoder's: video
+ * uses input `-ss` (see `decoder.ts`) because decoding a whole source from
+ * byte zero per clip is ruinous and the mediabunny PTS index lets us recover
+ * exactness. Audio decodes hundreds of times faster than realtime, so the
+ * trim happens inside the filter graph (`atrim`) with no `-ss` at all — this
+ * sidesteps AAC decoder priming/pre-roll, where an input seek can shift the
+ * result by a few milliseconds. Never combine the two: input `-ss` rebases
+ * PTS, which would silently invalidate the `atrim` window computed here.
+ */
+
+import type { AudioClipPlan, AudioMixSpec } from '../types'
+
+export interface AudioMixOptions {
+  fps: number
+  totalFrames: number
+  sampleRate: number
+  channels: number
+  /** Linear master gain. Default 1 — the browser exporter does not apply project.masterVolume. */
+  masterVolume?: number
+}
+
+/**
+ * The per-segment filter chain, without the amix/pad tail.
+ *
+ * `inputIndex` is the ffmpeg input index for this segment (input 0 is always
+ * the rawvideo pipe, so the first audio segment is input 1). The chain's
+ * output label is `a` followed by the zero-based segment position
+ * (`inputIndex - 1`), matching the labels `buildAudioMix` wires into `amix`.
+ *
+ * Every number here is derived from frames; seconds only appear once the
+ * value is interpolated into the string, so there is no double rounding
+ * between this function and its caller.
+ */
+export function buildSegmentChain(segment: AudioClipPlan, inputIndex: number, options: AudioMixOptions): string {
+  const { fps, sampleRate, channels, masterVolume = 1 } = options
+  const label = inputIndex - 1
+  const inSec = segment.sourceStartFrame / fps
+  const outSec = (segment.sourceStartFrame + segment.frameCount) / fps
+  const delayMs = Math.round((segment.startFrame / fps) * 1000)
+  const gain = segment.volume * masterVolume
+  const layout = channels === 1 ? 'mono' : 'stereo'
+
+  return (
+    `[${inputIndex}:a]atrim=start=${inSec}:end=${outSec},asetpts=PTS-STARTPTS,` +
+    `aformat=sample_fmts=fltp:sample_rates=${sampleRate}:channel_layouts=${layout},` +
+    `volume=${gain},adelay=${delayMs}:all=1[a${label}]`
+  )
+}
+
+/**
+ * Build the full audio mix graph for an export, or `null` when there is
+ * nothing to mix (no segments, or every segment muted) — the caller should
+ * pass the encoder `-an` in that case.
+ *
+ * Segments with `volume === 0` (a muted track, folded in by the resolver) are
+ * dropped before the graph is built: they would contribute silence to the
+ * mix regardless, and each one costs a decoder ffmpeg has to spin up.
+ */
+export function buildAudioMix(segments: AudioClipPlan[], options: AudioMixOptions): AudioMixSpec | null {
+  const active = segments.filter(segment => segment.volume !== 0)
+  if (active.length === 0) return null
+
+  const { fps, totalFrames, sampleRate, channels } = options
+  const chains = active.map((segment, i) => buildSegmentChain(segment, i + 1, options))
+
+  // amix's default `normalize=true` scales every input by 1/N, so an N-clip
+  // mix would come out N times quieter than the browser export. Web Audio
+  // sums without normalization — `normalize=0` is what matches it.
+  const labels = active.map((_, i) => `[a${i}]`).join('')
+  const mixed =
+    active.length > 1
+      ? `${chains.join(';')};${labels}amix=inputs=${active.length}:duration=longest:normalize=0[amix]`
+      : chains[0]
+  const mixedLabel = active.length > 1 ? 'amix' : 'a0'
+
+  // apad + atrim (rather than -shortest) guarantees the mix is exactly
+  // totalFrames / fps long: pad-then-trim is deterministic, whereas
+  // -shortest against an infinitely-padding filter is a known fragile edge.
+  const totalSec = totalFrames / fps
+  const tail = `[${mixedLabel}]apad=whole_dur=${totalSec},atrim=end=${totalSec},asetpts=N/SR/TB[aout]`
+
+  return {
+    inputs: active.map(segment => ({ source: segment.source, clipId: segment.clipId })),
+    filterComplex: `${mixed};${tail}`,
+    outLabel: '[aout]',
+    sampleRate,
+    channels,
+  }
+}

--- a/packages/export-server/src/ffmpeg/decoder.ts
+++ b/packages/export-server/src/ffmpeg/decoder.ts
@@ -1,0 +1,330 @@
+/**
+ * ClipDecoder — one ffmpeg decode process per video clip, plus the cursor
+ * that turns "the source presentation index I want" into "the next raw
+ * frame off the pipe". This is the Node replacement for mediabunny's
+ * `sink.canvasesAtTimestamps()` generator that the browser exporter uses
+ * (`packages/core/src/export/ExportWorker.ts:284`).
+ *
+ * One process per CLIP, not per source file: two clips trimmed from the same
+ * source need independent forward-only cursors, exactly as ExportWorker gives
+ * each clip its own generator. The caller (plan.ts / the frame loop) is
+ * responsible for opening a clip's decoder lazily on its first active frame
+ * and closing it on its last, so process count tracks simultaneously-active
+ * clips rather than total clips in the project.
+ *
+ * Frame accuracy rests entirely on `-fps_mode passthrough`: it forbids ffmpeg
+ * from duplicating or dropping frames to hit a constant rate, so raw frame
+ * `j` off the pipe IS source presentation frame `startIndex + j`. Every dup
+ * and every drop is therefore decided in JS, one export frame at a time, from
+ * the explicit `sourceIndices` the caller pre-computed against the real PTS
+ * index (see plan.ts's `mapSourceFramesToIndices`) — never by `-vf fps=` or
+ * `-r`, which would move that decision inside ffmpeg where it is invisible,
+ * unauditable, and rounds differently from the resolver.
+ *
+ * Seek is `-ss` BEFORE `-i`, deliberately (see `buildDecoderArgs`'s doc for
+ * why the midpoint lands exactly on the wanted frame). Output seek (`-ss`
+ * after `-i`) was rejected because it decodes from the start of the file for
+ * every clip, which is ruinous for a clip trimmed far into a long source.
+ *
+ * Known limitation: `-map 0:v:0` selects the first video stream, matching
+ * mediabunny's `getPrimaryVideoTrack()` for every common container but not
+ * guaranteed for exotic multi-track files.
+ */
+
+import { spawn } from 'node:child_process'
+import type { ChildProcess } from 'node:child_process'
+
+import { ExportServerError } from '../errors'
+import { attachStderrTail } from './spawn'
+import { RawFrameReader } from './rawFrames'
+
+import type { FfmpegBinary, DecodedFrame, VideoFrameIndex } from '../types'
+
+export interface ClipDecoderInit {
+  ffmpeg: FfmpegBinary
+  /** Resolved source: absolute path or http(s) URL. */
+  source: string
+  index: VideoFrameIndex
+  /** Source presentation indices, one per export frame this clip covers. Non-decreasing; -1 = no frame. */
+  sourceIndices: Int32Array
+  /** Pixel dimensions ffmpeg is asked to emit (may be < display dims when decodeMaxHeight is set). */
+  decodeWidth: number
+  decodeHeight: number
+  /** Geometry dimensions handed to resolveDrawRect — always the TRUE display dims. */
+  displayWidth: number
+  displayHeight: number
+  signal?: AbortSignal
+}
+
+/**
+ * The value of the first non-negative entry in `sourceIndices` — i.e. `k0`,
+ * the source presentation index of this clip's first visible frame. Scanning
+ * in order (rather than e.g. `Math.min`) matters only in that it stops at the
+ * first match; the plan's monotonicity guarantee means every later
+ * non-negative entry is >= this one anyway. Returns -1 when every entry is -1
+ * (a clip that is opened but never actually shows a frame — degenerate, but
+ * handled rather than assumed away: `computeSeekTime` treats -1 the same as
+ * 0, so the process still spawns cleanly with no seek).
+ */
+function firstNonNegativeSourceIndex(sourceIndices: Int32Array): number {
+  for (let i = 0; i < sourceIndices.length; i++) {
+    const value = sourceIndices[i]
+    if (value >= 0) return value
+  }
+  return -1
+}
+
+/**
+ * The `-ss` seek target, in seconds: the midpoint between the PTS of the
+ * frame before `k0` and the PTS of `k0` itself.
+ *
+ * `-ss` before `-i` uses `accurate_seek` (ffmpeg's input-seek default): it
+ * decodes from the keyframe at or before the seek time and DISCARDS frames
+ * whose PTS is below it, so the first emitted frame is the first one at or
+ * after the seek time. Landing exactly on `timestamps[k0]` would risk that
+ * frame being discarded by float rounding in `seekTime.toFixed(6)`; landing
+ * on the midpoint gives a full half-frame of margin on both sides, so no
+ * amount of formatting error can make ffmpeg emit `k0 - 1` or skip `k0`. The
+ * only cost is that ffmpeg may begin decoding one extra GOP earlier, once per
+ * clip — far cheaper than output-seek's "decode from the start of the file".
+ *
+ * The two time bases are NOT the same origin, which is the subtle part.
+ * mediabunny reports absolute track presentation timestamps: its own docs note
+ * the first one "may be positive or even negative. A negative starting
+ * timestamp means the track's timing has been offset". ffmpeg's input `-ss`,
+ * by contrast, is relative to the container's `start_time` — it adds
+ * `start_time` back before seeking. Passing an absolute PTS straight through
+ * therefore overshoots by `start_time` on any source whose first packet is not
+ * at 0 (MPEG-TS captures, MP4s with an edit list, anything remuxed with
+ * `-copyts`), and because `ClipDecoder` only counts frames after the seek, the
+ * clip renders the wrong source content for its ENTIRE duration with no error.
+ * Rebasing against `timestamps[0]` puts the request back in ffmpeg's base. A
+ * negative first timestamp is clamped to 0: ffmpeg has no negative input seek,
+ * and the offset is already folded into the container's own start_time.
+ */
+function computeSeekTime(timestamps: Float64Array, k0: number): number {
+  if (k0 <= 0) return 0
+  const base = timestamps[0] > 0 ? timestamps[0] : 0
+  return Math.max(0, (timestamps[k0 - 1] + timestamps[k0]) / 2 - base)
+}
+
+/**
+ * Pure argv builder — no spawning, so it is snapshot-testable on its own.
+ *
+ * `-fps_mode passthrough` is the single most important flag on this command
+ * line: it is what makes "raw frame `j` off the pipe is source presentation
+ * frame `startIndex + j`" true, and therefore what makes the whole cursor in
+ * `ClipDecoder.next()` valid. Never add `-vf fps=` or `-r` here.
+ */
+export function buildDecoderArgs(init: ClipDecoderInit): string[] {
+  const { source, index, sourceIndices, decodeWidth, decodeHeight } = init
+  const k0 = firstNonNegativeSourceIndex(sourceIndices)
+  const seekTime = computeSeekTime(index.timestamps, k0)
+
+  const args = ['-hide_banner', '-nostdin', '-loglevel', 'error']
+  if (seekTime !== 0) args.push('-ss', seekTime.toFixed(6))
+  args.push(
+    '-i', source,
+    '-map', '0:v:0', '-an', '-sn', '-dn',
+    '-vf', `scale=${decodeWidth}:${decodeHeight}:flags=bicubic`,
+    '-fps_mode', 'passthrough',
+    '-f', 'rawvideo', '-pix_fmt', 'rgba', 'pipe:1',
+  )
+  return args
+}
+
+export class ClipDecoder {
+  /** ffmpeg argv, exposed for tests and error messages. */
+  readonly args: readonly string[]
+
+  private readonly child: ChildProcess
+  private readonly reader: RawFrameReader
+  private readonly getStderrTail: () => string
+  /** Rejects with a DECODE_FAILED error iff the process exits abnormally; never resolves. Raced against every reader.read(). */
+  private readonly failureSignal: Promise<never>
+
+  /** Retained only so terminate() can detach the abort listener it registered. */
+  private abortSignal: AbortSignal | null = null
+  private onAbort: (() => void) | null = null
+
+  private readonly source: string
+  private readonly sourceIndices: Int32Array
+  private readonly decodeWidth: number
+  private readonly decodeHeight: number
+  private readonly displayWidth: number
+  private readonly displayHeight: number
+
+  /** Index into `sourceIndices` of the next export frame `next()` will serve. */
+  private step = 0
+  /** The source presentation index of the frame currently held (starts one before the clip's first wanted frame). */
+  private cursor: number
+  /** The most recently read raw frame — re-returned as-is on a duplicate (`want === cursor`). */
+  private held: Uint8ClampedArray | null = null
+  /** Set once the source has run dry; every subsequent next() short-circuits to null. */
+  private exhausted = false
+  /** Distinguishes an intentional close() kill from a real crash, for the exit handler below. */
+  private killedByUs = false
+  private closePromise: Promise<void> | null = null
+
+  private constructor(init: ClipDecoderInit) {
+    this.source = init.source
+    this.sourceIndices = init.sourceIndices
+    this.decodeWidth = init.decodeWidth
+    this.decodeHeight = init.decodeHeight
+    this.displayWidth = init.displayWidth
+    this.displayHeight = init.displayHeight
+
+    const startIndex = firstNonNegativeSourceIndex(init.sourceIndices)
+    this.cursor = startIndex - 1
+
+    this.args = buildDecoderArgs(init)
+    this.child = spawn(init.ffmpeg.path, this.args, { stdio: ['ignore', 'pipe', 'pipe'] })
+    // Shared with encoder.ts so neither module reinvents stderr capture.
+    this.getStderrTail = attachStderrTail(this.child)
+    this.reader = new RawFrameReader(this.child.stdout!, this.decodeWidth * this.decodeHeight * 4)
+
+    // A crashed ffmpeg still closes stdout cleanly, which RawFrameReader
+    // would otherwise read as ordinary end-of-source (a short clip, not an
+    // error). This promise turns a non-zero/abnormal exit into an explicit
+    // rejection so callers can tell "source ran out" from "ffmpeg died" —
+    // raced against reader.read() in next()'s pull loop. It deliberately
+    // never resolves on a clean exit: the real EOF path is left to
+    // RawFrameReader's own 'end' handling.
+    this.failureSignal = new Promise<never>((_, reject) => {
+      this.child.once('close', (code, signal) => {
+        if (this.killedByUs) return
+        if (code === 0 && signal === null) return
+        reject(this.decodeError(code, signal))
+      })
+    })
+    // Silence "unhandled rejection" when a clip finishes normally and this
+    // promise is left permanently pending-then-garbage-collected, or when it
+    // rejects between next() calls with nothing currently racing it.
+    this.failureSignal.catch(() => {})
+
+    // Detached in terminate(). Decoders are opened and closed per clip against
+    // one long-lived export signal, so leaving these attached would grow the
+    // listener count with the project's clip count — Node warns at 10 on an
+    // AbortSignal, turning a healthy 11-clip render into a spurious
+    // MaxListenersExceededWarning on a server's stderr — and would keep every
+    // closed decoder reachable from the signal for the whole export.
+    if (init.signal) {
+      if (init.signal.aborted) void this.close()
+      else {
+        this.abortSignal = init.signal
+        this.onAbort = () => void this.close()
+        init.signal.addEventListener('abort', this.onAbort, { once: true })
+      }
+    }
+  }
+
+  static open(init: ClipDecoderInit): ClipDecoder {
+    return new ClipDecoder(init)
+  }
+
+  /**
+   * Advances one export frame. Returns null when the source ran out or the
+   * step maps to -1 (target before this clip's first source frame — the same
+   * case mediabunny's `CanvasSink` returns null for).
+   *
+   * The returned `data` is a view owned by the underlying `RawFrameReader`
+   * and is invalidated by the next `next()` call — the compositor must draw
+   * it immediately, and the transition snapshot store must copy it if it
+   * needs to survive past that point.
+   *
+   * This is the Node analogue of `ExportWorker.ts:322-327`'s per-frame
+   * `decoder.gen.next()` advance, and the dup/drop kernel the whole package's
+   * frame-accuracy strategy rests on:
+   *   - `want === cursor` re-returns the held frame — a DUPLICATE, because the
+   *     source is slower than the project rate at this point.
+   *   - `want > cursor` pulls and discards intermediate frames — a DROP,
+   *     because the source is faster than the project rate.
+   *   - `want < cursor` is impossible under the plan's non-decreasing
+   *     guarantee; if it ever happens this throws rather than seeking
+   *     backwards, which `-fps_mode passthrough` + a forward-only pipe cannot
+   *     do anyway.
+   */
+  async next(): Promise<DecodedFrame | null> {
+    if (this.step >= this.sourceIndices.length) {
+      throw new ExportServerError(
+        'DECODE_FAILED',
+        `ClipDecoder.next() called past the end of its plan for '${this.source}' ` +
+        `(${this.sourceIndices.length} frame(s) planned)`,
+      )
+    }
+    const want = this.sourceIndices[this.step]
+    this.step++
+
+    if (want < 0) return null
+
+    if (want < this.cursor) {
+      throw new ExportServerError(
+        'DECODE_FAILED',
+        `non-monotonic source index for '${this.source}': requested ${want} ` +
+        `after the decoder cursor already reached ${this.cursor}`,
+      )
+    }
+
+    if (this.exhausted) return null
+
+    while (this.cursor < want) {
+      const frame = await Promise.race([this.reader.read(), this.failureSignal])
+      if (frame === null) {
+        this.exhausted = true
+        return null
+      }
+      this.held = frame
+      this.cursor++
+    }
+
+    if (!this.held) return null
+    return {
+      data: this.held,
+      width: this.decodeWidth,
+      height: this.decodeHeight,
+      displayWidth: this.displayWidth,
+      displayHeight: this.displayHeight,
+    }
+  }
+
+  /** Kills the process, drains stderr, releases the reader. Idempotent. */
+  async close(): Promise<void> {
+    if (!this.closePromise) this.closePromise = this.terminate()
+    return this.closePromise
+  }
+
+  private async terminate(): Promise<void> {
+    this.killedByUs = true
+    if (this.abortSignal && this.onAbort) {
+      this.abortSignal.removeEventListener('abort', this.onAbort)
+      this.abortSignal = null
+      this.onAbort = null
+    }
+    this.reader.destroy()
+    // SIGKILL, not SIGTERM: ffmpeg blocked writing to a full stdout pipe (the
+    // export loop stalled, or an abort mid-export) does not reliably act on
+    // SIGTERM, and teardown must not hang.
+    if (this.child.exitCode === null && this.child.signalCode === null) {
+      this.child.kill('SIGKILL')
+    }
+    await new Promise<void>(resolve => {
+      if (this.child.exitCode !== null || this.child.signalCode !== null) {
+        resolve()
+        return
+      }
+      this.child.once('close', () => resolve())
+    })
+  }
+
+  private decodeError(code: number | null, signal: NodeJS.Signals | null): ExportServerError {
+    const reason = signal ? `signal ${signal}` : `code ${code}`
+    const stderr = this.getStderrTail()
+    return new ExportServerError(
+      'DECODE_FAILED',
+      `ffmpeg exited with ${reason} while decoding '${this.source}'\n` +
+      `argv: ffmpeg ${this.args.join(' ')}\n` +
+      `stderr:\n${stderr || '(empty)'}`,
+      { stderr },
+    )
+  }
+}

--- a/packages/export-server/src/ffmpeg/encoder.ts
+++ b/packages/export-server/src/ffmpeg/encoder.ts
@@ -1,0 +1,190 @@
+/**
+ * FrameEncoder — the single encode/mux process.
+ *
+ * Rawvideo RGBA goes in on stdin (one export frame at a time, in presentation
+ * order); the audio filter graph (built by audio.ts, see AudioMixSpec) is
+ * spliced in as extra ffmpeg inputs + `-filter_complex`; MP4 comes out on
+ * disk. This is the only place in the package that owns a child process's
+ * stdin, so it is also the only place backpressure has to be handled —
+ * constraint 5 of the package brief: skipping the `drain` wait would buffer
+ * the entire export in memory, the exact failure this package exists to avoid.
+ *
+ * `-movflags +faststart` requires a seekable output, which is why `outPath`
+ * is a file path rather than a stdout pipe returning a Buffer — a
+ * fragmented-MP4 stdout stream cannot carry a moov-atom rewrite.
+ */
+
+import { spawn } from 'node:child_process'
+import { once } from 'node:events'
+
+import type { FfmpegBinary, AudioMixSpec } from '../types'
+import { ExportServerError } from '../errors'
+import { attachStderrTail } from './spawn'
+
+export interface EncoderAudio {
+  spec: AudioMixSpec
+  encoder: string
+  bitrate: number
+}
+
+export interface EncoderInit {
+  ffmpeg: FfmpegBinary
+  outPath: string
+  width: number
+  height: number
+  fps: number
+  videoEncoder: string
+  videoBitrate: number
+  audio: EncoderAudio | null
+  extraOutputArgs?: string[]
+  signal?: AbortSignal
+}
+
+/**
+ * Pure argv builder — no spawning, so it is snapshot-testable on its own.
+ *
+ * Order matters: audio inputs are appended after the rawvideo pipe (index 0),
+ * so they land at input index 1..N, matching the index `AudioMixSpec`'s
+ * filter graph was written against. `-b:v` (not CRF) so `videoBitrate` means
+ * the same thing here as it does in the browser exporter's ExportOptions.
+ * `extraOutputArgs` is spliced in last so a caller can override anything
+ * upstream of it (e.g. `['-preset', 'veryfast']`, `['-crf', '18', '-b:v', '0']`).
+ *
+ * The colour conversion is pinned rather than inherited. swscale's default for
+ * an untagged rgba input is BT.601 coefficients at limited range, and it writes
+ * "unspecified" into the bitstream — so players fall back to their usual
+ * heuristic and decode HD as BT.709, inverting a matrix that was never applied.
+ * That is the classic green/magenta cast on saturated colour. Chrome's
+ * WebCodecs path tags HD as BT.709, so inheriting the default would also mean
+ * the same project exports differently in the editor and on the server, which
+ * is the one property this package exists to guarantee. `scale` does the
+ * conversion (its `w`/`h` default to the input's, so this is colour-only),
+ * `in_range=full` states what rgba actually is, and the `-color*` flags tag the
+ * muxed stream with what was done to it.
+ */
+export function buildEncoderArgs(init: EncoderInit): string[] {
+  const { width, height, fps, videoEncoder, videoBitrate, audio, extraOutputArgs, outPath } = init
+  return [
+    '-hide_banner', '-nostdin', '-loglevel', 'error', '-y',
+    '-f', 'rawvideo', '-pix_fmt', 'rgba', '-s', `${width}x${height}`, '-r', String(fps), '-i', 'pipe:0',
+    ...(audio ? audio.spec.inputs.flatMap(i => ['-i', i.source]) : []),
+    ...(audio ? ['-filter_complex', audio.spec.filterComplex, '-map', audio.spec.outLabel] : []),
+    '-map', '0:v:0',
+    '-vf', 'scale=in_range=full:out_range=tv:out_color_matrix=bt709',
+    '-c:v', videoEncoder, '-b:v', String(videoBitrate), '-pix_fmt', 'yuv420p',
+    '-colorspace', 'bt709', '-color_primaries', 'bt709', '-color_trc', 'bt709', '-color_range', 'tv',
+    ...(audio
+      ? ['-c:a', audio.encoder, '-b:a', String(audio.bitrate), '-ar', String(audio.spec.sampleRate), '-ac', String(audio.spec.channels)]
+      : ['-an']),
+    '-movflags', '+faststart',
+    ...(extraOutputArgs ?? []),
+    '-f', 'mp4', outPath,
+  ]
+}
+
+/** Resolution of the process's terminal event — the only thing writeFrame's drain race and finish() both need. */
+interface ExitInfo {
+  code: number | null
+  signal: NodeJS.Signals | null
+}
+
+export class FrameEncoder {
+  readonly args: readonly string[]
+
+  private readonly proc: ReturnType<typeof spawn>
+  private readonly exitPromise: Promise<ExitInfo>
+  private readonly getStderrTail: () => string
+  /** Set once the process is known to be unusable; every subsequent writeFrame rethrows it instead of writing into a dead pipe. */
+  private failed: Error | null = null
+
+  private constructor(init: EncoderInit) {
+    this.args = buildEncoderArgs(init)
+    this.proc = spawn(init.ffmpeg.path, this.args, { stdio: ['pipe', 'ignore', 'pipe'] })
+
+    // A dead ffmpeg makes writes to stdin throw EPIPE. The real cause is
+    // always the stderr tail + exit code surfaced through exitPromise, so
+    // this handler exists only to stop the EPIPE itself from crashing the
+    // process as an unhandled 'error' on a Writable.
+    this.proc.stdin!.on('error', () => {})
+
+    // Shared with decoder.ts so neither module reinvents stderr capture.
+    this.getStderrTail = attachStderrTail(this.proc)
+
+    // Resolve on whichever terminal event fires first. 'error' covers a spawn
+    // that never happened at all (e.g. a race between ffmpeg discovery and
+    // the binary disappearing) — without this branch a failed spawn would
+    // hang writeFrame/finish forever waiting for a 'close' that never comes.
+    this.exitPromise = new Promise<ExitInfo>(resolve => {
+      this.proc.once('close', (code, signal) => resolve({ code, signal }))
+      this.proc.once('error', () => resolve({ code: null, signal: null }))
+    })
+
+    // Latch the failure the moment the process dies, independently of the
+    // drain race in writeFrame. Writes to a closed pipe do NOT fill the kernel
+    // buffer, so stdin.write() keeps returning true and the drain race is
+    // never reached — without this, an ffmpeg that died at frame 20 of 20,000
+    // would let the loop resolve, decode and composite every remaining frame
+    // into a dead pipe before finish() finally surfaced the error.
+    void this.exitPromise.then(({ code }) => {
+      if (code !== 0) this.captureFailure(code)
+    })
+
+    if (init.signal) {
+      if (init.signal.aborted) this.abort()
+      else init.signal.addEventListener('abort', () => this.abort(), { once: true })
+    }
+  }
+
+  static start(init: EncoderInit): FrameEncoder {
+    return new FrameEncoder(init)
+  }
+
+  /**
+   * Writes one RGBA frame, awaiting 'drain' when the pipe is full.
+   *
+   * `Buffer.from(frame.buffer, ...)` is a view, not a copy — the caller's
+   * `Uint8ClampedArray` must not be mutated again until this resolves.
+   *
+   * Race handled: if ffmpeg dies while we are awaiting 'drain', the pipe
+   * closes and 'drain' never fires, which would otherwise hang the export
+   * forever. Racing against `exitPromise` guarantees this call always
+   * settles, turning a silent hang into the real ENCODE_FAILED error.
+   */
+  async writeFrame(frame: Uint8ClampedArray): Promise<void> {
+    if (this.failed) throw this.failed
+    const buf = Buffer.from(frame.buffer, frame.byteOffset, frame.byteLength)
+    if (this.proc.stdin!.write(buf)) return
+    await Promise.race([
+      once(this.proc.stdin!, 'drain'),
+      this.exitPromise.then(({ code }) => {
+        throw this.captureFailure(code)
+      }),
+    ])
+  }
+
+  /** Ends stdin and resolves when ffmpeg exits 0; rejects with the stderr tail otherwise. */
+  async finish(): Promise<void> {
+    if (this.failed) throw this.failed
+    this.proc.stdin!.end()
+    const { code } = await this.exitPromise
+    if (code !== 0) throw this.captureFailure(code)
+  }
+
+  /** SIGKILLs the process. Safe to call after finish() — killing an already-exited process is a no-op. */
+  abort(): void {
+    this.proc.kill('SIGKILL')
+  }
+
+  /** Builds and caches the terminal error so every future writeFrame call rethrows the same one instead of racing exitPromise again. */
+  private captureFailure(code: number | null): ExportServerError {
+    if (this.failed) return this.failed as ExportServerError
+    const err = new ExportServerError(
+      'ENCODE_FAILED',
+      `ffmpeg exited with code ${code ?? 'null'}\n` +
+      `argv: ffmpeg ${this.args.join(' ')}\n` +
+      `stderr:\n${this.getStderrTail() || '(empty)'}`,
+    )
+    this.failed = err
+    return err
+  }
+}

--- a/packages/export-server/src/ffmpeg/locate.ts
+++ b/packages/export-server/src/ffmpeg/locate.ts
@@ -1,0 +1,176 @@
+/**
+ * ffmpeg discovery, version floor, and encoder capability check.
+ *
+ * ffmpeg is a system binary, deliberately never an npm dependency: vendoring a
+ * static build would add tens of MB to this package, drag GPL-licensed code
+ * into an MIT/Apache-2.0 dependency graph, and lose the hardware encoders
+ * (h264_videotoolbox / h264_nvenc / h264_qsv) that only the platform's own
+ * ffmpeg build has — a vendored static build ships none of them. Discovery
+ * therefore mirrors packages/cli/src/lib/browser.ts's search for a system
+ * Chrome: explicit option -> env var -> bare command name resolved via PATH,
+ * trying each in turn and surfacing the last failure if every attempt fails.
+ *
+ * The version floor exists because this package's entire frame-accuracy
+ * strategy (see decoder.ts) rests on `-fps_mode passthrough`, which forbids
+ * ffmpeg from duplicating/dropping frames to hit a constant rate. That flag
+ * landed in ffmpeg 5.1; below it we must refuse rather than silently produce
+ * a mistimed export.
+ */
+
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+
+import { ExportServerError } from '../errors'
+
+import type { FfmpegBinary } from '../types'
+
+const execFileAsync = promisify(execFile)
+
+/** Lowest ffmpeg that supports every flag/filter option this package emits. */
+export const MIN_FFMPEG_VERSION: readonly [number, number] = [5, 1]
+
+export interface LocateFfmpegOptions {
+  /** Explicit executable path; wins over discovery. */
+  ffmpegPath?: string
+  /** Encoder names that must be present, e.g. ['libx264', 'aac']. */
+  requireEncoders?: string[]
+}
+
+/**
+ * Encoder names ffmpeg may report that can produce H.264, used only to make
+ * an ENCODER_MISSING error actionable ("here's what you *can* use instead").
+ * Not exhaustive — vaapi/v4l2m2m variants are Linux-only and rare in the wild.
+ */
+const H264_ENCODERS = [
+  'libx264',
+  'libx264rgb',
+  'h264_videotoolbox',
+  'h264_nvenc',
+  'h264_qsv',
+  'h264_amf',
+  'h264_vaapi',
+  'h264_v4l2m2m',
+]
+
+/**
+ * Parses `ffmpeg -version` stdout into `[major, minor]`.
+ *
+ * Deliberately lenient: only the first line is inspected, and an optional
+ * leading `n` is tolerated (static builds from e.g. BtbN report
+ * `version n6.1.1`). Git/nightly builds print a non-numeric version like
+ * `version N-118234-g0abcdef` — that has no `\d+\.\d+` to match, so this
+ * returns `null` and the caller proceeds with a warning rather than locking
+ * out custom builds that may well be newer than any numbered release.
+ */
+export function parseFfmpegVersion(stdout: string): [number, number] | null {
+  const firstLine = stdout.split('\n')[0] ?? ''
+  const match = /version\s+n?(\d+)\.(\d+)/.exec(firstLine)
+  if (!match) return null
+  return [Number(match[1]), Number(match[2])]
+}
+
+/**
+ * Parses `ffmpeg -encoders` stdout into the set of encoder names.
+ *
+ * Encoder lines look like ` V....D libx264              libx264 H.264 ...` —
+ * a leading space, six capability flags, then the name. Each flag column has
+ * its own fixed alphabet (col 1: `V`/`A`/`S`; the rest: a letter or `.`) —
+ * `[VAS.]{6}` looks equivalent but is NOT: it also accepts `.` in col 1, which
+ * never occurs, and — the one that matters — rejects the letters actually
+ * used in columns 2-6 (`F`, `S`, `X`, `B`, `D`), so it silently drops any
+ * encoder line that sets one of those flags. On a real ffmpeg build that is
+ * most encoders, `libx264` included (it reports `D`), which would have made
+ * the capability check that gates this whole package unable to see the
+ * encoder it exists to verify. Matching each column's real alphabet is what
+ * makes this work against actual `-encoders` output instead of just the
+ * lines that happen to have no flags set. The header (`Encoders:`) and the
+ * flag legend above the encoder table don't match this shape and are ignored
+ * for free.
+ */
+export function parseEncoders(stdout: string): Set<string> {
+  const encoders = new Set<string>()
+  const lineRe = /^\s[VAS][F.][S.][X.][B.][D.]\s+(\S+)/gm
+  let match: RegExpExecArray | null
+  while ((match = lineRe.exec(stdout)) !== null) {
+    encoders.add(match[1])
+  }
+  return encoders
+}
+
+function compareVersions(a: readonly [number, number], b: readonly [number, number]): number {
+  return a[0] !== b[0] ? a[0] - b[0] : a[1] - b[1]
+}
+
+async function probeEncoders(candidate: string): Promise<Set<string>> {
+  const { stdout } = await execFileAsync(candidate, ['-hide_banner', '-encoders'])
+  return parseEncoders(stdout)
+}
+
+/**
+ * Locates a usable ffmpeg, verifies it meets {@link MIN_FFMPEG_VERSION}, and
+ * (when `requireEncoders` is given) verifies each named encoder is present.
+ *
+ * Discovery order: `options.ffmpegPath` -> `ELAH_FFMPEG` env -> `'ffmpeg'` on
+ * PATH — each candidate is tried by running `<candidate> -version`, in that
+ * order, so an explicit option always gets first chance and PATH is the
+ * fallback of last resort.
+ */
+export async function locateFfmpeg(options: LocateFfmpegOptions = {}): Promise<FfmpegBinary> {
+  const candidates = [options.ffmpegPath, process.env.ELAH_FFMPEG, 'ffmpeg'].filter(
+    (c): c is string => !!c,
+  )
+
+  let lastError: Error | undefined
+  for (const candidate of candidates) {
+    try {
+      const { stdout } = await execFileAsync(candidate, ['-version'])
+      const versionLine = stdout.split('\n')[0]?.trim() ?? ''
+      const version = parseFfmpegVersion(stdout)
+
+      if (version === null) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[@elah/export-server] ffmpeg at '${candidate}' reports a non-numeric version ` +
+            `('${versionLine}'); proceeding without a version check (assuming a git/nightly build).`,
+        )
+      } else if (compareVersions(version, MIN_FFMPEG_VERSION) < 0) {
+        throw new ExportServerError(
+          'FFMPEG_TOO_OLD',
+          `ffmpeg at '${candidate}' is version ${version[0]}.${version[1]}, but @elah/export-server ` +
+            `requires ${MIN_FFMPEG_VERSION[0]}.${MIN_FFMPEG_VERSION[1]}+ (needs -fps_mode passthrough, ` +
+            `added in ffmpeg 5.1, for frame-accurate decode). Found: ${versionLine}`,
+        )
+      }
+
+      const encoders = await probeEncoders(candidate)
+      const required = options.requireEncoders ?? []
+      const missing = required.filter(name => !encoders.has(name))
+      if (missing.length > 0) {
+        const available = H264_ENCODERS.filter(name => encoders.has(name))
+        const encoderLabel =
+          missing.length === 1
+            ? `encoder '${missing[0]}'`
+            : `encoders ${missing.map(name => `'${name}'`).join(', ')}`
+        throw new ExportServerError(
+          'ENCODER_MISSING',
+          `ffmpeg at ${candidate} has no ${encoderLabel}. Available H.264 encoders: ` +
+            `${available.length > 0 ? available.join(', ') : 'none found'}.`,
+        )
+      }
+
+      return { path: candidate, versionLine, version, encoders }
+    } catch (err) {
+      // FFMPEG_TOO_OLD / ENCODER_MISSING are fatal facts about a *found* ffmpeg,
+      // not evidence the candidate is unusable as a binary — surface them
+      // immediately rather than masking them behind a later FFMPEG_NOT_FOUND.
+      if (err instanceof ExportServerError) throw err
+      lastError = err as Error
+    }
+  }
+
+  throw new ExportServerError(
+    'FFMPEG_NOT_FOUND',
+    'No ffmpeg binary found for export. Install ffmpeg (brew install ffmpeg / apt install ffmpeg), ' +
+      `or pass ffmpegPath (or set ELAH_FFMPEG). Last error: ${lastError?.message}`,
+  )
+}

--- a/packages/export-server/src/ffmpeg/rawFrames.ts
+++ b/packages/export-server/src/ffmpeg/rawFrames.ts
@@ -1,0 +1,196 @@
+/**
+ * Frame-delimiting reader for an ffmpeg `-f rawvideo` stdout pipe.
+ *
+ * A rawvideo pipe is just bytes — ffmpeg never inserts frame boundaries, so
+ * the only thing that tells us where one frame ends and the next begins is
+ * `frameBytes` (= width * height * 4 for rgba), which the caller derives from
+ * the probe-produced source dimensions. Get that number wrong and every frame
+ * silently shears across the wrong boundary.
+ *
+ * Paused-mode only: we drive the stream with `'readable'` + `stream.read()`,
+ * never `'data'`/`resume()`. Flowing mode would let Node buffer the whole
+ * decode into RAM ahead of the export loop, which defeats the OS-pipe
+ * backpressure that is supposed to throttle ffmpeg to the speed we consume at
+ * (see decoder.ts's stdin backpressure for the encoder side of the same
+ * concern).
+ */
+
+import type { Readable } from 'node:stream'
+
+interface PendingRead {
+  resolve: (frame: Uint8ClampedArray | null) => void
+  reject: (err: Error) => void
+}
+
+export class RawFrameReader {
+  private readonly stream: Readable
+  private readonly frameBytes: number
+
+  private pending: Buffer[] = []
+  private pendingBytesInternal = 0
+
+  private ended = false
+  private errored: Error | null = null
+  private waiter: PendingRead | null = null
+
+  private destroyed = false
+
+  private readonly onReadable: () => void
+  private readonly onEnd: () => void
+  private readonly onError: (err: Error) => void
+
+  trailingBytes = 0
+
+  /** Bytes currently buffered ahead of the next `read()` — exposed for the backpressure regression test. */
+  get pendingBytes(): number {
+    return this.pendingBytesInternal
+  }
+
+  constructor(stream: Readable, frameBytes: number) {
+    this.stream = stream
+    this.frameBytes = frameBytes
+
+    // Bound once so removeListener() in destroy() actually removes them.
+    this.onReadable = () => this.pump()
+    this.onEnd = () => this.handleEnd()
+    this.onError = (err: Error) => this.handleError(err)
+
+    this.stream.on('readable', this.onReadable)
+    this.stream.on('end', this.onEnd)
+    this.stream.on('error', this.onError)
+  }
+
+  /**
+   * Resolves the next complete frame, or null once the stream ends cleanly.
+   * Rejects on stream error (including errors that arrived before this call).
+   *
+   * The returned array is a VIEW over an internal buffer valid only until the
+   * next `read()` call — copy it (`.slice()`) if you need to keep it past
+   * that point (transition snapshots do this).
+   */
+  read(): Promise<Uint8ClampedArray | null> {
+    if (this.waiter) {
+      throw new Error('RawFrameReader.read() called while a previous read() is still pending')
+    }
+
+    if (this.errored) {
+      return Promise.reject(this.errored)
+    }
+
+    const framed = this.tryTakeFrame()
+    if (framed) return Promise.resolve(framed)
+
+    if (this.ended) {
+      return Promise.resolve(this.finishAtEnd())
+    }
+
+    return new Promise<Uint8ClampedArray | null>((resolve, reject) => {
+      this.waiter = { resolve, reject }
+      // A chunk may already be sitting in the stream's internal buffer from
+      // before this read() was called (e.g. arrived between two reads).
+      this.pump()
+    })
+  }
+
+  destroy(): void {
+    if (this.destroyed) return
+    this.destroyed = true
+    this.stream.off('readable', this.onReadable)
+    this.stream.off('end', this.onEnd)
+    this.stream.off('error', this.onError)
+    // A destroy() mid-read should not leave a caller hanging forever.
+    if (this.waiter) {
+      const waiter = this.waiter
+      this.waiter = null
+      waiter.resolve(null)
+    }
+  }
+
+  /**
+   * Pulls only as much as the next frame needs, then settles the waiter if
+   * satisfied.
+   *
+   * Deliberately NOT a "drain everything currently readable" loop: `pending`
+   * refilling from the stream's internal buffer makes the stream re-emit
+   * 'readable' once that buffer refills from the underlying fd, so an
+   * unconditional drain loop here would pull forever regardless of whether
+   * anyone is consuming — exactly the flowing-mode-shaped bug this file's own
+   * header warns against, just reintroduced one level down. Stopping once
+   * `pendingBytes >= frameBytes` leaves the rest sitting in the stream's own
+   * (highWaterMark-bounded) buffer, which is what lets Node's/the OS's pipe
+   * backpressure actually reach ffmpeg: ffmpeg's stdout write blocks once that
+   * buffer is full, and stops being read again only once a caller's `read()`
+   * needs the next frame and calls `pump()` (via the 'readable' handler or via
+   * `read()` itself installing a waiter) to top the buffer back up.
+   */
+  private pump(): void {
+    if (this.destroyed) return
+
+    while (this.pendingBytesInternal < this.frameBytes) {
+      const chunk = this.stream.read() as Buffer | null
+      if (chunk === null) break
+      if (chunk.length === 0) continue
+      this.pending.push(chunk)
+      this.pendingBytesInternal += chunk.length
+    }
+
+    if (!this.waiter) return
+
+    const framed = this.tryTakeFrame()
+    if (framed) {
+      const waiter = this.waiter
+      this.waiter = null
+      waiter.resolve(framed)
+      return
+    }
+
+    if (this.ended) {
+      const waiter = this.waiter
+      this.waiter = null
+      waiter.resolve(this.finishAtEnd())
+    }
+  }
+
+  /** Takes exactly `frameBytes` off the front of `pending` if enough has accumulated. */
+  private tryTakeFrame(): Uint8ClampedArray | null {
+    if (this.pendingBytesInternal < this.frameBytes) return null
+
+    const buf = this.pending.length === 1 ? this.pending[0] : Buffer.concat(this.pending, this.pendingBytesInternal)
+
+    const frame = new Uint8ClampedArray(buf.buffer, buf.byteOffset, this.frameBytes)
+
+    const remainderLength = this.pendingBytesInternal - this.frameBytes
+    if (remainderLength > 0) {
+      this.pending = [buf.subarray(this.frameBytes)]
+    } else {
+      this.pending = []
+    }
+    this.pendingBytesInternal = remainderLength
+
+    return frame
+  }
+
+  /** Called once, at end-of-stream, when no more frames can ever complete. */
+  private finishAtEnd(): Uint8ClampedArray | null {
+    // A partial trailing frame is dropped, never emitted — the caller sees
+    // trailingBytes > 0 and can log/warn as it sees fit.
+    this.trailingBytes = this.pendingBytesInternal
+    this.pending = []
+    this.pendingBytesInternal = 0
+    return null
+  }
+
+  private handleEnd(): void {
+    this.ended = true
+    this.pump()
+  }
+
+  private handleError(err: Error): void {
+    this.errored = err
+    if (this.waiter) {
+      const waiter = this.waiter
+      this.waiter = null
+      waiter.reject(err)
+    }
+  }
+}

--- a/packages/export-server/src/ffmpeg/spawn.ts
+++ b/packages/export-server/src/ffmpeg/spawn.ts
@@ -1,0 +1,119 @@
+/**
+ * Small child_process helpers shared by decoder.ts and encoder.ts so neither
+ * reinvents stderr capture or exit handling. Nothing here knows about
+ * frames, Scenes, or ffmpeg argv shape — it is pure process plumbing.
+ */
+
+import { spawn } from 'node:child_process'
+import type { ChildProcess } from 'node:child_process'
+
+const DEFAULT_STDERR_TAIL_BYTES = 8192
+
+export interface RunResult {
+  code: number | null
+  stdout: string
+  stderr: string
+}
+
+/**
+ * Runs ffmpeg to completion and buffers both streams. For `-version` /
+ * `-encoders` only: it holds all of stdout in memory, which for a rawvideo
+ * decode/encode pipe would be gigabytes. `timeoutMs`, when given, guards
+ * against a hung probe (e.g. a misidentified binary waiting on stdin).
+ */
+export async function runFfmpeg(
+  binary: string,
+  args: string[],
+  timeoutMs?: number
+): Promise<RunResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(binary, args)
+    let stdout = ''
+    let stderr = ''
+    let settled = false
+
+    const timer =
+      timeoutMs !== undefined
+        ? setTimeout(() => {
+            if (settled) return
+            settled = true
+            child.kill('SIGKILL')
+            reject(new Error(`${binary} ${args.join(' ')} timed out after ${timeoutMs}ms`))
+          }, timeoutMs)
+        : undefined
+
+    child.stdout?.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString('utf8')
+    })
+    child.stderr?.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString('utf8')
+    })
+    child.once('error', (err) => {
+      if (settled) return
+      settled = true
+      if (timer) clearTimeout(timer)
+      reject(err)
+    })
+    child.once('close', (code) => {
+      if (settled) return
+      settled = true
+      if (timer) clearTimeout(timer)
+      resolve({ code, stdout, stderr })
+    })
+  })
+}
+
+/**
+ * Keeps only the last `maxBytes` of stderr, as a rolling buffer, so a
+ * long-lived decode/encode process can still report a useful error on
+ * failure without holding its entire stderr history in memory.
+ */
+export function attachStderrTail(
+  child: ChildProcess,
+  maxBytes: number = DEFAULT_STDERR_TAIL_BYTES
+): () => string {
+  let tail = Buffer.alloc(0)
+  child.stderr?.on('data', (chunk: Buffer) => {
+    tail = Buffer.concat([tail, chunk])
+    if (tail.length > maxBytes) {
+      tail = Buffer.from(tail.subarray(tail.length - maxBytes))
+    }
+  })
+  return () => tail.toString('utf8')
+}
+
+/**
+ * Resolves with the exit code on 'close'; rejects on spawn 'error'. `once` on
+ * both events avoids a double settle — Node emits 'close' after a spawn
+ * error too in some failure modes, and after this resolves/rejects once we
+ * no longer care.
+ */
+export function processExit(child: ChildProcess): Promise<number | null> {
+  return new Promise((resolve, reject) => {
+    child.once('error', (err) => reject(err))
+    child.once('close', (code) => resolve(code))
+  })
+}
+
+/**
+ * SIGKILL + await close, tolerant of an already-dead process.
+ *
+ * SIGKILL is deliberate, not SIGTERM: an ffmpeg process blocked writing to a
+ * full stdout pipe (the export loop stalled on backpressure, an abort mid
+ * export) does not reliably act on SIGTERM, and teardown must not hang.
+ *
+ * Guards on `exitCode`/`signalCode` before awaiting `processExit` because
+ * 'close' only ever fires once — if the process already exited, that event
+ * already fired and a second `.once('close', ...)` registration would never
+ * resolve.
+ */
+export async function killProcess(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return
+  child.kill('SIGKILL')
+  try {
+    await processExit(child)
+  } catch {
+    // Spawn never succeeded or 'error' fired on an already-dying process —
+    // either way there is nothing left to tear down.
+  }
+}

--- a/packages/export-server/src/index.ts
+++ b/packages/export-server/src/index.ts
@@ -1,0 +1,23 @@
+/**
+ * @elah/export-server — public API surface.
+ *
+ * The only entry point a consumer needs: `exportProject(project, options)`.
+ * Everything else in this package (plan.ts, probe.ts, ffmpeg/*, render/*) is
+ * an implementation detail reached only through this function, so nothing
+ * else is exported here.
+ */
+
+export { exportProject } from './exportProject'
+
+export type {
+  ExportProjectOptions,
+  ExportResult,
+  ExportProgress,
+  ExportPhase,
+  FontSpec,
+  OutputValidation,
+  Scene,
+} from './types'
+
+export { ExportServerError } from './errors'
+export type { ExportErrorCode, ExportServerErrorOptions } from './errors'

--- a/packages/export-server/src/plan.ts
+++ b/packages/export-server/src/plan.ts
@@ -1,0 +1,220 @@
+/**
+ * plan.ts — the Scene-scan pass.
+ *
+ * `planExport` is the second module (after the ffmpeg-invocation callers) allowed
+ * to touch `Project`, and only to call `resolveTimeline(frame, project)` and
+ * `getTotalFrames(project.clips)`. Everything it emits is derived from the
+ * resulting `Scene` objects — the decoder, compositor, and audio-graph builder
+ * never see `Project`/`Clip`, only the `ExportPlan` this module produces.
+ *
+ * Mirrors ExportWorker.ts's per-clip timestamp precomputation (:277-287) but as
+ * a standalone forward scan rather than something interleaved with the frame
+ * render loop, since ffmpeg decode (unlike mediabunny's CanvasSink) needs the
+ * whole per-clip timestamp list up front to build its `-ss` seek and argv.
+ */
+
+import { resolveTimeline, getTotalFrames } from '@elah/core'
+import type { Project } from '@elah/core'
+
+import { ExportServerError } from './errors'
+import type { AudioClipPlan, ExportPlan, VideoClipPlan, VideoFrameIndex } from './types'
+
+export interface PlanExportOptions {
+  /** Maps a Scene `src` to something ffmpeg/mediabunny can open. */
+  resolveSource: (src: string) => string
+}
+
+/** Video accumulator kept per clip id while the forward scan is in progress. */
+interface VideoAccumulator {
+  source: string
+  firstFrame: number
+  lastFrame: number
+  /** Built dense as the scan proceeds — see the gap-fill note below. */
+  sourceFrames: number[]
+}
+
+/** Audio accumulator kept per clip id while the forward scan is in progress. */
+interface AudioAccumulator {
+  source: string
+  firstFrame: number
+  lastFrame: number
+  /** Captured once, at the clip's first active frame. */
+  sourceStartFrame: number
+  volume: number
+}
+
+/**
+ * Scans every export frame's `Scene` exactly once and compresses the result
+ * into an `ExportPlan`. This is where frame accuracy is decided: everything
+ * downstream (ffmpeg argv, the dup/drop cursor, the audio filter graph) just
+ * executes the plan without ever resolving the timeline again.
+ */
+export function planExport(project: Project, options: PlanExportOptions): ExportPlan {
+  const totalFrames = getTotalFrames(project.clips)
+
+  // fps/stage come from the frame-0 Scene regardless of totalFrames (an empty
+  // project still has a valid fps/stage — resolveTimeline never depends on
+  // there being any clips). Reused as frame 0 of the scan below so it is never
+  // resolved twice.
+  const scene0 = resolveTimeline(0, project)
+  const fps = scene0.fps
+  const stage = scene0.stage
+
+  const videos = new Map<string, VideoAccumulator>()
+  const audios = new Map<string, AudioAccumulator>()
+  const imageSources: Array<{ src: string; source: string }> = []
+  const seenImages = new Set<string>()
+  const fontFamilies: string[] = []
+  const seenFonts = new Set<string>()
+
+  for (let frame = 0; frame < totalFrames; frame++) {
+    const scene = frame === 0 ? scene0 : resolveTimeline(frame, project)
+
+    // Every entry in scene.videos, INCLUDING opacity === 0 entries: a
+    // transition's outgoing clip is drawn at opacity 0 by the GPU (the export
+    // snapshot pass draws it instead), but its pixels must still be decoded —
+    // see ExportWorker.ts:331-345.
+    for (const v of scene.videos) {
+      const acc = videos.get(v.id)
+      if (!acc) {
+        videos.set(v.id, {
+          source: options.resolveSource(v.src),
+          firstFrame: frame,
+          lastFrame: frame,
+          sourceFrames: [v.sourceFrame],
+        })
+        continue
+      }
+      // Dense + monotonic contract: if this clip was absent for one or more
+      // interior frames (the transition pass in resolveTimeline.ts can re-add
+      // a clip outside its own window), fill the hole with the previously
+      // recorded value — a flat tail — before appending this frame's value.
+      // Keeps `sourceFrames.length === lastFrame - firstFrame + 1` and keeps
+      // exactly one decoder `.next()` per open frame in lockstep with the loop.
+      const gap = frame - acc.lastFrame - 1
+      for (let i = 0; i < gap; i++) {
+        acc.sourceFrames.push(acc.sourceFrames[acc.sourceFrames.length - 1])
+      }
+      acc.sourceFrames.push(v.sourceFrame)
+      acc.lastFrame = frame
+    }
+
+    for (const a of scene.audios) {
+      const acc = audios.get(a.id)
+      if (!acc) {
+        audios.set(a.id, {
+          source: options.resolveSource(a.src),
+          firstFrame: frame,
+          lastFrame: frame,
+          sourceStartFrame: a.sourceFrame,
+          volume: a.volume,
+        })
+        continue
+      }
+      acc.lastFrame = frame
+    }
+
+    for (const img of scene.images) {
+      if (seenImages.has(img.src)) continue
+      seenImages.add(img.src)
+      imageSources.push({ src: img.src, source: options.resolveSource(img.src) })
+    }
+
+    for (const txt of scene.texts) {
+      if (!txt.fontFamily || seenFonts.has(txt.fontFamily)) continue
+      seenFonts.add(txt.fontFamily)
+      fontFamilies.push(txt.fontFamily)
+    }
+  }
+
+  const videoPlans: VideoClipPlan[] = []
+  for (const [clipId, acc] of videos) {
+    assertNonDecreasing(clipId, acc.sourceFrames)
+    videoPlans.push({
+      clipId,
+      source: acc.source,
+      firstFrame: acc.firstFrame,
+      lastFrame: acc.lastFrame,
+      sourceFrames: Int32Array.from(acc.sourceFrames),
+    })
+  }
+
+  const audioPlans: AudioClipPlan[] = []
+  for (const [clipId, acc] of audios) {
+    audioPlans.push({
+      clipId,
+      source: acc.source,
+      startFrame: acc.firstFrame,
+      frameCount: acc.lastFrame - acc.firstFrame + 1,
+      sourceStartFrame: acc.sourceStartFrame,
+      volume: acc.volume,
+    })
+  }
+
+  return {
+    fps,
+    stage,
+    totalFrames,
+    videos: videoPlans,
+    audios: audioPlans,
+    imageSources,
+    fontFamilies,
+  }
+}
+
+/**
+ * Guards the decoder's monotonic cursor: it is only ever safe to hold or
+ * advance, never to seek backwards. `sourceFrames` is non-decreasing by
+ * construction — the resolver's transition clamps (resolveTimeline.ts:288-298,
+ * `Math.min(..., sourceDurationFrames - 1)` / `Math.max(0, ...)`) only ever
+ * flatten the ramp, and the gap-fill above only ever repeats the previous
+ * value. If this ever fails it means the resolver produced a decreasing
+ * `sourceFrame` for a clip, which would otherwise silently corrupt export by
+ * seeking a per-clip ffmpeg process backwards.
+ */
+function assertNonDecreasing(clipId: string, sourceFrames: number[]): void {
+  for (let i = 1; i < sourceFrames.length; i++) {
+    if (sourceFrames[i] < sourceFrames[i - 1]) {
+      throw new ExportServerError(
+        'PLAN_INVALID',
+        `clip "${clipId}": sourceFrames must be non-decreasing, got ${sourceFrames[i - 1]} -> ${sourceFrames[i]} at frame offset ${i}`,
+      )
+    }
+  }
+}
+
+/**
+ * The frame-accuracy kernel. Maps each export frame's `sourceFrame` (project-fps
+ * units) to a source presentation-frame index, using the same rule mediabunny's
+ * CanvasSink uses: the last frame whose PTS is <= the target timestamp.
+ * Returns -1 for targets that fall before the source's first timestamp
+ * (CanvasSink returns null there; the compositor draws nothing).
+ *
+ * `timestamps` is the presentation-timestamp index built in probe.ts (see
+ * {@link VideoFrameIndex}) — ascending seconds, one per source video frame.
+ *
+ * Implemented as a monotonic cursor rather than a per-frame binary search:
+ * `sourceFrames` is non-decreasing (planExport asserts it), so the targets
+ * derived from it are non-decreasing too, and the whole mapping is O(N + M)
+ * instead of O(N log M).
+ */
+export function mapSourceFramesToIndices(
+  sourceFrames: Int32Array,
+  fps: number,
+  timestamps: Float64Array,
+): Int32Array {
+  const out = new Int32Array(sourceFrames.length)
+  if (timestamps.length === 0) return out.fill(-1)
+
+  let k = 0
+  for (let j = 0; j < sourceFrames.length; j++) {
+    // Verbatim from ExportWorker.ts:280-282: the +0.5 midpoint matches the
+    // preview's Math.round(PTS / usPerFrame) convention, and dividing by the
+    // PROJECT fps (never the source fps) is what makes `sourceFrame` — a
+    // project-frame quantity — land on the right source frame.
+    const target = (sourceFrames[j] + 0.5) / fps
+    while (k + 1 < timestamps.length && timestamps[k + 1] <= target) k++
+    out[j] = target < timestamps[0] ? -1 : k
+  }
+  return out
+}

--- a/packages/export-server/src/probe.ts
+++ b/packages/export-server/src/probe.ts
@@ -1,0 +1,197 @@
+/**
+ * All mediabunny usage in this package lives here: probing, presentation-
+ * timestamp index construction, and post-export output validation. mediabunny
+ * is a pure-JS demuxer/index reader in this module — it never decodes or
+ * encodes a single sample. Decode is ffmpeg's job (decoder.ts); encode is
+ * ffmpeg's job too (encoder.ts).
+ *
+ * `probeMedia` is a direct port of packages/cli/src/lib/probe.ts:15, adapted
+ * to throw ExportServerError instead of CliError. Everything else here exists
+ * to build `buildVideoFrameIndex`'s presentation-timestamp index, which is
+ * what lets ffmpeg decode frame-accurately: see decoder.ts / plan.ts for how
+ * targets are computed against it (ExportWorker.ts:277-287 is the browser
+ * exporter's equivalent — it feeds mediabunny's own CanvasSink the same
+ * per-frame source timestamps we compute here for ffmpeg).
+ */
+
+import { ExportServerError } from './errors'
+
+import type { Input, InputVideoTrack } from 'mediabunny'
+import type { MediaInfo, VideoSourceInfo, VideoFrameIndex, OutputValidation } from './types'
+
+/** True for http(s) sources, which mediabunny reads via ranged UrlSource requests. */
+function isRemoteUrl(source: string): boolean {
+  return /^https?:\/\//.test(source)
+}
+
+/** Opens an `Input` over a local path or remote URL. Caller owns `.dispose()`. */
+async function openInput(source: string): Promise<Input> {
+  const mb = await import('mediabunny')
+  return new mb.Input({
+    formats: mb.ALL_FORMATS,
+    source: isRemoteUrl(source) ? new mb.UrlSource(source) : new mb.FilePathSource(source),
+  })
+}
+
+/**
+ * The duration + dimension + frame-rate facts every other function in this
+ * module needs about a video track. Factored out because `probeVideoSource`
+ * and `buildVideoFrameIndex` both need it (the index embeds a `VideoSourceInfo`).
+ */
+async function readVideoSourceInfo(track: InputVideoTrack): Promise<VideoSourceInfo> {
+  const [durationSec, displayWidth, displayHeight, codedWidth, codedHeight, stats] = await Promise.all([
+    track.computeDuration(),
+    track.getDisplayWidth(),
+    track.getDisplayHeight(),
+    track.getCodedWidth(),
+    track.getCodedHeight(),
+    track.computePacketStats(),
+  ])
+  return {
+    durationSec,
+    displayWidth,
+    displayHeight,
+    codedWidth,
+    codedHeight,
+    averageFrameRate: stats.averagePacketRate,
+  }
+}
+
+/**
+ * Synthesizes a constant-frame-rate presentation-timestamp index when the
+ * container yields no usable packet timestamps (rare; some live/fragmented
+ * inputs). `exact: false` tells callers (exportProject) to push a warning
+ * rather than silently trusting fabricated timestamps.
+ *
+ * When rate or duration can't be established either, an empty index is the
+ * honest answer: every target timestamp maps to -1 (nothing decoded) rather
+ * than a guessed frame count.
+ */
+function synthesizeCfrIndex(info: VideoSourceInfo): Float64Array {
+  const rate = info.averageFrameRate
+  if (!(rate > 0) || !(info.durationSec > 0)) return new Float64Array(0)
+  const frameCount = Math.max(1, Math.round(info.durationSec * rate))
+  const timestamps = new Float64Array(frameCount)
+  for (let i = 0; i < frameCount; i++) timestamps[i] = i / rate
+  return timestamps
+}
+
+/** Port of packages/cli/src/lib/probe.ts:15 — duration + coded dimensions. */
+export async function probeMedia(source: string): Promise<MediaInfo> {
+  let input: Input | undefined
+  try {
+    input = await openInput(source)
+    const durationSec = await input.computeDuration()
+    const video = await input.getPrimaryVideoTrack()
+    return {
+      durationSec,
+      width: video ? await video.getCodedWidth() : undefined,
+      height: video ? await video.getCodedHeight() : undefined,
+    }
+  } catch (err) {
+    throw new ExportServerError('PROBE_FAILED', `Cannot probe media '${source}': ${(err as Error).message}`)
+  } finally {
+    input?.dispose?.()
+  }
+}
+
+/** Duration + display (post-rotation, PAR-corrected) dimensions + average frame rate. */
+export async function probeVideoSource(source: string): Promise<VideoSourceInfo> {
+  let input: Input | undefined
+  try {
+    input = await openInput(source)
+    const track = await input.getPrimaryVideoTrack()
+    if (!track) throw new Error('source has no video track')
+    return await readVideoSourceInfo(track)
+  } catch (err) {
+    throw new ExportServerError(
+      'PROBE_FAILED',
+      `Cannot probe video source '${source}': ${(err as Error).message}`,
+    )
+  } finally {
+    input?.dispose?.()
+  }
+}
+
+/**
+ * Full presentation-timestamp index of the source's primary video track,
+ * ascending. Built from metadata-only packets — no sample data is read and
+ * nothing is decoded.
+ *
+ * `packets()` yields in *decode* order; the cursor walk in decoder.ts needs
+ * *presentation* order, so the collected timestamps are sorted before return.
+ * This is the one line that makes B-frame sources (decode order !=
+ * presentation order) safe to drive with a monotonic cursor.
+ */
+export async function buildVideoFrameIndex(source: string): Promise<VideoFrameIndex> {
+  let input: Input | undefined
+  try {
+    input = await openInput(source)
+    const track = await input.getPrimaryVideoTrack()
+    if (!track) throw new Error('source has no video track')
+
+    const info = await readVideoSourceInfo(track)
+
+    const mb = await import('mediabunny')
+    const sink = new mb.EncodedPacketSink(track)
+    const ts: number[] = []
+    for await (const packet of sink.packets(undefined, undefined, { metadataOnly: true })) {
+      ts.push(packet.timestamp)
+    }
+
+    if (ts.length === 0) {
+      return { ...info, timestamps: synthesizeCfrIndex(info), exact: false }
+    }
+
+    ts.sort((a, b) => a - b)
+    return { ...info, timestamps: Float64Array.from(ts), exact: true }
+  } catch (err) {
+    throw new ExportServerError(
+      'PROBE_FAILED',
+      `Cannot build frame index for '${source}': ${(err as Error).message}`,
+    )
+  } finally {
+    input?.dispose?.()
+  }
+}
+
+/**
+ * Re-opens the finished MP4 and reports what actually landed in it. Never
+ * throws on a content mismatch (missing audio, short frame count, etc.) —
+ * those are policy decisions for exportProject, which fails the export only
+ * when there is no video track at all. This function only throws if the file
+ * itself can't be opened/read.
+ */
+export async function validateOutputFile(path: string): Promise<OutputValidation> {
+  let input: Input | undefined
+  try {
+    input = await openInput(path)
+    const [durationSec, videoTrack, audioTrack] = await Promise.all([
+      input.computeDuration(),
+      input.getPrimaryVideoTrack(),
+      input.getPrimaryAudioTrack(),
+    ])
+
+    if (!videoTrack) {
+      return { durationSec, frameCount: null, width: 0, height: 0, hasAudioTrack: !!audioTrack }
+    }
+
+    const [width, height, stats] = await Promise.all([
+      videoTrack.getDisplayWidth(),
+      videoTrack.getDisplayHeight(),
+      videoTrack.computePacketStats(),
+    ])
+
+    return {
+      durationSec,
+      frameCount: stats.packetCount,
+      width,
+      height,
+      hasAudioTrack: !!audioTrack,
+    }
+  } catch (err) {
+    throw new ExportServerError('PROBE_FAILED', `Cannot validate output '${path}': ${(err as Error).message}`)
+  } finally {
+    input?.dispose?.()
+  }
+}

--- a/packages/export-server/src/render/__tests__/fonts.test.ts
+++ b/packages/export-server/src/render/__tests__/fonts.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// `@napi-rs/canvas` ships prebuilt native binaries; mocking it here keeps this
+// suite exercising pure substitution logic without depending on the package
+// being installed or on real font files existing on the test host.
+const registerFromPath = vi.fn((_path: string, _family?: string) => true)
+vi.mock('@napi-rs/canvas', () => ({
+  GlobalFonts: {
+    registerFromPath: (path: string, family?: string) => registerFromPath(path, family),
+    families: [] as Array<{ family: string }>,
+  },
+}))
+
+const { createFontRegistry } = await import('../fonts')
+
+beforeEach(() => {
+  registerFromPath.mockReset()
+  registerFromPath.mockReturnValue(true)
+})
+
+describe('createFontRegistry / substitute', () => {
+  it('substitutes an unknown family with something non-empty and records it as missing', () => {
+    const registry = createFontRegistry({ availableFamilies: ['Arial'] })
+    const result = registry.substitute('Definitely Not A Font')
+    expect(result.length).toBeGreaterThan(0)
+    expect(registry.missing).toContain('Definitely Not A Font')
+  })
+
+  it('picks the first available member of a CSS font stack', () => {
+    const registry = createFontRegistry({ availableFamilies: ['Bar', 'Baz'] })
+    expect(registry.substitute('Foo, Bar, Baz')).toBe('Bar')
+    expect(registry.missing).toEqual([])
+  })
+
+  it('trims whitespace and quotes from stack entries', () => {
+    const registry = createFontRegistry({ availableFamilies: ['Inter'] })
+    expect(registry.substitute(`"Foo",  'Inter' `)).toBe('Inter')
+  })
+
+  it('an explicit fallbackFamily wins over the first registered/available family', () => {
+    const registry = createFontRegistry({
+      fallbackFamily: 'Roboto',
+      availableFamilies: ['Roboto', 'Arial'],
+    })
+    expect(registry.substitute('Unknown Family')).toBe('Roboto')
+  })
+
+  it('ignores fallbackFamily if it is not itself available', () => {
+    const registry = createFontRegistry({
+      fallbackFamily: 'Not Installed',
+      availableFamilies: ['Arial'],
+    })
+    expect(registry.substitute('Unknown Family')).toBe('Arial')
+  })
+
+  it('returns a known family unchanged', () => {
+    const registry = createFontRegistry({ availableFamilies: ['Arial', 'Roboto'] })
+    expect(registry.substitute('Roboto')).toBe('Roboto')
+    expect(registry.missing).toEqual([])
+  })
+
+  it('treats undefined as the sans-serif default and substitutes it', () => {
+    const registry = createFontRegistry({ availableFamilies: ['Arial'] })
+    expect(registry.substitute(undefined)).toBe('Arial')
+    expect(registry.missing).toContain('sans-serif')
+  })
+
+  it('treats CSS generics as unresolved even without a fallbackFamily', () => {
+    const registry = createFontRegistry({ availableFamilies: ['Arial'] })
+    expect(registry.substitute('monospace')).toBe('Arial')
+    expect(registry.missing).toContain('monospace')
+  })
+
+  it('dedupes repeated misses of the same family', () => {
+    const registry = createFontRegistry({ availableFamilies: ['Arial'] })
+    registry.substitute('Ghost Font')
+    registry.substitute('Ghost Font')
+    expect(registry.missing).toEqual(['Ghost Font'])
+  })
+
+  it('falls back to the first registered font when no fallbackFamily is set', () => {
+    const registry = createFontRegistry({
+      fonts: [{ path: '/fonts/brand.ttf', family: 'Brand Sans' }],
+      availableFamilies: ['Brand Sans'],
+    })
+    expect(registry.substitute('Unknown')).toBe('Brand Sans')
+  })
+
+  it('falls back to the literal sans-serif default when nothing is available at all', () => {
+    const registry = createFontRegistry({ availableFamilies: [] })
+    expect(registry.substitute('Unknown')).toBe('sans-serif')
+  })
+
+  it('exposes the available family list verbatim', () => {
+    const registry = createFontRegistry({ availableFamilies: ['Arial', 'Roboto'] })
+    expect(registry.available).toEqual(['Arial', 'Roboto'])
+  })
+})
+
+describe('createFontRegistry / registration', () => {
+  it('registers each FontSpec via GlobalFonts.registerFromPath', () => {
+    createFontRegistry({
+      fonts: [{ path: '/fonts/a.ttf', family: 'A' }, { path: '/fonts/b.ttf' }],
+      availableFamilies: [],
+    })
+    expect(registerFromPath).toHaveBeenCalledTimes(2)
+    expect(registerFromPath).toHaveBeenNthCalledWith(1, '/fonts/a.ttf', 'A')
+    expect(registerFromPath).toHaveBeenNthCalledWith(2, '/fonts/b.ttf', undefined)
+  })
+
+  it('throws ExportServerError(FONT_LOAD_FAILED) naming the path when registration returns false', async () => {
+    registerFromPath.mockReturnValueOnce(false)
+    const { ExportServerError } = await import('../../errors')
+    expect(() =>
+      createFontRegistry({ fonts: [{ path: '/fonts/broken.ttf', family: 'Broken' }] }),
+    ).toThrow(ExportServerError)
+    try {
+      createFontRegistry({ fonts: [{ path: '/fonts/broken.ttf', family: 'Broken' }] })
+    } catch (err) {
+      expect((err as InstanceType<typeof ExportServerError>).message).toContain('/fonts/broken.ttf')
+    }
+  })
+
+  it('throws ExportServerError(FONT_LOAD_FAILED) naming the path when registration throws', async () => {
+    registerFromPath.mockImplementationOnce(() => {
+      throw new Error('bad font file')
+    })
+    const { ExportServerError } = await import('../../errors')
+    expect(() => createFontRegistry({ fonts: [{ path: '/fonts/corrupt.ttf' }] })).toThrow(ExportServerError)
+  })
+})

--- a/packages/export-server/src/render/__tests__/frame.test.ts
+++ b/packages/export-server/src/render/__tests__/frame.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it } from 'vitest'
+import { createCanvas } from '@napi-rs/canvas'
+import { computeTextLayout, type Scene, type ActiveTransition } from '@elah/core'
+
+import { FrameCompositor, type FrameSources } from '../frame'
+import type { FontRegistry } from '../fonts'
+import type { DecodedFrame } from '../../types'
+
+/** A FontRegistry stand-in — this suite never registers a real font file. */
+function fakeFonts(): FontRegistry {
+  return {
+    substitute: family => family ?? 'sans-serif',
+    missing: [],
+    available: ['sans-serif'],
+  }
+}
+
+function emptySources(): FrameSources {
+  return { video: new Map(), images: new Map() }
+}
+
+/** Base fields every ActiveClip needs, so each test only spells out what it varies. */
+function clipBase(id: string, zIndex: number) {
+  return { id, trackId: 't', name: id, sourceFrame: 0, opacity: 1, zIndex }
+}
+
+function baseScene(overrides: Partial<Scene>): Scene {
+  return {
+    frame: 0,
+    fps: 30,
+    stage: { width: 200, height: 100 },
+    videos: [],
+    audios: [],
+    texts: [],
+    images: [],
+    shapes: [],
+    freehand: [],
+    transitions: [],
+    ...overrides,
+  }
+}
+
+function pixelAt(data: Uint8ClampedArray, width: number, x: number, y: number): [number, number, number, number] {
+  const i = (y * width + x) * 4
+  return [data[i], data[i + 1], data[i + 2], data[i + 3]]
+}
+
+function solidFrame(size: number, r: number, g: number, b: number): DecodedFrame {
+  const data = new Uint8ClampedArray(size * size * 4)
+  for (let i = 0; i < size * size; i++) {
+    data[i * 4] = r
+    data[i * 4 + 1] = g
+    data[i * 4 + 2] = b
+    data[i * 4 + 3] = 255
+  }
+  return { data, width: size, height: size, displayWidth: size, displayHeight: size }
+}
+
+describe('FrameCompositor', () => {
+  it('draws a shape and a text clip, leaving the rest of the stage as the opaque black background', () => {
+    const width = 200
+    const height = 100
+    const compositor = new FrameCompositor({ width, height, fonts: fakeFonts() })
+
+    const scene = baseScene({
+      stage: { width, height },
+      shapes: [
+        {
+          ...clipBase('shape-1', 0),
+          type: 'shape',
+          shapeKind: 'rect',
+          shapeFill: '#ff0000',
+          shapeStroke: '#000000',
+          shapeStrokeWidth: 0,
+          transform: { x: 0.15, y: 0.5, scale: 0.2, rotation: 0, anchor: { x: 0.5, y: 0.5 } },
+        },
+      ],
+      texts: [
+        {
+          ...clipBase('text-1', 1),
+          type: 'text',
+          content: 'Hi',
+          color: '#00ff00',
+          fontSize: 40,
+        },
+      ],
+    })
+
+    const pixels = compositor.render(scene, emptySources())
+
+    // Shape: center (0.15,0.5) on a 200x100 stage -> (30,50); shortSide=100,
+    // scale=0.2 -> half=10, so the filled square spans (20,40)-(40,60).
+    expect(pixelAt(pixels, width, 30, 50)).toEqual([255, 0, 0, 255])
+
+    // Text: reuse computeTextLayout (the same function the compositor calls)
+    // to find the glyph bounding box instead of hard-coding pixel metrics that
+    // depend on the host's font rasterizer.
+    const measureCanvas = createCanvas(1, 1)
+    const layout = computeTextLayout(
+      measureCanvas.getContext('2d') as unknown as Pick<CanvasRenderingContext2D, 'font' | 'measureText'>,
+      { content: 'Hi', transform: undefined, fontSize: 40 },
+      { width, height },
+    )
+    let foundGreen = false
+    const x0 = Math.max(0, Math.floor(layout.box.x))
+    const x1 = Math.min(width - 1, Math.ceil(layout.box.x + layout.box.width))
+    const y0 = Math.max(0, Math.floor(layout.box.y))
+    const y1 = Math.min(height - 1, Math.ceil(layout.box.y + layout.box.height))
+    for (let y = y0; y <= y1 && !foundGreen; y++) {
+      for (let x = x0; x <= x1; x++) {
+        const [r, g, b] = pixelAt(pixels, width, x, y)
+        if (g > 100 && r < 100 && b < 100) {
+          foundGreen = true
+          break
+        }
+      }
+    }
+    expect(foundGreen).toBe(true)
+
+    // Far corner untouched by either clip stays the opaque black background.
+    expect(pixelAt(pixels, width, width - 1, height - 1)).toEqual([0, 0, 0, 255])
+  })
+
+  it('draws the higher zIndex shape on top when two shapes fully overlap', () => {
+    const width = 100
+    const height = 100
+    const compositor = new FrameCompositor({ width, height, fonts: fakeFonts() })
+
+    const transform = { x: 0.5, y: 0.5, scale: 0.6, rotation: 0, anchor: { x: 0.5, y: 0.5 } }
+    const scene = baseScene({
+      stage: { width, height },
+      shapes: [
+        // Listed out of zIndex order on purpose — the compositor must sort, not
+        // trust array order.
+        {
+          ...clipBase('blue-on-top', 1),
+          type: 'shape',
+          shapeKind: 'rect',
+          shapeFill: '#0000ff',
+          shapeStroke: '#000000',
+          shapeStrokeWidth: 0,
+          transform,
+        },
+        {
+          ...clipBase('red-underneath', 0),
+          type: 'shape',
+          shapeKind: 'rect',
+          shapeFill: '#ff0000',
+          shapeStroke: '#000000',
+          shapeStrokeWidth: 0,
+          transform,
+        },
+      ],
+    })
+
+    const pixels = compositor.render(scene, emptySources())
+    expect(pixelAt(pixels, width, 50, 50)).toEqual([0, 0, 255, 255])
+  })
+
+  it('freezes a video transition snapshot on its first frame and releases it once the transition ends', () => {
+    const width = 4
+    const height = 4
+    const compositor = new FrameCompositor({ width, height, fonts: fakeFonts() })
+
+    const videoClip = {
+      ...clipBase('v1', 0),
+      type: 'video' as const,
+      src: 'v1.mp4',
+      volume: 1,
+      opacity: 0, // resolver convention: outgoing clip is invisible, snapshot carries it
+    }
+
+    const transition: ActiveTransition = {
+      id: 't1',
+      kind: 'fade',
+      t: 0, // alpha = 1 - t = 1, fully opaque snapshot
+      fromClipId: 'v1',
+      toClipId: 'v2',
+    }
+
+    // Frame A: transition starts. The decoded frame is solid red — expect it
+    // to be captured and painted.
+    const frameA = baseScene({
+      stage: { width, height },
+      videos: [videoClip],
+      transitions: [transition],
+    })
+    const pixelsA = compositor.render(frameA, {
+      video: new Map([['v1', solidFrame(width, 255, 0, 0)]]),
+      images: new Map(),
+    })
+    expect(pixelAt(pixelsA, width, 1, 1)).toEqual([255, 0, 0, 255])
+
+    // Frame B: same transition still active, but the decoder has moved on to a
+    // different (green) source frame. The snapshot must stay frozen at red —
+    // it is captured once, not every frame.
+    const frameB = baseScene({
+      stage: { width, height },
+      videos: [videoClip],
+      transitions: [transition],
+    })
+    const pixelsB = compositor.render(frameB, {
+      video: new Map([['v1', solidFrame(width, 0, 255, 0)]]),
+      images: new Map(),
+    })
+    expect(pixelAt(pixelsB, width, 1, 1)).toEqual([255, 0, 0, 255])
+
+    // Frame C: the transition has ended (no longer in scene.transitions) — its
+    // snapshot must be released.
+    const frameC = baseScene({ stage: { width, height }, videos: [videoClip] })
+    compositor.render(frameC, { video: new Map([['v1', solidFrame(width, 0, 255, 0)]]), images: new Map() })
+
+    // Frame D: the same transition id reappears with a fresh (blue) source
+    // frame. If the frame-B snapshot had leaked past release, this would still
+    // read back red; a proper release lets it capture blue instead.
+    const frameD = baseScene({
+      stage: { width, height },
+      videos: [videoClip],
+      transitions: [transition],
+    })
+    const pixelsD = compositor.render(frameD, {
+      video: new Map([['v1', solidFrame(width, 0, 0, 255)]]),
+      images: new Map(),
+    })
+    expect(pixelAt(pixelsD, width, 1, 1)).toEqual([0, 0, 255, 255])
+
+    compositor.dispose()
+  })
+})

--- a/packages/export-server/src/render/fonts.ts
+++ b/packages/export-server/src/render/fonts.ts
@@ -1,0 +1,161 @@
+/**
+ * Font registration and family substitution.
+ *
+ * Node/Skia has no browser font stack: `@napi-rs/canvas` will happily accept
+ * `'sans-serif'` as a font name and then silently draw nothing (or fall back
+ * to whatever the OS's default happens to be), because there is no browser
+ * user-agent stylesheet mapping CSS generics to installed fonts. Text clips
+ * carry whatever `fontFamily` the editor stored — often a raw CSS stack like
+ * `'Inter, sans-serif'` — so every family requested by a Scene has to be
+ * resolved to one Skia actually knows about before `computeTextLayout` (core,
+ * unmodified) measures it and the compositor draws it. That resolution is
+ * this module's entire job; it registers nothing on its own initiative and
+ * changes no core code — it only sits between a Scene's text elements and the
+ * canvas font name that gets asked for.
+ */
+
+import { GlobalFonts } from '@napi-rs/canvas'
+
+import type { FontSpec } from '../types'
+import { ExportServerError } from '../errors'
+
+/**
+ * CSS generic families. These are never real installed-font names, so an
+ * exact-match lookup against `available` would only succeed by accident (a
+ * font literally named "serif"), which is not a case worth trusting — treat
+ * every one of them as unresolved and route through the fallback.
+ */
+const GENERIC_FAMILIES = new Set(['sans-serif', 'serif', 'monospace', 'system-ui', 'cursive', 'fantasy'])
+
+/**
+ * The default `computeTextLayout` (packages/core/src/renderer/gpu/layers/textLayout.ts)
+ * applies when a text clip omits `fontFamily`. Not imported from core — core
+ * has zero dependents in this package's module graph by design (Scene-only
+ * rule) — so this is intentionally the same literal, not a re-export.
+ */
+const DEFAULT_FONT_FAMILY = 'sans-serif'
+
+export interface FontRegistryOptions {
+  fonts?: FontSpec[]
+  /** Family used whenever a requested family cannot be resolved. */
+  fallbackFamily?: string
+  /**
+   * Families to treat as already available, bypassing `GlobalFonts.families`.
+   * Exists so `substitute`'s logic is unit-testable without a real font file
+   * or a populated (and host-dependent) system font registry. Defaults to
+   * `GlobalFonts.families` mapped to family names.
+   */
+  availableFamilies?: string[]
+}
+
+export interface FontRegistry {
+  /** The family Skia should actually be asked for. Never returns undefined. */
+  substitute(family: string | undefined): string
+  /** Requested families that had to be substituted — surfaced as ExportResult.warnings. */
+  readonly missing: readonly string[]
+  /** Families Skia currently knows about (registered + system). */
+  readonly available: readonly string[]
+}
+
+/** Strips a stack entry's surrounding whitespace and wrapping quotes: `' "Inter"'` -> `'Inter'`. */
+function cleanFamilyName(raw: string): string {
+  return raw.trim().replace(/^['"]|['"]$/g, '')
+}
+
+/**
+ * Registers every `FontSpec` with Skia's process-global font registry, then
+ * returns a resolver that maps any family a text clip might request onto one
+ * Skia can actually render.
+ *
+ * Registration happens eagerly, in `fonts` order, and fails loudly: a font
+ * path that doesn't load is `ExportServerError('FONT_LOAD_FAILED', ...)`
+ * naming the path, never a silent skip. A font that quietly failed to
+ * register would make every clip using it fall back to some other family
+ * with no error and no warning — a silently wrong export, which is strictly
+ * worse than a failed one.
+ */
+export function createFontRegistry(options: FontRegistryOptions): FontRegistry {
+  const { fonts = [], fallbackFamily, availableFamilies } = options
+
+  const registeredFamilies: string[] = []
+  for (const spec of fonts) {
+    let ok: boolean
+    try {
+      // registerFromPath returns a FontKey on success, null on failure — never
+      // a boolean. `!!` turns "was a key returned" into the yes/no this loop
+      // actually needs.
+      ok = !!GlobalFonts.registerFromPath(spec.path, spec.family)
+    } catch (err) {
+      throw new ExportServerError(
+        'FONT_LOAD_FAILED',
+        `Failed to register font at '${spec.path}'` +
+          `${spec.family ? ` as '${spec.family}'` : ''}: ${(err as Error).message}`,
+      )
+    }
+    if (!ok) {
+      throw new ExportServerError(
+        'FONT_LOAD_FAILED',
+        `Failed to register font at '${spec.path}'` +
+          `${spec.family ? ` as '${spec.family}'` : ''} — @napi-rs/canvas rejected the file.`,
+      )
+    }
+    if (spec.family) registeredFamilies.push(spec.family)
+  }
+
+  const available: string[] =
+    availableFamilies ?? GlobalFonts.families.map((entry: { family: string }) => entry.family)
+  const availableLower = new Set(available.map((family: string) => family.toLowerCase()))
+  const missing = new Set<string>()
+
+  function isKnown(family: string): boolean {
+    return availableLower.has(family.toLowerCase())
+  }
+
+  /**
+   * `fallbackFamily` if it was given and is actually available, else the
+   * first font this registry registered, else the first family Skia (or the
+   * injected list) reports, else the literal CSS default — that last case
+   * only fires when nothing was registered and `available` is empty, i.e. a
+   * misconfigured host with no system fonts at all.
+   */
+  function resolveFallback(): string {
+    if (fallbackFamily && isKnown(fallbackFamily)) return fallbackFamily
+    if (registeredFamilies.length > 0) return registeredFamilies[0]
+    if (available.length > 0) return available[0]
+    return DEFAULT_FONT_FAMILY
+  }
+
+  function substitute(family: string | undefined): string {
+    const requested = family ?? DEFAULT_FONT_FAMILY
+
+    // A CSS font stack ('Inter, sans-serif') and a single family both flow
+    // through this same loop — a bare family is just a one-entry stack.
+    const stack = requested
+      .split(',')
+      .map(cleanFamilyName)
+      .filter(entry => entry.length > 0)
+    const candidates = stack.length > 0 ? stack : [requested]
+
+    for (const candidate of candidates) {
+      if (!GENERIC_FAMILIES.has(candidate.toLowerCase()) && isKnown(candidate)) {
+        return candidate
+      }
+    }
+
+    // Nothing in the stack resolved: record the request as given (not the
+    // cleaned/split form) so warnings read back the same string the caller
+    // saw on the Scene's text element, then fall back.
+    missing.add(requested)
+    return resolveFallback()
+  }
+
+  return {
+    substitute,
+    get missing() {
+      return Array.from(missing)
+    },
+    get available() {
+      return available
+    },
+  }
+}

--- a/packages/export-server/src/render/frame.ts
+++ b/packages/export-server/src/render/frame.ts
@@ -1,0 +1,365 @@
+/**
+ * FrameCompositor — the compositor stage of the ffmpeg export pipeline.
+ *
+ * A line-by-line port of packages/core/src/export/ExportWorker.ts's
+ * renderFrame/drawMedia/drawText/drawShape/drawFreehand and its transition
+ * snapshot pass (:427-658, :300-301, :331-345, :350-357) from OffscreenCanvas
+ * 2D to `@napi-rs/canvas`. Same draw order, same defaults, same z-sort — only
+ * the canvas backend changed. This class reads ONLY the `Scene` (plus the
+ * already-decoded frames/images handed to it by other modules in this
+ * package), never `Project`/`Clip`, per the package's governing rule
+ * (see types.ts).
+ *
+ * The browser version's `xlog`/`isDebugFrame` tracing is intentionally
+ * dropped — it does not belong in this package.
+ */
+
+import {
+  resolveDrawRect,
+  computeTextLayout,
+  type Scene,
+  type Transform,
+  type ActiveVideoClip,
+  type ActiveImageClip,
+  type ActiveTextClip,
+  type ActiveShapeClip,
+  type ActiveFreehandClip,
+} from '@elah/core'
+import { createCanvas, ImageData, Path2D } from '@napi-rs/canvas'
+import type { Canvas, SKRSContext2D, Image } from '@napi-rs/canvas'
+
+import type { DecodedFrame } from '../types'
+import type { FontRegistry } from './fonts'
+
+/**
+ * The subset of a 2D context `computeTextLayout` needs — mirrors core's own
+ * (unexported) `TextMeasurer` type exactly. `@napi-rs/canvas`'s `SKRSContext2D`
+ * implements `font`/`measureText` but is not nominally assignable to
+ * `Pick<CanvasRenderingContext2D, 'font' | 'measureText'>`, so callers cast
+ * through this type at the one call site that needs it (see `drawText`).
+ */
+type TextMeasurer = Pick<CanvasRenderingContext2D, 'font' | 'measureText'>
+
+/** Anything the `drawImage` port can place on stage: a loaded image or a scratch canvas. */
+type DrawSource = Canvas | Image
+
+export interface FrameSources {
+  /** Decoded video frame per clip id; null when the decoder had nothing for this frame. */
+  video: ReadonlyMap<string, DecodedFrame | null>
+  /**
+   * Loaded image per RAW Scene src (`ActiveImageClip.src`) — this class never
+   * sees a resolved path/URL, so the map must be keyed by what it actually
+   * looks clips up by. `exportProject` loads each image via the resolved
+   * `plan.imageSources[].source` but keys this map by `.src`.
+   */
+  images: ReadonlyMap<string, Image>
+}
+
+export interface FrameCompositorInit {
+  width: number
+  height: number
+  fonts: FontRegistry
+}
+
+/** One persistent scratch canvas a clip's decoded frame is copied into before `drawImage`. */
+interface ScratchSurface {
+  canvas: Canvas
+  ctx: SKRSContext2D
+}
+
+/**
+ * A frozen bitmap of an outgoing clip, held for the duration of a transition.
+ * `owned` mirrors the browser version's `ImageBitmap.close()` bookkeeping:
+ * `true` for a snapshot canvas this class allocated (a copied video frame,
+ * released when the transition ends), `false` for a loaded `Image` that
+ * `FrameSources.images` still owns and this class must not touch further than
+ * holding a reference to it.
+ */
+interface SnapshotEntry {
+  source: DrawSource
+  owned: boolean
+  /** True display dims for placement — never the (possibly downscaled) canvas dims. */
+  displayWidth: number
+  displayHeight: number
+}
+
+type AnyItem =
+  | { kind: 'video'; item: ActiveVideoClip }
+  | { kind: 'image'; item: ActiveImageClip }
+  | { kind: 'text'; item: ActiveTextClip }
+  | { kind: 'shape'; item: ActiveShapeClip }
+  | { kind: 'freehand'; item: ActiveFreehandClip }
+
+export class FrameCompositor {
+  private readonly width: number
+  private readonly height: number
+  private readonly fonts: FontRegistry
+  private readonly canvas: Canvas
+  private readonly ctx: SKRSContext2D
+
+  /** Per-clip-id scratch canvas a decoded video frame's raw bytes are copied into. */
+  private readonly scratch = new Map<string, ScratchSurface>()
+  /** Per-transition-id frozen snapshot of the outgoing clip. */
+  private readonly snapshots = new Map<string, SnapshotEntry>()
+
+  constructor(init: FrameCompositorInit) {
+    this.width = init.width
+    this.height = init.height
+    this.fonts = init.fonts
+    this.canvas = createCanvas(init.width, init.height)
+    this.ctx = this.canvas.getContext('2d')
+  }
+
+  /**
+   * Draws one Scene and returns the stage's RGBA pixels.
+   * The returned array is a view into this class's own canvas buffer and is
+   * reused across calls — hand it to the encoder immediately, never retain it.
+   */
+  render(scene: Scene, sources: FrameSources): Uint8ClampedArray {
+    const { ctx, width, height } = this
+
+    // Opaque black background (ExportWorker.ts:449-451) — every exported frame
+    // is fully opaque, which is what makes the getImageData readback below
+    // safe regardless of premultiplied-vs-straight alpha.
+    ctx.clearRect(0, 0, width, height)
+    ctx.fillStyle = '#000'
+    ctx.fillRect(0, 0, width, height)
+
+    // Capture a snapshot of each transition's outgoing clip on its first
+    // frame. The frame/image is already decoded/loaded in `sources` — no
+    // extra seek or decode needed (ExportWorker.ts:329-345).
+    this.captureSnapshots(scene, sources)
+
+    const items: AnyItem[] = [
+      ...scene.videos.map(item => ({ kind: 'video' as const, item })),
+      ...scene.images.map(item => ({ kind: 'image' as const, item })),
+      ...scene.texts.map(item => ({ kind: 'text' as const, item })),
+      ...scene.shapes.map(item => ({ kind: 'shape' as const, item })),
+      ...scene.freehand.map(item => ({ kind: 'freehand' as const, item })),
+    ].sort((a, b) => a.item.zIndex - b.item.zIndex)
+
+    for (const entry of items) {
+      ctx.save()
+      ctx.globalAlpha = entry.item.opacity ?? 1
+
+      if (entry.kind === 'video') {
+        const frame = sources.video.get(entry.item.id) ?? null
+        if (frame) {
+          const surface = this.surfaceFor(entry.item.id, frame.width, frame.height)
+          surface.ctx.putImageData(new ImageData(frame.data, frame.width, frame.height), 0, 0)
+          // Use the frame's TRUE display size for placement, not the (possibly
+          // decode-capped) scratch canvas size — see CRITICAL geometry note below.
+          this.drawMedia(surface.canvas, frame.displayWidth, frame.displayHeight, entry.item.transform)
+        }
+      } else if (entry.kind === 'image') {
+        const image = sources.images.get(entry.item.src)
+        if (image) this.drawMedia(image, image.width, image.height, entry.item.transform)
+      } else if (entry.kind === 'text') {
+        this.drawText(entry.item)
+      } else if (entry.kind === 'shape') {
+        this.drawShape(entry.item)
+      } else {
+        this.drawFreehand(entry.item)
+      }
+
+      ctx.restore()
+    }
+
+    // Transition snapshot pass — mirrors TransitionOverlay's CSS logic in the
+    // 2D canvas API (ExportWorker.ts:531-554). The resolver already set the
+    // incoming clip's opacity to 1 and the outgoing clip's to 0 in the items
+    // loop above, so only the snapshot needs painting here.
+    for (const tr of scene.transitions) {
+      const snap = this.snapshots.get(tr.id)
+      if (!snap) continue
+      ctx.save()
+
+      if (tr.kind === 'slide') {
+        const sign = tr.direction === 'left' ? -1 : 1
+        ctx.translate(sign * tr.t * width, 0)
+        this.drawMedia(snap.source, snap.displayWidth, snap.displayHeight, undefined)
+      } else if (tr.kind === 'wipe') {
+        // Reveal the incoming clip from the right by shrinking the snapshot's visible area.
+        ctx.beginPath()
+        ctx.rect(0, 0, width * (1 - tr.t), height)
+        ctx.clip()
+        this.drawMedia(snap.source, snap.displayWidth, snap.displayHeight, undefined)
+      } else {
+        // fade (default)
+        ctx.globalAlpha = 1 - tr.t
+        this.drawMedia(snap.source, snap.displayWidth, snap.displayHeight, undefined)
+      }
+
+      ctx.restore()
+    }
+
+    this.releaseStaleSnapshots(scene)
+
+    return ctx.getImageData(0, 0, width, height).data
+  }
+
+  /** Releases scratch surfaces and snapshots. */
+  dispose(): void {
+    // @napi-rs/canvas canvases have no explicit close/dispose — their native
+    // buffers are reclaimed by GC once dereferenced, unlike the browser's
+    // ImageBitmap. Dropping the maps' references is the whole of "release".
+    this.scratch.clear()
+    this.snapshots.clear()
+  }
+
+  // ---------------------------------------------------------------------
+  // Transition snapshots (ExportWorker.ts:296-301, 331-345, 350-357)
+  // ---------------------------------------------------------------------
+
+  private captureSnapshots(scene: Scene, sources: FrameSources): void {
+    for (const tr of scene.transitions) {
+      if (this.snapshots.has(tr.id)) continue
+
+      const fromVideo = scene.videos.find(v => v.id === tr.fromClipId)
+      const fromImage = scene.images.find(i => i.id === tr.fromClipId)
+
+      if (fromVideo) {
+        const frame = sources.video.get(fromVideo.id) ?? null
+        if (!frame) continue
+        // `frame.data` is a view invalidated by the next decoder step —
+        // copy it into a fresh canvas before the current frame's decode
+        // advances (types.ts DecodedFrame doc comment).
+        const copy = new Uint8ClampedArray(frame.data)
+        const snapshotCanvas = createCanvas(frame.width, frame.height)
+        snapshotCanvas.getContext('2d').putImageData(new ImageData(copy, frame.width, frame.height), 0, 0)
+        this.snapshots.set(tr.id, {
+          source: snapshotCanvas,
+          owned: true,
+          displayWidth: frame.displayWidth,
+          displayHeight: frame.displayHeight,
+        })
+      } else if (fromImage) {
+        const image = sources.images.get(fromImage.src)
+        if (!image) continue
+        this.snapshots.set(tr.id, {
+          source: image,
+          owned: false,
+          displayWidth: image.width,
+          displayHeight: image.height,
+        })
+      }
+    }
+  }
+
+  /** Release snapshots whose transition window has closed. */
+  private releaseStaleSnapshots(scene: Scene): void {
+    const activeIds = new Set(scene.transitions.map(tr => tr.id))
+    for (const id of this.snapshots.keys()) {
+      if (!activeIds.has(id)) this.snapshots.delete(id)
+    }
+  }
+
+  // ---------------------------------------------------------------------
+  // Placement helpers — mirror the GPU renderer's drawRect/textLayout logic
+  // (ExportWorker.ts:565-658)
+  // ---------------------------------------------------------------------
+
+  private drawMedia(source: DrawSource, displayWidth: number, displayHeight: number, transform: Transform | undefined): void {
+    // CRITICAL: `render()` is called with the OUTPUT dimensions, and those are
+    // what get passed as stageW/stageH here — never `scene.stage.*` — exactly
+    // as ExportWorker.ts:347/485/500 does. Do not "fix" this to use the stage
+    // size; parity with the browser exporter depends on it.
+    const rect = resolveDrawRect(transform, this.width, this.height, displayWidth, displayHeight)
+    const cx = rect.x + rect.width / 2
+    const cy = rect.y + rect.height / 2
+
+    this.ctx.translate(cx, cy)
+    this.ctx.rotate(rect.rotation)
+    this.ctx.drawImage(source, -rect.width / 2, -rect.height / 2, rect.width, rect.height)
+  }
+
+  private drawText(clip: ActiveTextClip): void {
+    const ctx = this.ctx
+    // Substitute the font family first so the layout measures with the font
+    // that will actually paint (fonts.ts).
+    const item = { ...clip, fontFamily: this.fonts.substitute(clip.fontFamily) }
+    // computeTextLayout wants Pick<CanvasRenderingContext2D, 'font' | 'measureText'>;
+    // SKRSContext2D is structurally close but not nominally assignable, so we
+    // cast once here rather than widen the shared core signature.
+    const layout = computeTextLayout(ctx as unknown as TextMeasurer, item, { width: this.width, height: this.height })
+    ctx.fillStyle = layout.style.color
+    ctx.textAlign = layout.style.textAlign
+    ctx.textBaseline = 'middle'
+
+    const rotation = clip.transform?.rotation ?? 0
+    if (rotation !== 0) {
+      const cx = layout.center.x * this.width
+      const cy = layout.center.y * this.height
+      ctx.translate(cx, cy)
+      ctx.rotate(rotation)
+      ctx.translate(-cx, -cy)
+    }
+
+    for (let i = 0; i < layout.lines.length; i++) {
+      ctx.fillText(layout.lines[i], layout.anchorX, layout.firstLineY + i * layout.lineAdvance)
+    }
+  }
+
+  /** Mirrors ShapeLayer.paintShape — same centered rect/circle/triangle geometry. */
+  private drawShape(item: ActiveShapeClip): void {
+    const ctx = this.ctx
+    const cx = (item.transform?.x ?? 0.5) * this.width
+    const cy = (item.transform?.y ?? 0.5) * this.height
+    const shortSide = Math.min(this.width, this.height)
+    const half = (item.transform?.scale ?? 0.5) * shortSide * 0.5
+
+    ctx.fillStyle = item.shapeFill
+    ctx.strokeStyle = item.shapeStroke
+    ctx.lineWidth = item.shapeStrokeWidth
+
+    if (item.shapeKind === 'rect') {
+      ctx.beginPath()
+      ctx.rect(cx - half, cy - half, half * 2, half * 2)
+      ctx.fill()
+      if (item.shapeStrokeWidth > 0) ctx.stroke()
+    } else if (item.shapeKind === 'circle') {
+      ctx.beginPath()
+      ctx.arc(cx, cy, half, 0, Math.PI * 2)
+      ctx.fill()
+      if (item.shapeStrokeWidth > 0) ctx.stroke()
+    } else if (item.shapeKind === 'triangle') {
+      ctx.beginPath()
+      ctx.moveTo(cx, cy - half)
+      ctx.lineTo(cx + half, cy + half)
+      ctx.lineTo(cx - half, cy + half)
+      ctx.closePath()
+      ctx.fill()
+      if (item.shapeStrokeWidth > 0) ctx.stroke()
+    }
+  }
+
+  /** Mirrors FreehandLayer.paintFreehand — same Path2D stroke, invalid pathData is a no-op. */
+  private drawFreehand(item: ActiveFreehandClip): void {
+    if (!item.pathData) return
+
+    const ctx = this.ctx
+    ctx.strokeStyle = item.strokeColor
+    ctx.lineWidth = item.strokeWidth
+    ctx.lineCap = 'round'
+    ctx.lineJoin = 'round'
+
+    try {
+      const path = new Path2D(item.pathData)
+      ctx.stroke(path)
+    } catch {
+      // Invalid pathData — render nothing.
+    }
+  }
+
+  /** Returns (creating or resizing as needed) the scratch canvas a clip's decoded frame is copied into. */
+  private surfaceFor(clipId: string, width: number, height: number): ScratchSurface {
+    const existing = this.scratch.get(clipId)
+    if (existing && existing.canvas.width === width && existing.canvas.height === height) {
+      return existing
+    }
+    const canvas = createCanvas(width, height)
+    const surface: ScratchSurface = { canvas, ctx: canvas.getContext('2d') }
+    this.scratch.set(clipId, surface)
+    return surface
+  }
+}

--- a/packages/export-server/src/types.ts
+++ b/packages/export-server/src/types.ts
@@ -1,0 +1,280 @@
+/**
+ * Shared types for @elah/export-server.
+ *
+ * This file is the seam that makes the ffmpeg pipeline a *second consumer of
+ * the resolver* rather than a second renderer. Nothing here — and nothing in
+ * any module that imports only from here — references `Project` or `Clip`.
+ * Everything the decode/composite/encode stages need is either a `Scene` or a
+ * plan derived from a sequence of `Scene`s.
+ */
+
+import type { Scene } from '@elah/core'
+
+// ---------------------------------------------------------------------------
+// ffmpeg
+// ---------------------------------------------------------------------------
+
+/**
+ * A located, verified ffmpeg binary.
+ *
+ * ffmpeg is a system binary, never an npm dependency: vendoring a static build
+ * would add ~80 MB, drag GPL-licensed code into an Apache-2.0 package, and lose
+ * the hardware encoders (h264_videotoolbox / h264_nvenc / h264_qsv) that only
+ * the platform's own build has.
+ */
+export interface FfmpegBinary {
+  /** Path or bare command name that was verified to run. */
+  path: string
+  /** First line of `ffmpeg -version`, kept verbatim for error messages. */
+  versionLine: string
+  /** Parsed [major, minor]; `null` for git/nightly builds with no numeric version. */
+  version: [number, number] | null
+  /** Encoder names reported by `ffmpeg -encoders`. */
+  encoders: ReadonlySet<string>
+}
+
+// ---------------------------------------------------------------------------
+// Probing
+// ---------------------------------------------------------------------------
+
+export interface MediaInfo {
+  durationSec: number
+  width?: number
+  height?: number
+}
+
+export interface VideoSourceInfo {
+  durationSec: number
+  /**
+   * Post-rotation, pixel-aspect-corrected dimensions — the size the browser's
+   * CanvasSink hands the compositor, and therefore the content size that must
+   * be fed to `resolveDrawRect`.
+   */
+  displayWidth: number
+  displayHeight: number
+  codedWidth: number
+  codedHeight: number
+  /** Average frame rate from packet stats. Diagnostics only — never used to derive timestamps. */
+  averageFrameRate: number
+}
+
+/**
+ * The full presentation-timestamp index of a source's primary video track.
+ *
+ * Built from metadata-only packets, so it costs an index read rather than a
+ * file read. This index is what makes ffmpeg decode frame-accurate: it tells us
+ * which source frame each raw frame coming off the pipe actually is.
+ */
+export interface VideoFrameIndex extends VideoSourceInfo {
+  /** Presentation timestamps in seconds, ascending, one per source frame. */
+  timestamps: Float64Array
+  /** False when the index had to be synthesized from the average frame rate. */
+  exact: boolean
+}
+
+export interface OutputValidation {
+  durationSec: number
+  frameCount: number | null
+  width: number
+  height: number
+  hasAudioTrack: boolean
+}
+
+// ---------------------------------------------------------------------------
+// Decode
+// ---------------------------------------------------------------------------
+
+/**
+ * One decoded video frame.
+ *
+ * `data` is a view into the reader's buffer and is invalidated by the next
+ * decoder step — draw it immediately, and copy it if you need to keep it
+ * (the transition snapshot store does).
+ *
+ * `width`/`height` describe the pixel buffer; `displayWidth`/`displayHeight`
+ * describe the source's true display size. They differ when `decodeMaxHeight`
+ * caps decode resolution, and placement math must always use the display pair.
+ */
+export interface DecodedFrame {
+  data: Uint8ClampedArray
+  width: number
+  height: number
+  displayWidth: number
+  displayHeight: number
+}
+
+// ---------------------------------------------------------------------------
+// Plan — the compressed result of scanning every frame's Scene
+// ---------------------------------------------------------------------------
+
+export interface VideoClipPlan {
+  clipId: string
+  /** Resolved source: absolute path or http(s) URL. */
+  source: string
+  /** First export frame at which this clip appears in a Scene. */
+  firstFrame: number
+  /** Last export frame at which it appears, inclusive. */
+  lastFrame: number
+  /**
+   * One entry per export frame in `[firstFrame, lastFrame]`: the clip's
+   * `sourceFrame` from the Scene at that frame, in project-fps units.
+   * Dense and non-decreasing — the decoder cursor depends on both.
+   */
+  sourceFrames: Int32Array
+}
+
+export interface AudioClipPlan {
+  clipId: string
+  source: string
+  /** Timeline position of the clip's first frame. */
+  startFrame: number
+  /** Number of export frames the clip covers. */
+  frameCount: number
+  /** In-point into the source, in project-fps frames. */
+  sourceStartFrame: number
+  /** Effective linear gain from the Scene: clip volume x track gain, 0 when muted. */
+  volume: number
+}
+
+export interface ExportPlan {
+  fps: number
+  /** The project's stage size. Output size is derived from it, not equal to it. */
+  stage: { width: number; height: number }
+  totalFrames: number
+  videos: VideoClipPlan[]
+  audios: AudioClipPlan[]
+  /**
+   * Unique images, in first-appearance order. `src` is the raw `Scene` src —
+   * what the compositor keys `FrameSources.images` by, since it only ever
+   * sees `ActiveImageClip.src` — and `source` is that same src run through
+   * `resolveSource`, the string ffmpeg/mediabunny/`loadImage` can actually
+   * open. Keeping both avoids re-resolving (and re-hashing) a src once per
+   * frame per image just to look an already-loaded image back up.
+   */
+  imageSources: Array<{ src: string; source: string }>
+  /** Font families requested by text clips anywhere in the timeline. */
+  fontFamilies: string[]
+}
+
+// ---------------------------------------------------------------------------
+// Audio mix
+// ---------------------------------------------------------------------------
+
+export interface AudioMixInput {
+  /** Resolved source, added to the encoder argv as `-i <source>`. */
+  source: string
+  clipId: string
+}
+
+/**
+ * A ready-to-splice audio section of the encoder command line.
+ *
+ * Node has no Web Audio API, so the mix that `OfflineAudioContext` performs in
+ * the browser exporter is expressed as an ffmpeg filter graph instead. The
+ * graph is built from frame counts; seconds appear only in the emitted string.
+ */
+export interface AudioMixSpec {
+  /** Inputs in the order they are appended after the rawvideo input (index 1..N). */
+  inputs: AudioMixInput[]
+  /** Value passed to `-filter_complex`. */
+  filterComplex: string
+  /** Label passed to `-map`, e.g. `'[aout]'`. */
+  outLabel: string
+  sampleRate: number
+  channels: number
+}
+
+// ---------------------------------------------------------------------------
+// Public options / results
+// ---------------------------------------------------------------------------
+
+export interface FontSpec {
+  /** Path to a .ttf / .otf / .ttc file. */
+  path: string
+  /** Family name to register it under. Defaults to the name embedded in the file. */
+  family?: string
+}
+
+export type ExportPhase = 'planning' | 'probing' | 'encoding' | 'finalizing' | 'validating'
+
+export interface ExportProgress {
+  phase: ExportPhase
+  frame: number
+  totalFrames: number
+}
+
+export interface ExportProjectOptions {
+  /** Destination MP4. Its directory must already exist. */
+  outPath: string
+  /** Base directory that relative clip `src` values resolve against. Default `process.cwd()`. */
+  projectDir?: string
+  /** Explicit ffmpeg binary; beats `ELAH_FFMPEG` and `ffmpeg` on PATH. */
+  ffmpegPath?: string
+  /**
+   * Output height in pixels. Width follows the stage aspect ratio and is
+   * rounded to an even number (H.264 chroma subsampling requires it).
+   * Defaults to the stage height — no scaling.
+   */
+  outputHeight?: number
+  /** ffmpeg encoder name, not a codec family. Default `'libx264'`. */
+  videoEncoder?: string
+  /** Target video bitrate in bits/s. Default 8 Mbps, matching the browser exporter. */
+  videoBitrate?: number
+  /** ffmpeg encoder name. Default `'aac'`. */
+  audioEncoder?: string
+  /** Target audio bitrate in bits/s. Default 128 kbps. */
+  audioBitrate?: number
+  /** Mix sample rate. Default 48000. */
+  audioSampleRate?: number
+  /** Mix channel count. Default 2. */
+  audioChannels?: number
+  /** Spliced in just before the output path — the escape hatch for `-preset`, `-crf`, etc. */
+  extraOutputArgs?: string[]
+  /**
+   * Cap the height each video source is decoded at. Placement geometry still
+   * uses the source's true display size, so this trades sharpness for decode
+   * bandwidth without moving anything on the stage.
+   */
+  decodeMaxHeight?: number
+  /** Fonts registered before any text is measured. */
+  fonts?: FontSpec[]
+  /** Family substituted whenever a text clip asks for one Skia cannot resolve. */
+  fallbackFontFamily?: string
+  /**
+   * Linear gain applied to the whole mix. Default 1: the browser exporter does
+   * not apply `project.masterVolume`, so neither do we unless asked.
+   */
+  masterVolume?: number
+  /** Override how a clip `src` becomes an openable path/URL. Default `resolveSource(src, projectDir)`. */
+  resolveSource?: (src: string) => string
+  onProgress?: (progress: ExportProgress) => void
+  /** Aborts the export: children are killed and the partial output is removed. */
+  signal?: AbortSignal
+  /** Re-open the finished file with mediabunny and report what landed. Default true. */
+  validateOutput?: boolean
+}
+
+export interface ExportResult {
+  outPath: string
+  sizeBytes: number
+  totalFrames: number
+  fps: number
+  width: number
+  height: number
+  durationSec: number
+  hasAudio: boolean
+  /** Present unless `validateOutput` was disabled. */
+  validation?: OutputValidation
+  /** Non-fatal problems: a skipped audio clip, a substituted font, a short source. */
+  warnings: string[]
+  ffmpeg: {
+    path: string
+    versionLine: string
+    videoEncoder: string
+    audioEncoder?: string
+  }
+  elapsedMs: number
+}
+
+/** Re-exported so consumers can type a compositor without importing @elah/core directly. */
+export type { Scene }

--- a/packages/export-server/src/util/__tests__/sources.test.ts
+++ b/packages/export-server/src/util/__tests__/sources.test.ts
@@ -1,0 +1,58 @@
+import { resolve } from 'node:path'
+import { describe, it, expect } from 'vitest'
+
+import { isRemoteUrl, resolveSource } from '../sources'
+import { ExportServerError } from '../../errors'
+
+const BASE_DIR = '/project/dir'
+
+describe('isRemoteUrl', () => {
+  it('is true for http and https URLs', () => {
+    expect(isRemoteUrl('http://example.com/a.mp4')).toBe(true)
+    expect(isRemoteUrl('https://example.com/a.mp4')).toBe(true)
+  })
+
+  it('is false for relative, absolute, file:// and in-memory sources', () => {
+    expect(isRemoteUrl('media/a.mp4')).toBe(false)
+    expect(isRemoteUrl('/abs/media/a.mp4')).toBe(false)
+    expect(isRemoteUrl('file:///abs/media/a.mp4')).toBe(false)
+    expect(isRemoteUrl('blob:https://example.com/uuid')).toBe(false)
+    expect(isRemoteUrl('data:video/mp4;base64,AAA')).toBe(false)
+  })
+})
+
+describe('resolveSource', () => {
+  it('resolves a relative path against the base directory', () => {
+    expect(resolveSource('media/a.mp4', BASE_DIR)).toBe(resolve(BASE_DIR, 'media/a.mp4'))
+  })
+
+  it('passes an absolute path through unchanged', () => {
+    expect(resolveSource('/abs/media/a.mp4', BASE_DIR)).toBe('/abs/media/a.mp4')
+  })
+
+  it('converts a file:// URL to a filesystem path', () => {
+    expect(resolveSource('file:///abs/media/a.mp4', BASE_DIR)).toBe('/abs/media/a.mp4')
+  })
+
+  it('passes http(s) URLs through unchanged, ignoring baseDir', () => {
+    expect(resolveSource('http://example.com/a.mp4', BASE_DIR)).toBe('http://example.com/a.mp4')
+    expect(resolveSource('https://example.com/a.mp4', BASE_DIR)).toBe('https://example.com/a.mp4')
+  })
+
+  it('throws SOURCE_UNSUPPORTED for blob: sources', () => {
+    expect(() => resolveSource('blob:https://example.com/uuid', BASE_DIR)).toThrow(
+      ExportServerError,
+    )
+    try {
+      resolveSource('blob:https://example.com/uuid', BASE_DIR)
+      expect.unreachable()
+    } catch (err) {
+      expect(err).toBeInstanceOf(ExportServerError)
+      expect((err as ExportServerError).code).toBe('SOURCE_UNSUPPORTED')
+    }
+  })
+
+  it('throws SOURCE_UNSUPPORTED for data: sources', () => {
+    expect(() => resolveSource('data:video/mp4;base64,AAA', BASE_DIR)).toThrow(ExportServerError)
+  })
+})

--- a/packages/export-server/src/util/sources.ts
+++ b/packages/export-server/src/util/sources.ts
@@ -1,0 +1,48 @@
+/**
+ * sources.ts — clip `src` -> something ffmpeg and mediabunny can open.
+ *
+ * Ported (not imported) from packages/cli/src/lib/project-io.ts
+ * (`isRemoteUrl`, `resolveMediaSource`): @elah/cli is off limits to this
+ * package, and this is the one seam where the two exporters must agree byte
+ * for byte — a project JSON that renders one way through `elah export` must
+ * resolve its clip sources identically here, or "matches the editor" stops
+ * being true before a single frame is decoded.
+ *
+ * `blob:`/`data:` are the one divergence from the CLI: those srcs only exist
+ * inside a live browser session (an in-memory MediaSource/object URL), so a
+ * project exported from the browser without first materializing its assets
+ * to files has nothing on disk for ffmpeg or mediabunny to open. The CLI never
+ * has to consider them because it only ever loads projects that were already
+ * saved as files; a server export can receive either, so this module is the
+ * one that has to say so.
+ */
+
+import { isAbsolute, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { ExportServerError } from '../errors'
+
+/** True for http(s) sources, which ffmpeg and mediabunny's UrlSource open directly. */
+export function isRemoteUrl(src: string): boolean {
+  return /^https?:\/\//.test(src)
+}
+
+/** True for sources that only exist inside a browser tab and have no on-disk form. */
+function isInMemoryUrl(src: string): boolean {
+  return /^(blob|data):/.test(src)
+}
+
+/** Resolve a clip src against the project directory. Remote URLs pass through unchanged. */
+export function resolveSource(src: string, baseDir: string): string {
+  if (isInMemoryUrl(src)) {
+    throw new ExportServerError(
+      'SOURCE_UNSUPPORTED',
+      `Clip src '${src}' is an in-memory browser source (blob:/data:) and has no on-disk form ` +
+        'for ffmpeg or mediabunny to open. Materialize browser assets to files (and rewrite the ' +
+        'project\'s clip srcs to point at them) before exporting on the server.',
+    )
+  }
+  if (isRemoteUrl(src)) return src
+  if (src.startsWith('file://')) return fileURLToPath(src)
+  return isAbsolute(src) ? src : resolve(baseDir, src)
+}

--- a/packages/export-server/tsconfig.build.json
+++ b/packages/export-server/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist/types"
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/__tests__"]
+}

--- a/packages/export-server/tsconfig.json
+++ b/packages/export-server/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "noEmit": true,
+    "types": ["node"],
+    "lib": ["ES2022", "DOM"]
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## What does this PR do?

Adds `@elah/export-server` — a Node-only package that exports a project to MP4 using ffmpeg directly, so server-side rendering no longer needs a headless browser.

Closes #

---

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Performance improvement

---

## How to test

Requires ffmpeg on the system (`brew install ffmpeg` / `apt install ffmpeg`). Verify with `which ffmpeg` and `ffmpeg -encoders | grep 264`.

1. `npm install && npm run build --workspace=packages/core`
2. `npm run test --workspace=packages/export-server` — 142 tests, 12 files.
3. `npm run build --workspace=packages/export-server` — produces `dist/index.js` + `dist/types/index.d.ts`.
4. Real export, from a script importing the built `dist/index.js`:

```js
import { exportProject } from '@elah/export-server'

const result = await exportProject(project, {
  outPath: '/tmp/out.mp4',
  projectDir: '/path/to/assets',
  onProgress: p => console.log(p.phase, p.frame, '/', p.totalFrames),
})
```

5. Confirm the output with `ffprobe -show_entries stream=width,height,nb_frames,color_space,color_range -of json /tmp/out.mp4`. Expect the requested dimensions, the exact frame count, and `bt709` / `tv` colour tags.

**Frame accuracy** is the property worth checking hardest. Encode a source whose gray level encodes its own frame index:

```
ffmpeg -f lavfi -i "color=c=black:s=320x240:r=30:d=4" \
  -vf "geq=lum='2*N':cb=128:cr=128,format=yuv420p" -c:v libx264 -crf 0 counter.mp4
```

Export a clip with `sourceStartFrame: 45`, then read the centre pixel of each exported frame back out — it maps to source frames 45,46,47,48,49,50 exactly. Same with `sourceStartFrame: 90`. I ran both; they pass.

---

## Screenshots / Recording

Not a UI change — this package has no UI surface and touches nothing in `apps/web`. Verified instead by reading exported pixels back out, as described above.

Real-asset run for reference: two clips (1920×1080 with audio + 1080×1920 silent) merged onto a 1080×1920 stage produced 1141 frames / 38.03s / H.264+AAC in 18.8s (~16ms/frame, `libx264` software encode), with `validateOutput` agreeing with `ffprobe` on every field and zero warnings.

---

## Checklist

- [x] `npm test` passes
- [ ] `npm run typecheck` passes
- [ ] I've tested this in the playground
- [x] No `any` types introduced without justification

**On the two unchecked boxes**, both are honest rather than incidental:

`npm run typecheck` fails at the repo root, but only in `apps/web` — 65 pre-existing errors in `components/playground/production/*` (implicit `any` on store selectors, `unknown` asset types). They reproduce identically on `dev` at 35c28e3 with this branch unchecked out, and this PR touches no file in `apps/web`. `npm run typecheck --workspace=packages/export-server` is clean.

The playground is a browser surface and this package cannot run there — it imports `node:child_process` and a native addon. The equivalent smoke test is the real-asset export above.

---

## Notes for review

**Layer boundary.** The package is a `Scene` consumer, exactly like the export worker: it imports `resolveTimeline`, `resolveDrawRect`, `computeTextLayout` and `deserializeProject` from `@elah/core` and never touches `Project`/`Clip` internals beyond handing the project to the resolver. **`packages/core` is unmodified** — every symbol it needed was already exported. Nothing outside `packages/export-server` changes except two root `package.json` script lines (isolated in their own commit, `a10efa8`, easy to drop) and two docs.

**Frame accuracy strategy.** Explicit per-frame source indices from a mediabunny PTS index drive a monotonic dup/drop cursor over `-fps_mode passthrough`. There is no `-vf fps=` anywhere — it resamples by duplicating and dropping frames, which would break the integer-frame invariant.

**New dependency.** `@napi-rs/canvas`, justified in `BUNDLE_STRATEGY.md`. ffmpeg itself is deliberately *not* a dependency: it's discovered as a system binary the same way `browser.ts` discovers system Chrome, which keeps the hardware encoders and avoids redistributing a GPL binary.

**Known gaps**, all deliberate and documented in the source:
- Output is not byte-identical to the browser export. Skia's text shaping and antialiasing differ from Blink's. Placement geometry *is* identical (shared helpers) — that's the guarantee this makes. Golden-image tests need perceptual tolerance, never a hash.
- Font registration is effectively mandatory for text; Node has no system font stack.
- Colour is pinned to BT.709/limited and tagged. HDR and BT.601-tagged sources are not yet specially handled.
- Decoder concurrency is unbounded; the v1 single-video-track constraint keeps it at one or two in practice, but multi-track will need a cap.

**Follow-up I'd suggest rather than expand this PR with:** the frame-accuracy proof above lives in a scratch script, not the suite. It belongs in `__tests__` as a generated-fixture test.
