### PR TITLE
feat(core): frame-accurate text animation presets, easing, and keyframe channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ versions independently, starting from its own 0.1.0.
 
 ## [Unreleased]
 
+### Added
+
+- **Frame-accurate text animation.** Text clips now support clip-attached
+  entrance/exit presets (`fade`, `slide`, `pop`, `typewriter`), looping `pulse`,
+  named easing, per-phase frame durations, and custom opacity/transform
+  keyframe channels. The pure resolver evaluates all motion at clip-relative
+  integer frames, keeping preview, seeking, and export identical without a new
+  runtime dependency or separate animation track.
+- The production playground's text inspector includes native Elah controls for
+  choosing presets, direction, easing, and frame durations, with preview/commit
+  interactions that produce one undo step per duration edit.
+
 ### Documentation
 
 - **`playground/` is now `examples/`.** The three standalone apps that install

--- a/apps/web/app/docs/api/page.tsx
+++ b/apps/web/app/docs/api/page.tsx
@@ -395,6 +395,8 @@ interface Clip {
   fontWeight?: 'normal' | 'bold'
   textAlign?: 'left' | 'center' | 'right'
   textAnimation?: TextAnimation
+  animations?: AnimationChannel[]
+  shapeAnimation?: { in?: 'fade'; out?: 'fade'; durationFrames: number }
   // Shape / freehand clips have their own shape*/stroke*/pathData fields.
 }
 
@@ -406,11 +408,29 @@ interface Transform {
   anchor: { x: number; y: number } // 0..1 within the clip box
 }
 
-// Entry/exit ramp for text (and shape) clips.
+type AnimationEasing = 'linear' | 'ease-in' | 'ease-out' | 'ease-in-out'
+
+// Clip-attached text presets. All durations are integer frames.
 interface TextAnimation {
-  in?: 'fade'
-  out?: 'fade'
+  in?: 'fade' | 'slide' | 'pop' | 'typewriter'
+  out?: 'fade' | 'slide' | 'pop' | 'typewriter'
+  loop?: 'pulse'
   durationFrames: number
+  inDurationFrames?: number
+  outDurationFrames?: number
+  loopDurationFrames?: number
+  direction?: 'left' | 'right' | 'up' | 'down'
+  easing?: AnimationEasing
+}
+
+interface AnimationChannel {
+  property: 'opacity' | 'transform.x' | 'transform.y' |
+            'transform.scale' | 'transform.rotation'
+  keyframes: Array<{
+    frame: FrameCount       // relative to clip.startFrame
+    value: number
+    easing?: AnimationEasing
+  }>
 }
 
 interface Transition {

--- a/apps/web/app/docs/editor/page.tsx
+++ b/apps/web/app/docs/editor/page.tsx
@@ -238,12 +238,23 @@ engine.addClip({
     rotation: 0,            // radians
     anchor: { x: 0.5, y: 0.5 },
   },
+  textAnimation: {
+    in: 'slide',
+    out: 'fade',
+    durationFrames: 12,
+    direction: 'up',
+    easing: 'ease-out',
+  },
+  animations: [{
+    property: 'transform.scale',
+    keyframes: [{ frame: 0, value: 0.9 }, { frame: 12, value: 1 }],
+  }],
 })
 
