### PR TITLE
ui: gate analytics behind consent with DNT and privacy docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,20 @@ OPENAI_API_KEY=
 ## Powers the Photos panel and image imports in the production playground.
 ## Get a free key at https://www.pexels.com/api/
 PEXEL_API_KEY=
+
+## --- Website analytics (all NEXT_PUBLIC_*, browser-exposed) ---------------
+## These power tracking on the marketing site only. All are optional: leave a
+## variable unset and that tool never loads. When set, tracking still fires
+## only after the visitor accepts the consent banner (and never under
+## Do-Not-Track). See the Analytics docs page at /docs/analytics.
+
+## PostHog project token — client product analytics.
+## Get it in your PostHog project settings: https://posthog.com/
+NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN=
+
+## PostHog host (e.g. https://us.i.posthog.com).
+NEXT_PUBLIC_POSTHOG_HOST=
+
+## Reddit advertiser pixel id — measures Reddit ad campaigns.
+## Find it in Reddit Ads → Events Manager: https://ads.reddit.com/
+NEXT_PUBLIC_REDDIT_PIXEL_ID=

--- a/README.md
+++ b/README.md
@@ -278,6 +278,16 @@ For the longer treatment, see [`ARCHITECTURE.md`](./ARCHITECTURE.md).
 
 ---
 
