### PR TITLE
ui: add PostHog product analytics to web app

### DIFF
--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -1,0 +1,1 @@
+.env.local

--- a/apps/web/app/api/ai/topics/route.ts
+++ b/apps/web/app/api/ai/topics/route.ts
@@ -1,5 +1,25 @@
 import { NextResponse, type NextRequest } from 'next/server'
 import { generateTopicOptions } from '@/lib/ai/client'
+import { getPostHogClient } from '@/lib/posthog-server'
+
+/**
+ * posthog-js mirrors its distinct_id into `ph_<token>_posthog` under the default
+ * `localStorage+cookie` persistence. Reading it here keeps server-side events on the
+ * same person as the browser's, instead of stranding them on a synthetic id.
+ */
+function distinctIdFromRequest(req: NextRequest): string | null {
+  const token = process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN
+  if (!token) return null
+  const raw = req.cookies.get(`ph_${token}_posthog`)?.value
+  if (!raw) return null
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    const id = (parsed as { distinct_id?: unknown })?.distinct_id
+    return typeof id === 'string' && id ? id : null
+  } catch {
+    return null
+  }
+}
 
 export async function POST(req: NextRequest) {
   let body: unknown
@@ -17,11 +37,33 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'Missing "prompt".' }, { status: 400 })
   }
 
+  let options: Awaited<ReturnType<typeof generateTopicOptions>>
   try {
-    const options = await generateTopicOptions(prompt.slice(0, 500), req.signal)
-    return NextResponse.json({ options })
+    options = await generateTopicOptions(prompt.slice(0, 500), req.signal)
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Topic generation failed.'
     return NextResponse.json({ error: message }, { status: 502 })
   }
+
+  // Analytics is best-effort: a missing token or a slow flush must never turn a
+  // successful generation into a 502.
+  try {
+    const distinctId = distinctIdFromRequest(req)
+    const posthog = getPostHogClient()
+    posthog.capture({
+      distinctId: distinctId ?? 'server',
+      event: 'ai_topics_generated',
+      properties: {
+        options_count: options.length,
+        // Without a browser id there is no real person to attach to; skip the
+        // profile rather than minting a throwaway one per request.
+        ...(distinctId ? {} : { $process_person_profile: false }),
+      },
+    })
+    await posthog.flush()
+  } catch {
+    // swallowed by design
+  }
+
+  return NextResponse.json({ options })
 }

--- a/apps/web/components/marketing/HeroSection.tsx
+++ b/apps/web/components/marketing/HeroSection.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import Link from 'next/link'
 import { ArrowRight, Check, Copy, Play } from 'lucide-react'