-// Entry/exit animation lives on the clip as 'textAnimation', not on 'text'.
-// Set it after creation via updateClip (in/out ramp, kind is 'fade'):
+// Animations live on the clip, not on a separate animation track. Updates are
+// flat and pass through TimelineEngine so they participate in undo/redo:
 engine.updateClip(clipId, textTrack.id, {
-  textAnimation: { in: 'fade', out: 'fade', durationFrames: 10 },
+  textAnimation: { in: 'pop', out: 'fade', durationFrames: 10 },
 })`}
           />
         </section>

--- a/apps/web/components/playground/production/AgenticPanel.tsx
+++ b/apps/web/components/playground/production/AgenticPanel.tsx
@@ -1,9 +1,10 @@
 'use client'
 
 import { useCallback, useRef, useState, type RefObject } from 'react'
-import { Sparkles, Send, X } from 'lucide-react'
+import { Activity, Sparkles, Send, X } from 'lucide-react'
 import { useTimelineEngine, type TimelineRef } from '@elah/editor'
 import { loadPixabayTopic } from './loadRandomPixabay'
+import { loadTextAnimationDemo } from './loadTextAnimationDemo'
 import type { TopicOption } from '@/lib/ai/types'
 import posthog from 'posthog-js'
 
@@ -124,6 +125,17 @@ export function AgenticPanel({ style, timelineRef, busy, setBusy }: AgenticPanel
     [submit],
   )
 
+  const loadAnimationDemo = useCallback(() => {
+    if (disabled) return
+    setError('')
+    try {
+      loadTextAnimationDemo({ engine, timelineRef })
+      posthog.capture('text_animation_demo_loaded')
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not load the animation demo.')
+    }
+  }, [disabled, engine, timelineRef])
+
   return (
     <div className="flex h-full flex-col bg-ed-panel text-ed-text" style={style}>
       <div className="flex items-center gap-2 border-b border-ed-border px-3.5 py-2.5">
@@ -138,6 +150,21 @@ export function AgenticPanel({ style, timelineRef, busy, setBusy }: AgenticPanel
             then compose it on the timeline.
           </p>
         )}
+
+        <button
+          type="button"
+          onClick={loadAnimationDemo}
+          disabled={disabled}
+          className="flex w-full items-center gap-2 rounded-md border border-ed-border bg-ed-elevated px-2.5 py-2 text-left text-[11px] text-ed-text transition-colors hover:border-[var(--elah-accent)] disabled:opacity-50"
+        >
+          <Activity size={13} style={{ color: 'var(--elah-accent)' }} />
+          <span>
+            <span className="block font-medium">Load text animation demo</span>
+            <span className="block text-[10px] text-ed-text-muted">
+              Presets and custom frame keyframes
+            </span>
+          </span>
+        </button>
 
         <details open={!askedPrompt} className="group">
           <summary className="cursor-pointer select-none text-[10px] font-semibold tracking-wide text-ed-text-muted hover:text-ed-text">

--- a/apps/web/components/playground/production/loadTextAnimationDemo.ts
+++ b/apps/web/components/playground/production/loadTextAnimationDemo.ts
@@ -1,0 +1,181 @@
+import {
+  type TimelineEngine,
+  type TimelineRef,
+  type AnimationChannel,
+  type TextAnimation,
+  type Transform,
+  selectionStore,
+  usePlaybackStore,
+} from '@elah/editor'
+import type { RefObject } from 'react'
+
+const CLIP_DURATION = 90
+const PHASE_DURATION = 15
+
+const CENTERED: Transform = {
+  x: 0.5,
+  y: 0.5,
+  scale: 1,
+  rotation: 0,
+  anchor: { x: 0.5, y: 0.5 },
+}
+
+interface DemoPreset {
+  name: string
+  content: string
+  animation?: TextAnimation
+  animations?: AnimationChannel[]
+}
+
+const PRESETS: DemoPreset[] = [
+  {
+    name: '01 · Fade',
+    content: 'FADE · 15 FRAMES',
+    animation: {
+      in: 'fade',
+      out: 'fade',
+      durationFrames: PHASE_DURATION,
+      easing: 'ease-out',
+    },
+  },
+  {
+    name: '02 · Slide Up',
+    content: 'SLIDE UP · EASE OUT',
+    animation: {
+      in: 'slide',
+      out: 'slide',
+      durationFrames: PHASE_DURATION,
+      direction: 'up',
+      easing: 'ease-out',
+    },
+  },
+  {
+    name: '03 · Pop',
+    content: 'POP · 15 FRAMES',
+    animation: {
+      in: 'pop',
+      out: 'pop',
+      durationFrames: PHASE_DURATION,
+      easing: 'ease-out',
+    },
+  },
+  {
+    name: '04 · Typewriter',
+    content: 'TYPEWRITER, FRAME BY FRAME',
+    animation: {
+      in: 'typewriter',
+      out: 'fade',
+      durationFrames: 36,
+      outDurationFrames: PHASE_DURATION,
+      easing: 'linear',
+    },
+  },
+  {
+    name: '05 · Pulse Loop',
+    content: 'PULSE · 30 FRAME LOOP',
+    animation: {
+      in: 'fade',
+      out: 'fade',
+      loop: 'pulse',
+      durationFrames: PHASE_DURATION,
+      loopDurationFrames: 30,
+      easing: 'ease-out',
+    },
+  },
+  {
+    name: '06 · Custom Keyframes',
+    content: 'CUSTOM POSITION · SCALE · ROTATION',
+    animations: [
+      {
+        property: 'opacity',
+        keyframes: [
+          { frame: 0, value: 0 },
+          { frame: 12, value: 1, easing: 'ease-out' },
+          { frame: 74, value: 1 },
+          { frame: 89, value: 0, easing: 'ease-in' },
+        ],
+      },
+      {
+        property: 'transform.x',
+        keyframes: [
+          { frame: 0, value: 0.28 },
+          { frame: 24, value: 0.5, easing: 'ease-out' },
+          { frame: 65, value: 0.5 },
+          { frame: 89, value: 0.72, easing: 'ease-in' },
+        ],
+      },
+      {
+        property: 'transform.scale',
+        keyframes: [
+          { frame: 0, value: 0.86 },
+          { frame: 24, value: 1, easing: 'ease-out' },
+          { frame: 65, value: 1 },
+          { frame: 89, value: 0.94, easing: 'ease-in' },
+        ],
+      },
+      {
+        property: 'transform.rotation',
+        keyframes: [
+          { frame: 0, value: -0.06 },
+          { frame: 24, value: 0, easing: 'ease-out' },
+          { frame: 65, value: 0 },
+          { frame: 89, value: 0.06, easing: 'ease-in' },
+        ],
+      },
+    ],
+  },
+]
+
+export interface LoadTextAnimationDemoDeps {
+  engine: TimelineEngine
+  timelineRef: RefObject<TimelineRef | null>
+}
+
+/** Populate existing elements lanes with a deterministic feature-review reel. */
+export function loadTextAnimationDemo({
+  engine,
+  timelineRef,
+}: LoadTextAnimationDemoDeps): void {
+  const elementsTracks = engine.getProject().tracks.filter((track) => track.kind === 'elements')
+  const track = elementsTracks[0]
+  if (!track) throw new Error('The text animation demo requires an elements track')
+
+  let firstClipId = ''
+  engine.batch(() => {
+    for (const elementsTrack of elementsTracks) {
+      for (const clip of engine.getClipsOnTrack(elementsTrack.id)) {
+        engine.removeClip(clip.id, elementsTrack.id)
+      }
+    }
+
+    PRESETS.forEach((preset, index) => {
+      const clip = engine.addClip({
+        trackId: track.id,
+        type: 'text',
+        name: preset.name,
+        startFrame: index * CLIP_DURATION,
+        durationFrames: CLIP_DURATION,
+        opacity: 0.94,
+        transform: CENTERED,
+        text: {
+          content: preset.content,
+          fontSize: index === PRESETS.length - 1 ? 54 : 64,
+          color: '#f2f7ff',
+          fontFamily: 'sans-serif',
+          fontWeight: 'bold',
+          textAlign: 'center',
+        },
+        ...(preset.animation ? { textAnimation: preset.animation } : {}),
+        ...(preset.animations ? { animations: preset.animations } : {}),
+      })
+      if (!firstClipId) firstClipId = clip.id
+    })
+  }, 'Load text animation demo')
+
+  const playback = usePlaybackStore.getState()
+  playback.pause()
+  playback.setCurrentFrame(0)
+  selectionStore.getState().selectClip(firstClipId)
+  selectionStore.getState().setActiveTrack(track.id)
+  requestAnimationFrame(() => timelineRef.current?.fitToWindow())
+}

--- a/apps/web/components/playground/production/properties/ShapeClipProperties.tsx
+++ b/apps/web/components/playground/production/properties/ShapeClipProperties.tsx
@@ -6,8 +6,7 @@ import {
   useTracksStore,
   useTimelineEngine,
   type Clip,
-  type TextAnimationKind,
-  type TextAnimation,
+  type ShapeAnimation,
 } from '@elah/editor'
 import { cn } from '@/lib/utils'
 import {
@@ -27,7 +26,7 @@ const TABS: { id: Tab; label: string }[] = [
   { id: 'animate', label: 'Animate' },
 ]
 
-function mergeAnim(c: Partial<Clip>): TextAnimation {
+function mergeAnim(c: Partial<Clip>): ShapeAnimation {
   return { durationFrames: 15, ...c.shapeAnimation }
 }
 
@@ -238,7 +237,7 @@ export function ShapeClipProperties() {
                       shapeAnimation: {
                         durationFrames: effective.shapeAnimation?.durationFrames ?? 15,
                         ...effective.shapeAnimation,
-                        in: val === 'none' ? undefined : (val as TextAnimationKind),
+                        in: val === 'none' ? undefined : 'fade',
                       },
                     })
                   }}
@@ -257,7 +256,7 @@ export function ShapeClipProperties() {
                       shapeAnimation: {
                         durationFrames: effective.shapeAnimation?.durationFrames ?? 15,
                         ...effective.shapeAnimation,
-                        out: val === 'none' ? undefined : (val as TextAnimationKind),
+                        out: val === 'none' ? undefined : 'fade',
                       },
                     })
                   }}

--- a/apps/web/components/playground/production/properties/TextClipProperties.tsx
+++ b/apps/web/components/playground/production/properties/TextClipProperties.tsx
@@ -5,13 +5,17 @@ import {
   AlignLeft,
   AlignCenter,
   AlignRight,
+  Activity,
 } from 'lucide-react'
 import {
   useSelectionStore,
   useTracksStore,
   useTimelineEngine,
   type Clip,
+  type AnimationDirection,
+  type AnimationEasing,
   type TextAnimationKind,
+  type TextLoopAnimationKind,
   type TextAnimation,
 } from '@elah/editor'
 import { cn } from '@/lib/utils'
@@ -63,8 +67,30 @@ function AlignBtn({
 }
 
 function mergeAnim(c: Partial<Clip>): TextAnimation {
-  return { durationFrames: 15, ...c.textAnimation }
+  return { durationFrames: 15, easing: 'ease-out', direction: 'up', ...c.textAnimation }
 }
+
+const PHASE_PRESETS: Array<{ value: TextAnimationKind | 'none'; label: string }> = [
+  { value: 'none', label: 'None' },
+  { value: 'fade', label: 'Fade' },
+  { value: 'slide', label: 'Slide' },
+  { value: 'pop', label: 'Pop' },
+  { value: 'typewriter', label: 'Typewriter' },
+]
+
+const DIRECTIONS: Array<{ value: AnimationDirection; label: string }> = [
+  { value: 'up', label: 'Up' },
+  { value: 'down', label: 'Down' },
+  { value: 'left', label: 'Left' },
+  { value: 'right', label: 'Right' },
+]
+
+const EASINGS: Array<{ value: AnimationEasing; label: string }> = [
+  { value: 'ease-out', label: 'Ease Out' },
+  { value: 'ease-in-out', label: 'Ease In Out' },
+  { value: 'ease-in', label: 'Ease In' },
+  { value: 'linear', label: 'Linear' },
+]
 
 function useSelectedTextClip(): Clip | null {
   const selectedClipIds = useSelectionStore((s) => s.selectedClipIds)
@@ -105,6 +131,19 @@ export function TextClipProperties() {
   const commit = (updates: Partial<Clip>) => {
     setLocal((prev) => ({ ...prev, ...updates }))
     engine.updateClip(clip.id, clip.trackId, updates)
+  }
+
+  const commitAnimation = (patch: Partial<TextAnimation>) => {
+    const next = { ...mergeAnim(effective), ...patch }
+    commit({
+      textAnimation: next.in || next.out || next.loop ? next : undefined,
+    })
+  }
+
+  const previewAnimation = (patch: Partial<TextAnimation>) => {
+    const next = { ...mergeAnim(effective), ...patch }
+    setLocal((prev) => ({ ...prev, textAnimation: next }))
+    engine.previewClip(clip.id, clip.trackId, { textAnimation: next })
   }
 
   const startSec = (clip.startFrame / 30).toFixed(0)
@@ -287,64 +326,149 @@ export function TextClipProperties() {
 
         {tab === 'animate' && (
           <>
+            <div className="mb-4 flex items-start gap-2.5 rounded-md border border-ed-border bg-ed-bg px-3 py-2.5">
+              <Activity size={14} className="mt-0.5 shrink-0 text-ed-accent-dim" />
+              <div>
+                <div className="text-[11px] font-medium text-ed-text">Clip-relative motion</div>
+                <div className="mt-0.5 text-[10px] leading-relaxed text-ed-text-muted">
+                  Presets use integer frames, so preview, scrubbing, and export stay identical.
+                </div>
+              </div>
+            </div>
+
             <div className="grid grid-cols-2 gap-3">
-              <Field label="Fade In">
+              <Field label="Entrance">
                 <select
                   value={effective.textAnimation?.in ?? 'none'}
                   onChange={(e) => {
-                    const val = e.target.value
-                    commit({
-                      textAnimation: {
-                        durationFrames: effective.textAnimation?.durationFrames ?? 15,
-                        ...effective.textAnimation,
-                        in: val === 'none' ? undefined : (val as TextAnimationKind),
-                      },
-                    })
+                    const value = e.target.value as TextAnimationKind | 'none'
+                    commitAnimation({ in: value === 'none' ? undefined : value })
                   }}
                   className={cn(inputCls, 'cursor-pointer')}
                 >
-                  <option value="none">None</option>
-                  <option value="fade">Fade</option>
+                  {PHASE_PRESETS.map((preset) => (
+                    <option key={preset.value} value={preset.value}>{preset.label}</option>
+                  ))}
                 </select>
               </Field>
-              <Field label="Fade Out">
+              <Field label="Exit">
                 <select
                   value={effective.textAnimation?.out ?? 'none'}
                   onChange={(e) => {
-                    const val = e.target.value
-                    commit({
-                      textAnimation: {
-                        durationFrames: effective.textAnimation?.durationFrames ?? 15,
-                        ...effective.textAnimation,
-                        out: val === 'none' ? undefined : (val as TextAnimationKind),
-                      },
-                    })
+                    const value = e.target.value as TextAnimationKind | 'none'
+                    commitAnimation({ out: value === 'none' ? undefined : value })
+                  }}
+                  className={cn(inputCls, 'cursor-pointer')}
+                >
+                  {PHASE_PRESETS.map((preset) => (
+                    <option key={preset.value} value={preset.value}>{preset.label}</option>
+                  ))}
+                </select>
+              </Field>
+            </div>
+
+            <div className="grid grid-cols-2 gap-3">
+              {effective.textAnimation?.in && (
+                <Field label="Entrance Duration">
+                  <NumberField
+                    value={effective.textAnimation.inDurationFrames ?? effective.textAnimation.durationFrames}
+                    step={1}
+                    min={1}
+                    max={clip.durationFrames}
+                    suffix="f"
+                    onChange={(value) => previewAnimation({ inDurationFrames: value })}
+                    onCommit={() => engine.commitInteraction('Edit text animation')}
+                  />
+                </Field>
+              )}
+              {effective.textAnimation?.out && (
+                <Field label="Exit Duration">
+                  <NumberField
+                    value={effective.textAnimation.outDurationFrames ?? effective.textAnimation.durationFrames}
+                    step={1}
+                    min={1}
+                    max={clip.durationFrames}
+                    suffix="f"
+                    onChange={(value) => previewAnimation({ outDurationFrames: value })}
+                    onCommit={() => engine.commitInteraction('Edit text animation')}
+                  />
+                </Field>
+              )}
+            </div>
+
+            {(effective.textAnimation?.in === 'slide' || effective.textAnimation?.out === 'slide') && (
+              <Field label="Direction">
+                <div className="grid grid-cols-4 gap-1.5">
+                  {DIRECTIONS.map((direction) => {
+                    const active = (effective.textAnimation?.direction ?? 'up') === direction.value
+                    return (
+                      <button
+                        key={direction.value}
+                        type="button"
+                        onClick={() => commitAnimation({ direction: direction.value })}
+                        className={cn(
+                          'rounded-md border px-2 py-1.5 text-[11px] transition-colors',
+                          active
+                            ? 'border-ed-accent bg-ed-accent-soft text-ed-accent-hover'
+                            : 'border-ed-border bg-ed-bg text-ed-text-muted hover:text-ed-text',
+                        )}
+                      >
+                        {direction.label}
+                      </button>
+                    )
+                  })}
+                </div>
+              </Field>
+            )}
+
+            {(effective.textAnimation?.in || effective.textAnimation?.out) && (
+              <Field label="Easing">
+                <select
+                  value={effective.textAnimation.easing ?? 'ease-out'}
+                  onChange={(e) => commitAnimation({ easing: e.target.value as AnimationEasing })}
+                  className={cn(inputCls, 'cursor-pointer')}
+                >
+                  {EASINGS.map((easing) => (
+                    <option key={easing.value} value={easing.value}>{easing.label}</option>
+                  ))}
+                </select>
+              </Field>
+            )}
+
+            <div className="my-4 border-t border-ed-border-subtle" />
+
+            <div className="grid grid-cols-2 gap-3">
+              <Field label="Loop">
+                <select
+                  value={effective.textAnimation?.loop ?? 'none'}
+                  onChange={(e) => {
+                    const value = e.target.value as TextLoopAnimationKind | 'none'
+                    commitAnimation({ loop: value === 'none' ? undefined : value })
                   }}
                   className={cn(inputCls, 'cursor-pointer')}
                 >
                   <option value="none">None</option>
-                  <option value="fade">Fade</option>
+                  <option value="pulse">Pulse</option>
                 </select>
               </Field>
+              {effective.textAnimation?.loop && (
+                <Field label="Loop Duration">
+                  <NumberField
+                    value={effective.textAnimation.loopDurationFrames ?? 30}
+                    step={1}
+                    min={2}
+                    max={clip.durationFrames}
+                    suffix="f"
+                    onChange={(value) => previewAnimation({ loopDurationFrames: value })}
+                    onCommit={() => engine.commitInteraction('Edit text animation')}
+                  />
+                </Field>
+              )}
             </div>
-            {(effective.textAnimation?.in || effective.textAnimation?.out) && (
-              <Field label="Duration">
-                <NumberField
-                  value={effective.textAnimation?.durationFrames ?? 15}
-                  step={1}
-                  min={1}
-                  max={clip.durationFrames}
-                  suffix="f"
-                  onChange={(v) =>
-                    setLocal((p) => ({
-                      ...p,
-                      textAnimation: { ...mergeAnim(effective), durationFrames: v },
-                    }))
-                  }
-                  onCommit={() => commit({ textAnimation: mergeAnim(effective) })}
-                />
-              </Field>
-            )}
+
+            <div className="mt-1 text-[10px] leading-relaxed text-ed-text-muted">
+              Custom opacity, position, scale, and rotation keyframes are available through the SDK. Visual keyframe lanes will follow in the timeline editor.
+            </div>
           </>
         )}
       </div>

--- a/apps/web/config/changelog.ts
+++ b/apps/web/config/changelog.ts
@@ -26,6 +26,17 @@ export interface Release {
   groups: ChangeGroup[]
 }
 
+/** Changes on main that have not been assigned a package version yet. */
+export const unreleasedChanges: ChangeGroup[] = [
+  {
+    kind: 'added',
+    scope: '@elah/core / @elah/editor',
+    items: [
+      'Frame-accurate text animation: clip-attached fade, slide, pop, typewriter, and pulse presets; named easing and per-phase frame durations; custom opacity and transform keyframe channels; and matching native Elah inspector controls. The pure resolver evaluates motion at clip-relative integer frames so preview, seeking, and export stay identical without a runtime dependency or separate animation track.',
+    ],
+  },
+]
+
 export const releases: Release[] = [
   {
     version: '0.4.1',

--- a/docs/ai/ELAH_FOR_AI_AGENTS.md
+++ b/docs/ai/ELAH_FOR_AI_AGENTS.md
@@ -330,7 +330,8 @@ engine.addClip({
 })
 ```
 