+## Analytics & privacy
+
+The published website uses opt-in product analytics (PostHog) and a Reddit
+pixel — both gated behind a consent banner and disabled under Do-Not-Track, and
+inert unless their `NEXT_PUBLIC_*` variables are set (see
+[`.env.example`](./.env.example)). The elah libraries ship no telemetry. Full
+details on the [Analytics docs page](https://www.elah.dev/docs/analytics).
+
+---
+
 ## Contributing
 
 The foundation and the first feature wave have shipped; work now is feature and

--- a/apps/web/app/docs/analytics/page.tsx
+++ b/apps/web/app/docs/analytics/page.tsx
@@ -1,0 +1,130 @@
+import type { Metadata } from 'next'
+import { DocsToc } from '@/components/docs/DocsToc'
+
+export const metadata: Metadata = {
+  title: 'Analytics & Tracking',
+  description:
+    'What the elah.dev site tracks, the environment variables that enable it, and how consent, Do-Not-Track, and opt-out work.',
+  alternates: { canonical: '/docs/analytics' },
+}
+
+const toc = [
+  { id: 'what-we-track', title: 'What we track', level: 2 },
+  { id: 'env', title: 'Environment variables', level: 2 },
+  { id: 'consent', title: 'Consent & Do-Not-Track', level: 2 },
+  { id: 'opt-out', title: 'Changing your choice', level: 2 },
+  { id: 'self-hosting', title: 'Self-hosting', level: 2 },
+]
+
+const mono = 'rounded bg-surface-container px-1.5 py-0.5 text-xs font-mono'
+
+export default function AnalyticsDocsPage() {
+  return (
+    <div className="flex gap-12">
+      <article className="min-w-0 max-w-3xl flex-1">
+        <div className="mb-8 border-b border-outline-variant pb-6">
+          <div className="label-mono mb-2 text-2xs text-on-surface-variant opacity-90">Privacy</div>
+          <h1
+            className="text-3xl font-semibold tracking-tight text-on-surface"
+            style={{ fontFamily: 'var(--font-inter), sans-serif' }}
+          >
+            Analytics &amp; Tracking
+          </h1>
+          <p className="mt-3 text-base leading-relaxed text-on-surface-variant">
+            The elah.dev website uses two analytics tools. Both are opt-in: nothing loads or sends data until
+            you accept the consent banner, and neither runs if your browser sends a Do-Not-Track signal. The
+            elah libraries themselves (<code className={mono}>@elah/core</code> and the rest) contain no
+            telemetry — this applies only to the marketing site.
+          </p>
+        </div>
+
+        <section className="mb-10">
+          <h2 id="what-we-track" className="mb-4 scroll-mt-20 text-xl font-semibold tracking-tight text-on-surface" style={{ fontFamily: 'var(--font-inter), sans-serif' }}>
+            What we track
+          </h2>
+          <ul className="space-y-3 text-sm leading-relaxed text-on-surface-variant">
+            <li>
+              <strong className="text-on-surface">PostHog</strong> — privacy-friendly product analytics:
+              page views and a few interaction events (install-command copies, playground launches, export
+              flow). Reverse-proxied through <code className={mono}>/ingest</code> so it is resilient to
+              ad-blockers.
+            </li>
+            <li>
+              <strong className="text-on-surface">Reddit Pixel</strong> — fires a{' '}
+              <code className={mono}>PageVisit</code> event on load and on client-side route changes, used to
+              measure Reddit ad campaigns.
+            </li>
+          </ul>
+        </section>
+
+        <section className="mb-10">
+          <h2 id="env" className="mb-4 scroll-mt-20 text-xl font-semibold tracking-tight text-on-surface" style={{ fontFamily: 'var(--font-inter), sans-serif' }}>
+            Environment variables
+          </h2>
+          <p className="mb-4 text-sm leading-relaxed text-on-surface-variant">
+            Each tool is inert unless its variable is set. All are <code className={mono}>NEXT_PUBLIC_</code>{' '}
+            (exposed to the browser, as the client SDKs require) and are read from the repo-root{' '}
+            <code className={mono}>.env</code> — see <code className={mono}>.env.example</code>.
+          </p>
+          <ul className="space-y-2 text-sm leading-relaxed text-on-surface-variant">
+            <li>
+              <code className={mono}>NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN</code> — PostHog project token.
+            </li>
+            <li>
+              <code className={mono}>NEXT_PUBLIC_POSTHOG_HOST</code> — PostHog host (e.g.{' '}
+              <code className={mono}>https://us.i.posthog.com</code>).
+            </li>
+            <li>
+              <code className={mono}>NEXT_PUBLIC_REDDIT_PIXEL_ID</code> — Reddit advertiser pixel id.
+            </li>
+          </ul>
+          <p className="mt-4 text-sm leading-relaxed text-on-surface-variant">
+            Leave any of them unset and that tool is never loaded — a clean way to run the site with no
+            tracking at all.
+          </p>
+        </section>
+
+        <section className="mb-10">
+          <h2 id="consent" className="mb-4 scroll-mt-20 text-xl font-semibold tracking-tight text-on-surface" style={{ fontFamily: 'var(--font-inter), sans-serif' }}>
+            Consent &amp; Do-Not-Track
+          </h2>
+          <p className="mb-4 text-sm leading-relaxed text-on-surface-variant">
+            On first visit a banner asks to accept or decline. Until you choose, PostHog is initialised{' '}
+            <em>opted-out</em> and the Reddit pixel script is never injected — so no analytics network request
+            happens pre-consent. Accepting opts PostHog in and loads the pixel; declining keeps both off. Your
+            choice is stored in <code className={mono}>localStorage</code> (<code className={mono}>elah-analytics-consent</code>) and remembered on return.
+          </p>
+          <p className="text-sm leading-relaxed text-on-surface-variant">
+            If your browser sends <strong className="text-on-surface">Do-Not-Track</strong>, both tools stay
+            off and the banner never appears — the signal is treated as a decline.
+          </p>
+        </section>
+
+        <section className="mb-10">
+          <h2 id="opt-out" className="mb-4 scroll-mt-20 text-xl font-semibold tracking-tight text-on-surface" style={{ fontFamily: 'var(--font-inter), sans-serif' }}>
+            Changing your choice
+          </h2>
+          <p className="text-sm leading-relaxed text-on-surface-variant">
+            Clearing the site&apos;s <code className={mono}>localStorage</code> (or the{' '}
+            <code className={mono}>elah-analytics-consent</code> key) resets the banner on next load. Enabling
+            Do-Not-Track in your browser disables both tools immediately.
+          </p>
+        </section>
+
+        <section className="mb-10">
+          <h2 id="self-hosting" className="mb-4 scroll-mt-20 text-xl font-semibold tracking-tight text-on-surface" style={{ fontFamily: 'var(--font-inter), sans-serif' }}>
+            Self-hosting
+          </h2>
+          <p className="text-sm leading-relaxed text-on-surface-variant">
+            If you deploy your own copy of the site, simply omit the three variables above and no analytics
+            code runs. One known gap: PostHog capture in the AI topics API route
+            (<code className={mono}>app/api/ai/topics/route.ts</code>) is server-side and fires on that explicit
+            action; it is not covered by the client consent gate.
+          </p>
+        </section>
+      </article>
+
+      <DocsToc items={toc} />
+    </div>
+  )
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -13,6 +13,8 @@ import { siteConfig } from '@/config/site'
 import { ThemeProvider } from '@/components/ThemeProvider'
 import { JsonLd } from '@/components/seo/JsonLd'
 import { RedditPixel } from '@/components/RedditPixel'
+import { ConsentProvider } from '@/components/ConsentProvider'
+import { ConsentBanner } from '@/components/ConsentBanner'
 
 const inter = Inter({
   subsets: ['latin'],
@@ -152,10 +154,11 @@ export default function RootLayout({
         </a>
         <JsonLd data={organizationJsonLd} />
         <JsonLd data={webSiteJsonLd} />
-        <RedditPixel />
-        <ThemeProvider>
-          {children}
-        </ThemeProvider>
+        <ConsentProvider>
+          <RedditPixel />
+          <ThemeProvider>{children}</ThemeProvider>
+          <ConsentBanner />
+        </ConsentProvider>
       </body>
     </html>
   )

--- a/apps/web/components/ConsentBanner.tsx
+++ b/apps/web/components/ConsentBanner.tsx
@@ -1,0 +1,47 @@
+'use client'
+
+import Link from 'next/link'
+import { useConsent } from '@/components/ConsentProvider'
+
+// Shown only until the visitor makes a choice, and never when Do-Not-Track is
+// set (that already resolves to denied). Fixed to the bottom, above content.
+export function ConsentBanner() {
+  const { consent, dnt, accept, decline } = useConsent()
+
+  if (dnt || consent !== 'unset') return null
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Analytics consent"
+      className="fixed inset-x-0 bottom-0 z-[60] border-t border-outline-variant bg-surface-low/95 backdrop-blur-sm"
+    >
+      <div className="mx-auto flex max-w-4xl flex-col gap-3 px-4 py-4 sm:flex-row sm:items-center sm:justify-between sm:px-6">
+        <p className="text-sm leading-relaxed text-on-surface-variant">
+          We use privacy-friendly product analytics and a Reddit pixel to understand usage. Nothing is
+          loaded until you accept.{' '}
+          <Link href="/docs/analytics" className="text-primary underline underline-offset-2">
+            Learn more
+          </Link>
+          .
+        </p>
+        <div className="flex shrink-0 items-center gap-2">
+          <button
+            type="button"
+            onClick={decline}
+            className="btn-ghost"
+          >
+            Decline
+          </button>
+          <button
+            type="button"
+            onClick={accept}
+            className="btn-primary"
+          >
+            Accept
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/components/ConsentProvider.tsx
+++ b/apps/web/components/ConsentProvider.tsx
@@ -1,0 +1,82 @@
+'use client'
+
+import { createContext, useContext, useEffect, useState } from 'react'
+import posthog from 'posthog-js'
+
+export type Consent = 'granted' | 'denied' | 'unset'
+
+const STORAGE_KEY = 'elah-analytics-consent'
+
+interface ConsentValue {
+  consent: Consent
+  /** True when the browser signals Do-Not-Track — tracking is force-denied and the banner is suppressed. */
+  dnt: boolean
+  accept: () => void
+  decline: () => void
+}
+
+const ConsentContext = createContext<ConsentValue>({
+  consent: 'unset',
+  dnt: false,
+  accept: () => {},
+  decline: () => {},
+})
+
+function detectDnt(): boolean {
+  if (typeof window === 'undefined') return false
+  const w = window as Window & { doNotTrack?: string }
+  const n = navigator as Navigator & { msDoNotTrack?: string }
+  const signal = n.doNotTrack ?? w.doNotTrack ?? n.msDoNotTrack
+  return signal === '1' || signal === 'yes'
+}
+
+// Reflect the choice into PostHog. init() runs opted-out by default
+// (instrumentation-client.ts), so capturing only starts once granted.
+function syncPosthog(consent: Consent) {
+  try {
+    if (consent === 'granted') posthog.opt_in_capturing()
+    else posthog.opt_out_capturing()
+  } catch {
+    // posthog may be uninitialised (no token configured) — safe to ignore
+  }
+}
+
+export function ConsentProvider({ children }: { children: React.ReactNode }) {
+  const [consent, setConsent] = useState<Consent>('unset')
+  const [dnt, setDnt] = useState(false)
+
+  useEffect(() => {
+    const hasDnt = detectDnt()
+    setDnt(hasDnt)
+    if (hasDnt) {
+      // Honour the browser signal without prompting or persisting.
+      setConsent('denied')
+      syncPosthog('denied')
+      return
+    }
+    const stored = localStorage.getItem(STORAGE_KEY)
+    const resolved: Consent = stored === 'granted' || stored === 'denied' ? stored : 'unset'
+    setConsent(resolved)
+    if (resolved !== 'unset') syncPosthog(resolved)
+  }, [])
+
+  function choose(next: 'granted' | 'denied') {
+    setConsent(next)
+    try {
+      localStorage.setItem(STORAGE_KEY, next)
+    } catch {
+      // storage may be unavailable (private mode) — choice still applies this session
+    }
+    syncPosthog(next)
+  }
+
+  return (
+    <ConsentContext.Provider
+      value={{ consent, dnt, accept: () => choose('granted'), decline: () => choose('denied') }}
+    >
+      {children}
+    </ConsentContext.Provider>
+  )
+}
+
+export const useConsent = () => useContext(ConsentContext)

--- a/apps/web/components/RedditPixel.tsx
+++ b/apps/web/components/RedditPixel.tsx
@@ -3,6 +3,7 @@
 import { Suspense, useEffect, useRef } from 'react'
 import Script from 'next/script'
 import { usePathname, useSearchParams } from 'next/navigation'
+import { useConsent } from '@/components/ConsentProvider'
 
 declare global {
   interface Window {
@@ -36,7 +37,11 @@ function RedditPixelPageviews() {
 }
 
 export function RedditPixel() {
-  if (!PIXEL_ID) return null
+  const { consent } = useConsent()
+
+  // Only inject the pixel after explicit opt-in (and when configured). Before
+  // consent this renders nothing, so no Reddit request is made.
+  if (!PIXEL_ID || consent !== 'granted') return null
 
   return (
     <>

--- a/apps/web/config/docs.ts
+++ b/apps/web/config/docs.ts
@@ -90,4 +90,8 @@ export const docsNav: DocNavSection[] = [
       { title: 'Custom Layers', href: '/docs/plugins#custom-layers' },
     ],
   },
+  {
+    title: 'Privacy',
+    items: [{ title: 'Analytics & Tracking', href: '/docs/analytics' }],
+  },
 ]

--- a/apps/web/instrumentation-client.ts
+++ b/apps/web/instrumentation-client.ts
@@ -17,6 +17,10 @@ if (!token) {
     defaults: '2026-01-30',
     capture_exceptions: true,
     debug: process.env.NODE_ENV === 'development',
+    // Consent-gated: start opted out and honour Do-Not-Track. ConsentProvider
+    // calls opt_in_capturing() once the visitor accepts.
+    opt_out_capturing_by_default: true,
+    respect_dnt: true,
   })
 }
 

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## What does this PR do?

Gates the website's analytics (PostHog + the Reddit pixel) behind opt-in consent, honours Do-Not-Track, and documents the tracking + env vars.

Closes #

---

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Performance improvement

---

## Why

The Reddit pixel (added recently on `dev`) and PostHog both fired unconditionally the moment their env vars were set — no opt-in, no Do-Not-Track handling — and none of the analytics env vars were documented. This adds a single lightweight consent layer over both and a privacy docs page.

## What changed

- **`components/ConsentProvider.tsx`** (new) — client context. Reads/persists the choice in `localStorage['elah-analytics-consent']`, detects Do-Not-Track (forces `denied`, suppresses the banner), and drives PostHog `opt_in_capturing()` / `opt_out_capturing()`.
- **`components/ConsentBanner.tsx`** (new) — bottom banner (Accept / Decline, "Learn more" → `/docs/analytics`), shown only when the choice is unset and DNT is off.
- **`instrumentation-client.ts`** — PostHog now inits with `opt_out_capturing_by_default: true` and `respect_dnt: true`; capture starts only after Accept.
- **`components/RedditPixel.tsx`** — gated on `consent === 'granted'` in addition to the id, so the pixel script never injects pre-consent.
- **`app/layout.tsx`** — wraps the tree in `ConsentProvider`, renders `RedditPixel` + `ConsentBanner` inside it.
- **`app/docs/analytics/page.tsx`** (new) + `config/docs.ts` — a "Privacy → Analytics & Tracking" docs page (what's tracked, env vars, consent/DNT, opt-out, self-hosting).
- **`.env.example`** — documents `NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN`, `NEXT_PUBLIC_POSTHOG_HOST`, `NEXT_PUBLIC_REDDIT_PIXEL_ID` (all optional; inert unless set).
- **`README.md`** — short "Analytics & privacy" section.

No new dependencies (uses posthog-js built-ins). No change to the reverse-proxy rewrites. Server-side PostHog capture in `app/api/ai/topics/route.ts` is left as-is (explicit AI action, not page load) — noted as a known gap on the docs page.

---

## How to test

1. Set `NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN` (and optionally `NEXT_PUBLIC_REDDIT_PIXEL_ID`) in the repo-root `.env`; `npm run dev --workspace=apps/web`, open http://localhost:3001/.
2. First visit shows the consent banner. Before choosing: no `redditstatic.com/ads/pixel.js` request; `posthog.has_opted_in_capturing() === false`.
3. **Accept** → PostHog captures (`/ingest` events); if the Reddit id is set, `window.rdt` becomes a function and `pixel.js` loads (`PageVisit` fires, plus on client-side route changes). Choice persists across reloads (banner gone).
4. **Decline** → neither tool loads.
5. Enable browser Do-Not-Track → no banner, neither tool loads.
6. Visit `/docs/analytics` — the docs page renders in the Privacy sidebar section.
7. `npm run typecheck` and `npm test` at the repo root.

---

## Screenshots / Recording

-

<!-- Attaching: consent banner + docs page captures. -->

---

## Checklist

- [x] `npm test` passes
- [x] `npm run typecheck` passes
- [x] I've tested this in the playground
- [x] No `any` types introduced without justification