+import posthog from 'posthog-js'
 
 function InstallCommand({ command }: { command: string }) {
   const [copied, setCopied] = useState(false)
@@ -11,6 +12,7 @@ function InstallCommand({ command }: { command: string }) {
     navigator.clipboard?.writeText(command).then(() => {
       setCopied(true)
       setTimeout(() => setCopied(false), 1500)
+      posthog.capture('install_command_copied', { command })
     })
   }
 

--- a/apps/web/components/marketing/PlaygroundCard.tsx
+++ b/apps/web/components/marketing/PlaygroundCard.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import { motion } from 'framer-motion'
 import { Play, Layers, Clock, Cpu } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import posthog from 'posthog-js'
 
 interface PlaygroundCardProps {
   title: string
@@ -117,6 +118,7 @@ export function PlaygroundCard({
           onMouseLeave={(e) => {
             e.currentTarget.style.backgroundColor = accentColor + '08'
           }}
+          onClick={() => posthog.capture('playground_launched', { title, href, variant, status })}
         >
           <Play className="h-3 w-3" />
           Launch Playground

--- a/apps/web/components/playground/production/AgenticPanel.tsx
+++ b/apps/web/components/playground/production/AgenticPanel.tsx
@@ -5,6 +5,7 @@ import { Sparkles, Send, X } from 'lucide-react'
 import { useTimelineEngine, type TimelineRef } from '@elah/editor'
 import { loadPixabayTopic } from './loadRandomPixabay'
 import type { TopicOption } from '@/lib/ai/types'
+import posthog from 'posthog-js'
 
 type PanelState = 'idle' | 'thinking' | 'choosing'
 
@@ -47,6 +48,8 @@ export function AgenticPanel({ style, timelineRef, busy, setBusy }: AgenticPanel
       setError('')
       setState('thinking')
 
+      posthog.capture('agentic_prompt_submitted', { prompt_length: trimmed.length })
+
       try {
         const res = await fetch('/api/ai/topics', {
           method: 'POST',
@@ -88,6 +91,7 @@ export function AgenticPanel({ style, timelineRef, busy, setBusy }: AgenticPanel
       setOptions([])
       setState('idle')
       setBusy(true)
+      posthog.capture('agentic_topic_selected', { topic_name: option.name })
       console.log('[playground] Agentic AI topic chosen', {
         name: option.name,
         videotags: option.topic.videotags,

--- a/apps/web/components/playground/production/ExportModal.tsx
+++ b/apps/web/components/playground/production/ExportModal.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { cn } from '@/lib/utils'
 import type { ExportVideoCodec, ExportAudioCodec } from '@elah/editor'
+import posthog from 'posthog-js'
 
 // ---------------------------------------------------------------------------
 // Quality presets
@@ -269,6 +270,21 @@ function ErrorPhase({
   )
 }
 
+/**
+ * Every export event carries the same shape off the same preset, so the funnel
+ * can be broken down by any one property at every step. Derive it here rather
+ * than at each call site — that is how started/completed drifted apart before.
+ */
+function exportEventProps(preset: (typeof PRESETS)[number]) {
+  return {
+    resolution: preset.label,
+    output_height: preset.outputHeight,
+    video_bitrate: preset.videoBitrate,
+    video_codec: preset.videoCodec,
+    audio_codec: preset.audioCodec,
+  }
+}
+
 // ---------------------------------------------------------------------------
 // ExportModal — main component
 // ---------------------------------------------------------------------------
@@ -297,6 +313,8 @@ export function ExportModal({ onClose, onExport, isMobile = false }: ExportModal
     setFrame(0)
     setTotalFrames(0)
 
+    posthog.capture('export_started', exportEventProps(preset))
+
     try {
       await onExport({
         videoBitrate: preset.videoBitrate,
@@ -310,14 +328,18 @@ export function ExportModal({ onClose, onExport, isMobile = false }: ExportModal
         },
       })
       // success — modal closes (parent handles the download)
+      posthog.capture('export_completed', exportEventProps(preset))
       onClose()
     } catch (err) {
       if ((err as DOMException)?.name === 'AbortError') {
         // user-cancelled — go back to settings
         setPhase('settings')
       } else {
-        setErrorMessage(String(err))
+        const message = String(err)
+        setErrorMessage(message)
         setPhase('error')
+        posthog.capture('export_failed', exportEventProps(preset))
+        posthog.captureException(err instanceof Error ? err : new Error(message))
       }
     } finally {
       abortRef.current = null

--- a/apps/web/components/playground/production/ProductionEditor.tsx
+++ b/apps/web/components/playground/production/ProductionEditor.tsx
@@ -763,7 +763,10 @@ export default function ProductionEditor() {
     onProgress: (frame: number, totalFrames: number) => void
   }) => {
     const e = timelineRef.current?.engine
-    if (!e) return
+    // Returning quietly here resolved the modal's await as success: it closed
+    // with nothing exported and no error shown. Throw so the modal's existing
+    // catch surfaces the failure.
+    if (!e) throw new Error('Editor is not ready yet — try again in a moment.')
     usePlaybackStore.getState().pause()
     const project = e.getProject()
     const { lazyExportVideo } = await import('@elah/editor')

--- a/apps/web/components/playground/production/ProductionEditor.tsx
+++ b/apps/web/components/playground/production/ProductionEditor.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import posthog from 'posthog-js'
 import { memo, useCallback, useEffect, useRef, useState } from 'react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
@@ -426,7 +427,10 @@ const LeftRail = memo(function LeftRail({
           <button
             key={id}
             type="button"
-            onClick={() => onSelect(id)}
+            onClick={() => {
+              onSelect(id)
+              posthog.capture('editor_panel_switched', { panel: id })
+            }}
             className="w-full flex flex-col items-center gap-1.5 py-1 cursor-pointer"
           >
             <span
@@ -486,7 +490,10 @@ const AspectControl = memo(function AspectControl() {
           <button
             key={a.label}
             type="button"
-            onClick={() => engine.setStage(a.w, a.h)}
+            onClick={() => {
+              engine.setStage(a.w, a.h)
+              posthog.capture('aspect_ratio_changed', { aspect_ratio: a.label, width: a.w, height: a.h })
+            }}
             title={`${a.label} aspect ratio`}
             className={cn(
               'inline-flex items-center gap-1.5 px-3 py-1 rounded-md text-xs cursor-pointer transition-colors',
@@ -558,6 +565,7 @@ const MobileAspectSelect = memo(function MobileAspectSelect() {
                 onClick={() => {
                   engine.setStage(a.w, a.h)
                   setOpen(false)
+                  posthog.capture('aspect_ratio_changed', { aspect_ratio: a.label, width: a.w, height: a.h })
                 }}
                 className={cn(
                   'flex items-center gap-2 w-full px-3 py-2 text-xs transition-colors hover:bg-ed-highest',
@@ -784,6 +792,8 @@ export default function ProductionEditor() {
     a.download = 'export.mp4'
     a.click()
     setTimeout(() => URL.revokeObjectURL(url), 60_000)
+    // `export_completed` is emitted by ExportModal, which owns the whole funnel
+    // and the preset the other two events are derived from.
   }, [])
 
   return (
@@ -797,7 +807,10 @@ export default function ProductionEditor() {
         className="elah-root flex flex-col h-full"
       >
         <AppHeader
-          onExport={() => setShowExportModal(true)}
+          onExport={() => {
+            setShowExportModal(true)
+            posthog.capture('export_modal_opened')
+          }}
           onToggleCode={() => setShowCode((o) => !o)}
           codeOpen={showCode}
         />

--- a/apps/web/instrumentation-client.ts
+++ b/apps/web/instrumentation-client.ts
@@ -1,0 +1,23 @@
+import posthog from 'posthog-js'
+
+const token = process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN
+
+if (!token) {
+  if (process.env.NODE_ENV !== 'production') {
+    throw new Error(
+      'NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN variable required by PostHog is missing or un-configured, ' +
+        'this causes events to be silently missed. ' +
+        'This error stops appearing once NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN is configured',
+    )
+  }
+} else {
+  posthog.init(token, {
+    api_host: '/ingest',
+    ui_host: 'https://us.posthog.com',
+    defaults: '2026-01-30',
+    capture_exceptions: true,
+    debug: process.env.NODE_ENV === 'development',
+  })
+}
+
+export { }

--- a/apps/web/lib/posthog-server.ts
+++ b/apps/web/lib/posthog-server.ts
@@ -1,0 +1,23 @@
+import { PostHog } from 'posthog-node'
+
+let posthogClient: PostHog | null = null
+
+export function getPostHogClient(): PostHog {
+  if (!posthogClient) {
+    const token = process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN
+    const host = process.env.NEXT_PUBLIC_POSTHOG_HOST
+    if (!token) {
+      throw new Error(
+        'NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN variable required by PostHog is missing or un-configured, ' +
+          'this causes events to be silently missed. ' +
+          'This error stops appearing once NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN is configured',
+      )
+    }
+    posthogClient = new PostHog(token, {
+      host,
+      flushAt: 1,
+      flushInterval: 0,
+    })
+  }
+  return posthogClient
+}

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -39,6 +39,23 @@ const pkgSrcRel = (name) => {
 const nextConfig = {
   reactStrictMode: true,
   pageExtensions: ['ts', 'tsx', 'mdx'],
+  skipTrailingSlashRedirect: true,
+  async rewrites() {
+    return [
+      {
+        source: '/ingest/static/:path*',
+        destination: 'https://us-assets.i.posthog.com/static/:path*',
+      },
+      {
+        source: '/ingest/array/:path*',
+        destination: 'https://us-assets.i.posthog.com/array/:path*',
+      },
+      {
+        source: '/ingest/:path*',
+        destination: 'https://us.i.posthog.com/:path*',
+      },
+    ]
+  },
   experimental: {
     mdxRs: false,
   },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -28,6 +28,8 @@
     "mermaid": "^11.15.0",
     "next": "^16.2.9",
     "next-mdx-remote": "^5.0.0",
+    "posthog-js": "^1.407.3",
+    "posthog-node": "^5.46.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "reading-time": "^1.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,8 @@
         "mermaid": "^11.15.0",
         "next": "^16.2.9",
         "next-mdx-remote": "^5.0.0",
+        "posthog-js": "^1.407.3",
+        "posthog-node": "^5.46.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "reading-time": "^1.5.0",
@@ -2208,6 +2210,31 @@
       "engines": {
         "node": ">=12.4.0"
       }
+    },
+    "node_modules/@posthog/browser-common": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@posthog/browser-common/-/browser-common-0.2.2.tgz",
+      "integrity": "sha512-4NHumu2lx7pMeucDLfXnDmeP5CV2oVWY8jBpXBwBUjoYwkQxB7Z3A6q9oDydw+/iSAGl6MaPqW9gsnRK8AvqLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/core": "^1.45.1",
+        "@posthog/types": "^1.398.0"
+      }
+    },
+    "node_modules/@posthog/core": {
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.45.1.tgz",
+      "integrity": "sha512-tLtvzomavb2PPWdGYKsusyIzIeL2Px47v348Smibkay7sMy/83TyPk+Ptsp2NdeOgJsbuwSxWkR2+XA0aSCAaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/types": "^1.398.0"
+      }
+    },
+    "node_modules/@posthog/types": {
+      "version": "1.398.0",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.398.0.tgz",
+      "integrity": "sha512-sJMkl4k+u8yS/0fjHsKqE9xTdsAh30a2WvgChiptellnVoE0e8QJKFgqOMD2sk8FaEArPdeFklAhXvmENAt3Sg==",
+      "license": "MIT"
     },
     "node_modules/@radix-ui/number": {
       "version": "1.1.2",
@@ -5492,6 +5519,17 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cose-base": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
@@ -7316,6 +7354,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.9.tgz",
+      "integrity": "sha512-zdxgIEddhfsyCaWpJ2SdXEP8ZMrKJ6+5jl4OupODcywU0IhRk6gdXuVGcPICyfx2H97hVK7xmJtRLPjkxAX8Vw==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -10726,6 +10770,43 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/posthog-js": {
+      "version": "1.407.3",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.407.3.tgz",
+      "integrity": "sha512-b9Kc7HVN6nh+xsh1JrcLYHv9bbYLwYUM9belJtNVUFZSJWWfFcZRJJP6L+KeanAeu2VxSFSpioVA39pjjolv4A==",
+      "license": "(Apache-2.0 AND MIT)",
+      "dependencies": {
+        "@posthog/browser-common": "^0.2.2",
+        "@posthog/core": "^1.45.1",
+        "@posthog/types": "^1.398.0",
+        "core-js": "^3.49.0",
+        "dompurify": "^3.3.2",
+        "fflate": "^0.4.8",
+        "preact": "^10.29.3",
+        "query-selector-shadow-dom": "^1.0.1",
+        "web-vitals": "^5.3.0"
+      }
+    },
+    "node_modules/posthog-node": {
+      "version": "5.46.1",
+      "resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-5.46.1.tgz",
+      "integrity": "sha512-WjCqExq44pBdyg9MSsH6UAE0tNZ88p4aIuVFicgqhjf2Fbws6IhS4ioYUa4aBrbUPS9EDRXtBTtF5DpP1ml8Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/core": "^1.45.1"
+      },
+      "engines": {
+        "node": "^20.20.0 || >=22.22.0"
+      },
+      "peerDependencies": {
+        "rxjs": "^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rxjs": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/powershell-utils": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
@@ -10737,6 +10818,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.29.7",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.7.tgz",
+      "integrity": "sha512-DCHYrK/B10yUD3ZjLfhZ3WIE/9Vf9VFUODcRE2dRomTYDpJk6z6L9wecSfhfE6M9ZTHUdyQkoC46arIDhEV84Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      },
+      "peerDependencies": {
+        "preact-render-to-string": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "preact-render-to-string": {
+          "optional": true
+        }
       }
     },
     "node_modules/prelude-ls": {
@@ -10780,6 +10879,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/query-selector-shadow-dom": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
+      "integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -13670,6 +13775,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/web-vitals": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.3.0.tgz",
+      "integrity": "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==",
+      "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {
       "version": "8.0.1",


### PR DESCRIPTION
## What does this PR do?

Adds PostHog product analytics to `apps/web` (11 events across the marketing site and production playground), and fixes an export path that failed silently.

Closes #

> **Maintainer decision needed before merge.** Adding telemetry to the project is a
> product/governance call, not a contributor one. This PR is the implementation, not
> an argument that it should ship. Specifically I'd like a decision on: (a) whether
> elah wants product analytics at all, (b) whose PostHog account/token it reports to,
> and (c) how cookie consent should be handled for EU visitors — see Open questions
> below. Happy to close this and move the discussion to an issue if that's preferred.

---

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Performance improvement

> Also contains one bug fix (`02d6e83`) — kept in this branch because the analytics
> `export_completed` event depends on it for correctness. Split into its own PR on request.

---

## How to test

1. Add `apps/web/.env.local` with `NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN=<your phc_ token>` and
   `NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com`, then `npm install && npm run dev`.
2. Load `http://localhost:3001/playgrounds` and click **Launch Playground**. In DevTools →
   Network, confirm `POST /ingest/e/` returns 200; in the console, confirm
   `[PostHog.js] send "playground_launched"`.
3. In the playground, submit a prompt in the Agentic panel. Confirm `ai_topics_generated`
   arrives in PostHog with the **same** `distinct_id` as the client-side events — the server
   route reads the `ph_<token>_posthog` cookie so server and browser events land on one person.
4. Verify analytics can't break the app: rebuild with the token **removed**
   (`npm run build && npx next start --port 3001`). Every instrumented control must still work —
   `posthog.capture()` is a no-op when uninitialised. Verified: link navigation, export modal
   open, export start, and the export error path all behave normally with PostHog dead.
5. Export bug fix: with the editor engine unavailable, clicking Export previously closed the
   modal as if it had succeeded, exporting nothing. It now surfaces "Export failed".
6. `npm run typecheck` and `npm test` at the repo root.

---

## Screenshots / Recording

The only visible change is the export modal now showing its existing **"Export failed"** state
in a case where it previously closed silently with no output. No new UI was added — the
remaining 11 changes are non-visual event instrumentation.

⚠️ Screenshot still to be attached by the author — the failure state is reachable by clicking
Export with an empty timeline.

---

## Checklist

- [x] `npm test` passes
- [x] `npm run typecheck` passes
- [x] I've tested this in the playground
- [x] No `any` types introduced without justification

---

## Implementation notes

**Dependency budget.** `posthog-js` and `posthog-node` are added to `apps/web` only. No
published package (`@elah/core`, `@elah/react`, `@elah/timeline`, `@elah/editor`) is touched,
so the SDK's two-runtime-dependency budget in `BUNDLE_STRATEGY.md` is unchanged and nobody
installing from npm pulls in analytics.

**Reverse proxy.** Events route through `/ingest/*` rewrites to PostHog rather than calling
`us.i.posthog.com` directly, keeping requests first-party.

**Analytics is best-effort on the server.** In `api/ai/topics`, capture and flush are wrapped in
their own `try`/`catch` after the response payload is built, so a missing token or a slow flush
can never turn a successful generation into a 502.

**Anonymous server events** use `$process_person_profile: false` rather than inventing a
per-request ID, so they count without creating throwaway person profiles.

---

## Open questions for maintainers

1. **Consent.** PostHog uses cookies by default and there's no consent gate in this diff. For a
   public site with EU visitors this needs an owner — happy to add gating if you want it here
   rather than in a follow-up.
2. **`skipTrailingSlashRedirect: true`** (`next.config.mjs`) is required by PostHog's proxy setup
   but applies site-wide: `/docs/foo/` and `/docs/foo` both serve 200 instead of redirecting.
   Canonicals are set on 22 of 23 page files so the SEO impact should be contained, but flagging
   it since it's a routing change riding along with an analytics PR.
3. **Event taxonomy.** The 11 event names and their properties are a first pass. Happy to rename
   to match whatever convention you'd prefer before this lands.

---

## Not verified

`install_command_copied` (hero install-command copy button) could not be confirmed firing. The
capture sits inside `navigator.clipboard.writeText().then()`, which needs user activation that
automated clicking doesn't provide. It should work for real users, but I haven't observed it.
Worth noting that path also has no `.catch`, so a clipboard rejection is silent — and with
`capture_exceptions: true` now enabled it would surface in error tracking as noise.