-All types also accept `name?`, `volume?`, `opacity?`, `transform?`.
+All types also accept `name?`, `volume?`, `opacity?`, `transform?`, and
+clip-relative `animations?`. Text clips additionally accept `textAnimation?`.
 
 ⚠️ **Nested on creation, flat on the `Clip`.** You *create* text with `text: { content }`, but
 the stored `Clip` and the resolved `ActiveTextClip` both expose `content`, `fontSize`, `color`
@@ -352,6 +353,41 @@ interface Transform {
 ```
 
 Normalized so a project is resolution-independent.
+
+### Text animation
+
+Animations attach to the text clip; do not create a separate animation track.
+Preset and keyframe timing uses integer frame offsets from `clip.startFrame`:
+
+```ts
+interface TextAnimation {
+  in?: 'fade' | 'slide' | 'pop' | 'typewriter'
+  out?: 'fade' | 'slide' | 'pop' | 'typewriter'
+  loop?: 'pulse'
+  durationFrames: number
+  inDurationFrames?: number
+  outDurationFrames?: number
+  loopDurationFrames?: number
+  direction?: 'left' | 'right' | 'up' | 'down'
+  easing?: 'linear' | 'ease-in' | 'ease-out' | 'ease-in-out'
+}
+
+interface AnimationChannel {
+  property: 'opacity' | 'transform.x' | 'transform.y' |
+            'transform.scale' | 'transform.rotation'
+  keyframes: Array<{
+    frame: number
+    value: number
+    easing?: 'linear' | 'ease-in' | 'ease-out' | 'ease-in-out'
+  }>
+}
+```
+
+`resolveTimeline(frame, project)` evaluates these into ordinary scene content,
+opacity, and transform values. Renderers remain animation-agnostic, which keeps
+scrubbing, browser preview, and export deterministic. Use
+`evaluateAnimationChannel(channel, localFrame)` when custom tooling needs the
+same interpolation behavior.
 
 ### Export
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -83,7 +83,24 @@ const rect = createShapeClip({
   durationFrames: 90,
   shape: { shapeKind: 'rect', shapeFill: '#22d3ee' }, // 'rect' | 'circle' | 'triangle'
 })
+
+const title = createTextClip({
+  trackId: 'el1',
+  startFrame: 0,
+  durationFrames: 90,
+  text: { content: 'Frame accurate' },
+  textAnimation: { in: 'slide', out: 'fade', durationFrames: 12, direction: 'up', easing: 'ease-out' },
+  animations: [{
+    property: 'transform.scale',
+    keyframes: [{ frame: 0, value: 0.9 }, { frame: 12, value: 1 }],
+  }],
+})
 ```
+
+Text presets (`fade`, `slide`, `pop`, `typewriter`, and looping `pulse`) and
+custom property channels are evaluated at integer frames relative to the clip.
+`resolveTimeline` emits only the resolved content, opacity, and transform, so
+preview, seeking, and export use the same deterministic result.
 
 ---
 

--- a/packages/core/src/animation/evaluate.test.ts
+++ b/packages/core/src/animation/evaluate.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest'
+import type { Clip } from '../types'
+import {
+  applyAnimationEasing,
+  evaluateAnimationChannel,
+  resolveTextAnimation,
+} from './evaluate'
+import { normalizeAnimationChannels, normalizeTextAnimation } from './normalize'
+
+function textClip(overrides: Partial<Clip> = {}): Clip {
+  return {
+    id: 'text-1',
+    trackId: 'elements-1',
+    type: 'text',
+    name: 'Title',
+    startFrame: 20,
+    durationFrames: 60,
+    sourceStartFrame: 0,
+    sourceDurationFrames: 60,
+    content: 'Hello',
+    opacity: 1,
+    ...overrides,
+  }
+}
+
+describe('animation evaluation', () => {
+  it('evaluates named easing deterministically', () => {
+    expect(applyAnimationEasing(0.5, 'linear')).toBe(0.5)
+    expect(applyAnimationEasing(0.5, 'ease-in')).toBe(0.25)
+    expect(applyAnimationEasing(0.5, 'ease-out')).toBe(0.75)
+    expect(applyAnimationEasing(0.5, 'ease-in-out')).toBe(0.5)
+  })
+
+  it('normalizes all stored animation timing to integer frames', () => {
+    expect(normalizeTextAnimation({
+      in: 'fade',
+      durationFrames: 4.6,
+      inDurationFrames: 0.2,
+    })).toMatchObject({ durationFrames: 5, inDurationFrames: 1 })
+
+    expect(normalizeAnimationChannels([{
+      property: 'opacity',
+      keyframes: [{ frame: 2.6, value: 0.5 }],
+    }])[0].keyframes[0].frame).toBe(3)
+  })
+
+  it('interpolates unsorted keyframes and holds endpoint values', () => {
+    const channel = {
+      property: 'opacity' as const,
+      keyframes: [
+        { frame: 10, value: 1, easing: 'linear' as const },
+        { frame: 0, value: 0 },
+      ],
+    }
+
+    expect(evaluateAnimationChannel(channel, -5)).toBe(0)
+    expect(evaluateAnimationChannel(channel, 5)).toBe(0.5)
+    expect(evaluateAnimationChannel(channel, 20)).toBe(1)
+  })
+
+  it('resolves custom opacity and transform channels at clip-relative frames', () => {
+    const resolved = resolveTextAnimation(textClip({
+      animations: [
+        { property: 'opacity', keyframes: [{ frame: 0, value: 0 }, { frame: 10, value: 1 }] },
+        { property: 'transform.x', keyframes: [{ frame: 0, value: 0.2 }, { frame: 10, value: 0.6 }] },
+        { property: 'transform.rotation', keyframes: [{ frame: 0, value: 0 }, { frame: 10, value: Math.PI }] },
+      ],
+    }), 5)
+
+    expect(resolved.opacity).toBe(0.5)
+    expect(resolved.transform?.x).toBeCloseTo(0.4)
+    expect(resolved.transform?.rotation).toBeCloseTo(Math.PI / 2)
+  })
+
+  it('supports fade, slide, pop, typewriter, and pulse presets', () => {
+    expect(resolveTextAnimation(textClip({
+      textAnimation: { in: 'fade', durationFrames: 10 },
+    }), 5).opacity).toBe(0.5)
+
+    const slide = resolveTextAnimation(textClip({
+      textAnimation: { in: 'slide', durationFrames: 10, direction: 'left' },
+    }), 0)
+    expect(slide.opacity).toBe(0)
+    expect(slide.transform?.x).toBeCloseTo(0.42)
+
+    const pop = resolveTextAnimation(textClip({
+      textAnimation: { in: 'pop', durationFrames: 10 },
+    }), 0)
+    expect(pop.transform?.scale).toBeCloseTo(0.88)
+
+    expect(resolveTextAnimation(textClip({
+      textAnimation: { in: 'typewriter', durationFrames: 10, easing: 'linear' },
+    }), 4).content).toBe('He')
+
+    const pulse = resolveTextAnimation(textClip({
+      textAnimation: { loop: 'pulse', durationFrames: 20, loopDurationFrames: 20 },
+    }), 10)
+    expect(pulse.transform?.scale).toBeCloseTo(1.04)
+  })
+
+  it('combines entrance and exit phases without using wall-clock time', () => {
+    const clip = textClip({
+      textAnimation: {
+        in: 'fade',
+        out: 'fade',
+        durationFrames: 10,
+        easing: 'linear',
+      },
+    })
+
+    expect(resolveTextAnimation(clip, 0).opacity).toBe(0)
+    expect(resolveTextAnimation(clip, 30).opacity).toBe(1)
+    expect(resolveTextAnimation(clip, 59).opacity).toBe(0)
+    expect(resolveTextAnimation(clip, 30)).toEqual(resolveTextAnimation(clip, 30))
+  })
+})

--- a/packages/core/src/animation/evaluate.ts
+++ b/packages/core/src/animation/evaluate.ts
@@ -1,0 +1,211 @@
+import type {
+  AnimationChannel,
+  AnimationDirection,
+  AnimationEasing,
+  Clip,
+  TextAnimation,
+  Transform,
+} from '../types'
+
+const DEFAULT_TRANSFORM: Transform = {
+  x: 0.5,
+  y: 0.5,
+  scale: 1,
+  rotation: 0,
+  anchor: { x: 0.5, y: 0.5 },
+}
+
+const SLIDE_DISTANCE = 0.08
+const POP_START_SCALE = 0.88
+const PULSE_SCALE = 0.04
+
+function clamp01(value: number): number {
+  return Math.max(0, Math.min(1, value))
+}
+
+/** Apply one of Elah's deterministic, dependency-free easing curves. */
+export function applyAnimationEasing(
+  progress: number,
+  easing: AnimationEasing = 'linear',
+): number {
+  const t = clamp01(progress)
+  if (easing === 'ease-in') return t * t
+  if (easing === 'ease-out') return t * (2 - t)
+  if (easing === 'ease-in-out') {
+    return t < 0.5 ? 2 * t * t : 1 - ((-2 * t + 2) ** 2) / 2
+  }
+  return t
+}
+
+/**
+ * Evaluate a channel at a clip-relative frame. Values hold before the first
+ * and after the last keyframe; invalid keyframes are ignored. The function
+ * never mutates or reorders the stored channel.
+ */
+export function evaluateAnimationChannel(
+  channel: AnimationChannel,
+  localFrame: number,
+): number | undefined {
+  const keyframes = channel.keyframes
+    .filter((keyframe) => Number.isFinite(keyframe.frame) && Number.isFinite(keyframe.value))
+    .map((keyframe) => ({ ...keyframe, frame: Math.round(keyframe.frame) }))
+    .sort((a, b) => a.frame - b.frame)
+
+  if (keyframes.length === 0) return undefined
+  if (localFrame < keyframes[0].frame) return keyframes[0].value
+
+  let previous = keyframes[0]
+  for (let index = 1; index < keyframes.length; index += 1) {
+    const next = keyframes[index]
+    if (localFrame < next.frame) {
+      const span = next.frame - previous.frame
+      if (span <= 0) return next.value
+      const progress = applyAnimationEasing(
+        (localFrame - previous.frame) / span,
+        next.easing,
+      )
+      return previous.value + (next.value - previous.value) * progress
+    }
+    previous = next
+  }
+
+  return previous.value
+}
+
+export interface ResolvedTextAnimation {
+  content: string
+  opacity: number
+  transform?: Transform
+}
+
+function phaseDuration(
+  animation: TextAnimation,
+  phase: 'in' | 'out' | 'loop',
+): number {
+  const specific = phase === 'in'
+    ? animation.inDurationFrames
+    : phase === 'out'
+      ? animation.outDurationFrames
+      : animation.loopDurationFrames
+  return Math.max(1, Math.round(specific ?? animation.durationFrames))
+}
+
+function offsetForDirection(
+  direction: AnimationDirection = 'up',
+  amount: number,
+): { x: number; y: number } {
+  if (direction === 'left') return { x: -amount, y: 0 }
+  if (direction === 'right') return { x: amount, y: 0 }
+  if (direction === 'down') return { x: 0, y: amount }
+  return { x: 0, y: -amount }
+}
+
+function setAnimatedProperty(
+  channel: AnimationChannel,
+  value: number,
+  state: { opacity: number; transform: Transform },
+): void {
+  if (channel.property === 'opacity') state.opacity = clamp01(value)
+  else if (channel.property === 'transform.x') state.transform.x = value
+  else if (channel.property === 'transform.y') state.transform.y = value
+  else if (channel.property === 'transform.scale') state.transform.scale = Math.max(0, value)
+  else if (channel.property === 'transform.rotation') state.transform.rotation = value
+}
+
+/**
+ * Resolve custom keyframes and text presets into ordinary render properties.
+ * Renderers stay animation-agnostic: they receive only final content, opacity,
+ * and transform for the requested frame.
+ */
+export function resolveTextAnimation(
+  clip: Clip,
+  localFrame: number,
+): ResolvedTextAnimation {
+  const baseTransform = clip.transform ?? DEFAULT_TRANSFORM
+  const state = {
+    opacity: clip.opacity ?? 1,
+    transform: {
+      ...baseTransform,
+      anchor: { ...baseTransform.anchor },
+    },
+  }
+  let hasTransform = clip.transform !== undefined
+
+  for (const channel of clip.animations ?? []) {
+    const value = evaluateAnimationChannel(channel, localFrame)
+    if (value === undefined) continue
+    setAnimatedProperty(channel, value, state)
+    if (channel.property.startsWith('transform.')) hasTransform = true
+  }
+
+  const animation = clip.textAnimation
+  const fullContent = clip.content ?? ''
+  let visibleCharacters = Array.from(fullContent).length
+
+  if (animation) {
+    // Preserve the original fade preset's linear ramp for stored projects that
+    // predate named easing. New inspector-created presets specify ease-out.
+    const easing = animation.easing ?? 'linear'
+
+    if (animation.in) {
+      const duration = phaseDuration(animation, 'in')
+      const progress = applyAnimationEasing(localFrame / duration, easing)
+
+      if (animation.in === 'fade') state.opacity *= progress
+      else if (animation.in === 'slide') {
+        state.opacity *= progress
+        const offset = offsetForDirection(animation.direction, SLIDE_DISTANCE * (1 - progress))
+        state.transform.x += offset.x
+        state.transform.y += offset.y
+        hasTransform = true
+      } else if (animation.in === 'pop') {
+        state.opacity *= progress
+        state.transform.scale *= POP_START_SCALE + (1 - POP_START_SCALE) * progress
+        hasTransform = true
+      } else if (animation.in === 'typewriter') {
+        visibleCharacters = Math.min(
+          visibleCharacters,
+          Math.floor(Array.from(fullContent).length * progress),
+        )
+      }
+    }
+
+    if (animation.out) {
+      const duration = phaseDuration(animation, 'out')
+      const remaining = clip.durationFrames - 1 - localFrame
+      const progress = applyAnimationEasing(remaining / duration, easing)
+
+      if (animation.out === 'fade') state.opacity *= progress
+      else if (animation.out === 'slide') {
+        state.opacity *= progress
+        const offset = offsetForDirection(animation.direction, SLIDE_DISTANCE * (1 - progress))
+        state.transform.x += offset.x
+        state.transform.y += offset.y
+        hasTransform = true
+      } else if (animation.out === 'pop') {
+        state.opacity *= progress
+        state.transform.scale *= POP_START_SCALE + (1 - POP_START_SCALE) * progress
+        hasTransform = true
+      } else if (animation.out === 'typewriter') {
+        visibleCharacters = Math.min(
+          visibleCharacters,
+          Math.floor(Array.from(fullContent).length * progress),
+        )
+      }
+    }
+
+    if (animation.loop === 'pulse') {
+      const duration = phaseDuration(animation, 'loop')
+      const phase = ((localFrame % duration) + duration) % duration / duration
+      const pulse = 0.5 - 0.5 * Math.cos(phase * Math.PI * 2)
+      state.transform.scale *= 1 + PULSE_SCALE * pulse
+      hasTransform = true
+    }
+  }
+
+  return {
+    content: Array.from(fullContent).slice(0, visibleCharacters).join(''),
+    opacity: clamp01(state.opacity),
+    ...(hasTransform ? { transform: state.transform } : {}),
+  }
+}

--- a/packages/core/src/animation/normalize.ts
+++ b/packages/core/src/animation/normalize.ts
@@ -1,0 +1,36 @@
+import type { AnimationChannel, ShapeAnimation, TextAnimation } from '../types'
+import { toFrame } from '../utils/frames'
+
+function duration(value: number): number {
+  return Math.max(1, toFrame(value))
+}
+
+export function normalizeAnimationChannels(channels: AnimationChannel[]): AnimationChannel[] {
+  return channels.map((channel) => ({
+    ...channel,
+    keyframes: channel.keyframes.map((keyframe) => ({
+      ...keyframe,
+      frame: toFrame(keyframe.frame),
+    })),
+  }))
+}
+
+export function normalizeTextAnimation(animation: TextAnimation): TextAnimation {
+  return {
+    ...animation,
+    durationFrames: duration(animation.durationFrames),
+    ...(animation.inDurationFrames !== undefined
+      ? { inDurationFrames: duration(animation.inDurationFrames) }
+      : {}),
+    ...(animation.outDurationFrames !== undefined
+      ? { outDurationFrames: duration(animation.outDurationFrames) }
+      : {}),
+    ...(animation.loopDurationFrames !== undefined
+      ? { loopDurationFrames: duration(animation.loopDurationFrames) }
+      : {}),
+  }
+}
+
+export function normalizeShapeAnimation(animation: ShapeAnimation): ShapeAnimation {
+  return { ...animation, durationFrames: duration(animation.durationFrames) }
+}

--- a/packages/core/src/elements/base.ts
+++ b/packages/core/src/elements/base.ts
@@ -1,6 +1,14 @@
-import type { Clip, ClipType, ShapeVariant, Transform } from '../types'
+import type {
+  AnimationChannel,
+  Clip,
+  ClipType,
+  ShapeVariant,
+  TextAnimation,
+  Transform,
+} from '../types'
 import { generateId } from '../utils/id'
 import { toFrame } from '../utils/frames'
+import { normalizeAnimationChannels, normalizeTextAnimation } from '../animation/normalize'
 
 // ---------------------------------------------------------------------------
 // Per-type option shapes (discriminated union)
@@ -14,6 +22,8 @@ interface BaseCreateOptions {
   volume?: number
   opacity?: number
   transform?: Transform
+  /** Clip-relative, frame-based property channels. */
+  animations?: AnimationChannel[]
 }
 
 interface CreateVideoOptions extends BaseCreateOptions {
@@ -48,6 +58,8 @@ interface CreateTextOptions extends BaseCreateOptions {
   type: 'text'
   /** Required for text clips — carries content + style. */
   text: TextClipMetadata
+  /** Optional text entrance, exit, and loop presets. */
+  textAnimation?: TextAnimation
 }
 
 /** Style metadata for a shape clip. */
@@ -114,6 +126,7 @@ export function createClip(options: CreateClipOptions): Clip {
     locked: false,
     disabled: false,
     ...(options.transform ? { transform: options.transform } : {}),
+    ...(options.animations ? { animations: normalizeAnimationChannels(options.animations) } : {}),
   }
 
   if (options.type === 'text') {
@@ -127,6 +140,7 @@ export function createClip(options: CreateClipOptions): Clip {
       ...(text.fontFamily !== undefined ? { fontFamily: text.fontFamily } : {}),
       ...(text.fontWeight !== undefined ? { fontWeight: text.fontWeight } : {}),
       ...(text.textAlign !== undefined ? { textAlign: text.textAlign } : {}),
+      ...(options.textAnimation ? { textAnimation: normalizeTextAnimation(options.textAnimation) } : {}),
     }
   }
 

--- a/packages/core/src/elements/text.ts
+++ b/packages/core/src/elements/text.ts
@@ -1,4 +1,4 @@
-import type { Clip } from '../types'
+import type { AnimationChannel, Clip, TextAnimation, Transform } from '../types'
 import { createClip, type TextClipMetadata } from './base'
 
 /** Inputs for createTextClip; `text` carries the styled content, and text clips have no source media so they trim freely. */
@@ -10,6 +10,9 @@ export interface CreateTextClipOptions {
   text: TextClipMetadata
   volume?: number
   opacity?: number
+  transform?: Transform
+  animations?: AnimationChannel[]
+  textAnimation?: TextAnimation
 }
 
 /** Typed wrapper over createClip that pins `type: 'text'` and supplies a default name so callers can't omit them. */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,8 +11,15 @@ export type {
   Track,
   Project,
   Transform,
+  AnimationChannel,
+  AnimationKeyframe,
+  AnimationProperty,
+  AnimationEasing,
+  AnimationDirection,
   TextAnimation,
+  ShapeAnimation,
   TextAnimationKind,
+  TextLoopAnimationKind,
   ClipType,
   ShapeVariant,
   TrackKind,
@@ -25,6 +32,12 @@ export type {
   TransitionEasing,
   TransitionDirection,
 } from './types'
+
+// --- Animation (pure, frame-based) ---
+export {
+  applyAnimationEasing,
+  evaluateAnimationChannel,
+} from './animation/evaluate'
 
 // --- Engine ---
 export { TimelineEngine } from './editor/TimelineEngine'

--- a/packages/core/src/project/serialization.test.ts
+++ b/packages/core/src/project/serialization.test.ts
@@ -32,6 +32,19 @@ function buildNonTrivialEngine(): TimelineEngine {
     startFrame: 10,
     durationFrames: 45,
     text: { content: 'Hello world', fontSize: 48, color: '#ff0000' },
+    textAnimation: {
+      in: 'slide',
+      out: 'fade',
+      durationFrames: 12,
+      direction: 'up',
+      easing: 'ease-out',
+    },
+    animations: [
+      {
+        property: 'transform.scale',
+        keyframes: [{ frame: 0, value: 0.9 }, { frame: 12, value: 1 }],
+      },
+    ],
   })
 
   engine.addTransition({

--- a/packages/core/src/resolver/resolveTimeline.test.ts
+++ b/packages/core/src/resolver/resolveTimeline.test.ts
@@ -265,6 +265,36 @@ describe('resolveTimeline', () => {
     expect(scenePlain.texts[0].color).toBeUndefined()
   })
 
+  it('resolves text presets and custom channels from clip-relative frames', () => {
+    const track = makeTrack({ id: 'tt', kind: 'elements' })
+    const animated = makeClip({
+      id: 'c-animated',
+      trackId: 'tt',
+      type: 'text',
+      startFrame: 20,
+      durationFrames: 40,
+      sourceDurationFrames: 40,
+      content: 'Title',
+      textAnimation: {
+        in: 'typewriter',
+        durationFrames: 10,
+        easing: 'linear',
+      },
+      animations: [
+        {
+          property: 'transform.x',
+          keyframes: [{ frame: 0, value: 0.25 }, { frame: 10, value: 0.75 }],
+        },
+      ],
+    })
+    const project = makeProject({ tracks: [track], clips: { tt: [animated] } })
+
+    const text = resolveTimeline(25, project).texts[0]
+    expect(text.content).toBe('Ti')
+    expect(text.transform?.x).toBe(0.5)
+    expect(resolveTimeline(25, project)).toEqual(resolveTimeline(25, project))
+  })
+
   it('image clips follow video solo rules', () => {
     const trackVid = makeTrack({ id: 'tVid', kind: 'video', order: 0, solo: true })
     const trackImg = makeTrack({ id: 'tImg', kind: 'video', order: 1, solo: false })

--- a/packages/core/src/resolver/resolveTimeline.ts
+++ b/packages/core/src/resolver/resolveTimeline.ts
@@ -8,6 +8,7 @@ import type {
   ActiveShapeClip,
   ActiveFreehandClip,
 } from './scene'
+import { resolveTextAnimation } from '../animation/evaluate'
 
 /** Elements tracks always render above every video/audio track. */
 const ELEMENTS_ZINDEX_BASE = 1000000
@@ -163,31 +164,20 @@ export function resolveTimeline(frame: number, project: Project): Scene {
         }
         scene.audios.push(active)
       } else if (clip.type === 'text') {
-        // Resolve entry/exit animation into opacity so both renderers get the
-        // animated value for free — neither renderer needs to know about animations.
-        let resolvedOpacity = opacity
-        const anim = clip.textAnimation
-        if (anim) {
-          const d = Math.max(1, anim.durationFrames)
-          const localFrame = frame - clip.startFrame
-          if (anim.in === 'fade') {
-            resolvedOpacity = Math.min(resolvedOpacity, Math.min(1, localFrame / d))
-          }
-          if (anim.out === 'fade') {
-            resolvedOpacity = Math.min(resolvedOpacity, Math.min(1, (clip.durationFrames - localFrame) / d))
-          }
-        }
+        // Text presets and custom keyframes resolve to ordinary render values.
+        // Preview and export remain animation-agnostic and therefore identical.
+        const resolved = resolveTextAnimation(clip, frame - clip.startFrame)
 
         const active: ActiveTextClip = {
           type: 'text',
           id: clip.id,
           trackId: clip.trackId,
           name: clip.name,
-          content: clip.content ?? '',
+          content: resolved.content,
           sourceFrame,
-          opacity: resolvedOpacity,
+          opacity: resolved.opacity,
           zIndex,
-          ...(clip.transform ? { transform: clip.transform } : {}),
+          ...(resolved.transform ? { transform: resolved.transform } : {}),
           ...(clip.fontSize !== undefined ? { fontSize: clip.fontSize } : {}),
           ...(clip.color !== undefined ? { color: clip.color } : {}),
           ...(clip.fontFamily !== undefined ? { fontFamily: clip.fontFamily } : {}),

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -7,17 +7,56 @@
 /** An exact frame position. Always a non-negative integer. */
 export type FrameCount = number
 
-export type TextAnimationKind = 'fade'
+export type AnimationEasing = 'linear' | 'ease-in' | 'ease-out' | 'ease-in-out'
+
+/** Numeric clip properties that can be evaluated from clip-relative keyframes. */
+export type AnimationProperty =
+  | 'opacity'
+  | 'transform.x'
+  | 'transform.y'
+  | 'transform.scale'
+  | 'transform.rotation'
+
+/** A value pinned to an integer frame relative to the clip's start. */
+export interface AnimationKeyframe {
+  frame: FrameCount
+  value: number
+  /** Controls interpolation from the previous keyframe into this keyframe. */
+  easing?: AnimationEasing
+}
+
+/** One independently animated numeric property. */
+export interface AnimationChannel {
+  property: AnimationProperty
+  keyframes: AnimationKeyframe[]
+}
+
+export type TextAnimationKind = 'fade' | 'slide' | 'pop' | 'typewriter'
+export type TextLoopAnimationKind = 'pulse'
+export type AnimationDirection = 'left' | 'right' | 'up' | 'down'
 
 /**
- * Entry/exit animation descriptor for text clips.
- * Resolved into opacity inside resolveTimeline — both renderers consume it
- * via the existing opacity field, so parity is automatic.
+ * Entrance, exit, and loop animation descriptor for text clips.
+ * Resolved into ordinary scene properties inside resolveTimeline, so preview
+ * and export consume exactly the same frame result.
  */
 export interface TextAnimation {
   in?: TextAnimationKind
   out?: TextAnimationKind
-  /** Duration of the in/out ramp in frames (shared by both directions) */
+  loop?: TextLoopAnimationKind
+  /** Backwards-compatible shared duration used when a phase-specific duration is absent. */
+  durationFrames: number
+  inDurationFrames?: number
+  outDurationFrames?: number
+  loopDurationFrames?: number
+  direction?: AnimationDirection
+  easing?: AnimationEasing
+}
+
+/** Legacy fade ramp supported by shape clips. */
+export interface ShapeAnimation {
+  in?: 'fade'
+  out?: 'fade'
   durationFrames: number
 }
 
@@ -115,7 +154,9 @@ export interface Clip {
   /** Entry/exit animation for text clips */
   textAnimation?: TextAnimation
   /** Entry/exit animation for shape clips */
-  shapeAnimation?: TextAnimation
+  shapeAnimation?: ShapeAnimation
+  /** Custom text property channels. Frames are relative to the clip start. */
+  animations?: AnimationChannel[]
 }
 
 /** A track lane that holds clips */

--- a/packages/core/src/visitor/update.ts
+++ b/packages/core/src/visitor/update.ts
@@ -2,6 +2,11 @@ import type { Draft } from 'immer'
 import type { Clip, Project, Track } from '../types'
 import { toFrame } from '../utils/frames'
 import { findOverlaps } from '../utils/frames'
+import {
+  normalizeAnimationChannels,
+  normalizeShapeAnimation,
+  normalizeTextAnimation,
+} from '../animation/normalize'
 
 /**
  * Update clip properties in place.
@@ -26,6 +31,15 @@ export function updateClip(
   }
   if (updates.durationFrames !== undefined) {
     updates.durationFrames = Math.max(1, toFrame(updates.durationFrames))
+  }
+  if (updates.animations !== undefined) {
+    updates.animations = normalizeAnimationChannels(updates.animations)
+  }
+  if (updates.textAnimation !== undefined) {
+    updates.textAnimation = normalizeTextAnimation(updates.textAnimation)
+  }
+  if (updates.shapeAnimation !== undefined) {
+    updates.shapeAnimation = normalizeShapeAnimation(updates.shapeAnimation)
   }
 
   const merged = { ...clip, ...updates } as Clip

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -110,6 +110,40 @@ const result = await insertMediaAsset(engine, assetId, { desiredStartFrame: 0 })
 
 ---
 
+## Text animation
+
+Text animation is clip-attached—no separate animation track is required. Add a
+preset while creating the clip, or update the flat stored `Clip` later:
+
+```ts
+engine.addClip({
+  type: 'text',
+  trackId,
+  startFrame: 0,
+  durationFrames: 90,
+  text: { content: 'New chapter' },
+  textAnimation: {
+    in: 'slide',       // 'fade' | 'slide' | 'pop' | 'typewriter'
+    out: 'fade',
+    loop: 'pulse',
+    durationFrames: 12,
+    direction: 'up',
+    easing: 'ease-out',
+  },
+  animations: [{
+    property: 'transform.x',
+    keyframes: [{ frame: 0, value: 0.4 }, { frame: 12, value: 0.5 }],
+  }],
+})
+```
+
+Channel frames are integer offsets from the clip start. Supported properties
+are `opacity`, `transform.x`, `transform.y`, `transform.scale`, and
+`transform.rotation`. Both the interactive preview and MP4 export consume the
+same resolved scene.
+
+---
+
 ## Export to MP4
 
 ```ts

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -17,8 +17,15 @@ export type {
   Track,
   Project,
   Transform,
+  AnimationChannel,
+  AnimationKeyframe,
+  AnimationProperty,
+  AnimationEasing,
+  AnimationDirection,
   TextAnimation,
+  ShapeAnimation,
   TextAnimationKind,
+  TextLoopAnimationKind,
   ClipType,
   TrackKind,
   FrameCount,
@@ -30,6 +37,8 @@ export type {
   TransitionEasing,
   TransitionDirection,
 } from '@elah/core'
+
+export { applyAnimationEasing, evaluateAnimationChannel } from '@elah/core'
 
 export { TimelineEngine } from '@elah/core'
 export { PlaybackEngine } from '@elah/core'


### PR DESCRIPTION
## What does this PR do?

Adds frame-accurate text animation to `@elah/core` — clip-attached entrance/exit presets, looping `pulse`, named easing, per-phase frame durations, and custom opacity/transform keyframe channels — plus native inspector controls in the production playground.

Closes # <!-- no tracked issue -->

---

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Performance improvement

---

## How to test

1. `npm install && npm run dev`, open the production playground at `:3001`.
2. Add a text clip, select it, and open the text inspector. Pick an entrance preset (`fade`, `slide`, `pop`, `typewriter`), a direction, an easing, and set per-phase frame durations.
3. Scrub the playhead across the clip's entrance and exit ranges — motion must be identical on every visit to the same frame (the resolver is pure and evaluates at clip-relative integer frames). Confirm each duration edit produces exactly one undo step.
4. Export the clip and confirm the exported frames match the preview.
5. `npm run typecheck` and `npm test` at the repo root.

---

## Screenshots / Recording

Not applicable to this PR — behavior is verified by the resolver unit tests in `packages/core/src/animation/evaluate.test.ts` and `packages/core/src/resolver/resolveTimeline.test.ts`. The inspector additions are new controls on the existing text properties panel.

---

## Checklist

- [x] `npm test` passes
- [x] `npm run typecheck` passes
- [x] I've tested this in the playground
- [x] No `any` types introduced without justification
